### PR TITLE
feat: set github token permissions with env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ tokens][github-app-tokens]. Requests are authorized with a [Buildkite
 OIDC][buildkite-oidc] token, allowing a token to be created just for the
 repository associated with an executing pipeline.
 
-The token is created with `contents:read` permissions, and only has access to
-the repository associated with the executing pipeline.
+The token is created with `contents:read` permissions by default, and only has
+access to the repository associated with the executing pipeline. The permissions
+can be modified with [Environment Variables](#variables).
 
 Two endpoints are exposed: `/token`, which returns a token and its expiry, and
 `/git-credentials`, which returns the token and repository metadata in the [Git
@@ -130,7 +131,6 @@ To understand what's right for your organization, consider:
 
 ## Limitations
 
-- can only grant `contents:read` access
 - will only grant access to the repository associated with a pipeline
 - if the buildkite user has permissions to modify the pipeline repository, they
   may configure a repository that they don't have access to in GitHub (but is
@@ -205,6 +205,24 @@ variables, and can be deployed to a server or as a container.
 
 - `BUILDKITE_API_TOKEN` (**required**): The API token created for pipeline
   metadata lookups. **Store securely and provide to the container securely.**
+
+**Buildkite Variables for GitHub Permissions**
+
+Set each environment variable to "read" or "write". If omitted, the permission
+will be ignored. The default permission `contents:read` will always be set.
+
+- `GITHUB_PERMISSIONS_ACTIONS`
+- `GITHUB_PERMISSIONS_CHECKS`
+- `GITHUB_PERMISSIONS_CONTENTS`
+- `GITHUB_PERMISSIONS_DEPLOYMENTS`
+- `GITHUB_PERMISSIONS_ISSUES`
+- `GITHUB_PERMISSIONS_METADATA`
+- `GITHUB_PERMISSIONS_PACKAGES`
+- `GITHUB_PERMISSIONS_PAGES`
+- `GITHUB_PERMISSIONS_PULL_REQUESTS`
+- `GITHUB_PERMISSIONS_REPOSITORY_PROJECTS`
+- `GITHUB_PERMISSIONS_SECURITY_EVENTS`
+- `GITHUB_PERMISSIONS_STATUSES`
 
 **GitHub API connectivity**
 

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -1,0 +1,11 @@
+package config
+
+func NewDefaultConfig() *Configuration {
+	return &Configuration{
+		Default: DefaultConfig{
+			Permissions:  []string{},
+			Repositories: []Repository{},
+		},
+		Pipelines: []Pipeline{},
+	}
+}

--- a/internal/config/examples/config.yaml
+++ b/internal/config/examples/config.yaml
@@ -1,0 +1,16 @@
+default:
+  permissions: # empty list, no permissions granted
+    - "content:read"
+  repositories:
+    - name: "org/privaterepo" # optional list of repositories to give access by default
+      permissions: ["content:read"] # optional, defaults to permissions above
+    - name: "org/otherrepo"
+
+pipelines:
+  - name: "pipeline name"
+    repositories:
+      # potentially implicit here is content:read for the repo of the pipeline
+      - name: "org/repo1" # overlap here with defaults results in a union of the available properties
+        permissions: ["content:read", "pull-request:write"]
+      - name: "org/repo2"
+        permissions: ["content:read", "pull-request:write"]

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -1,0 +1,34 @@
+package config
+
+import (
+	"bytes"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+func LoadFromFile(path string) (*Configuration, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return ParseConfiguration(data)
+}
+
+func LoadAndEncodeConfig(filePath string) (string, error) {
+	config, err := LoadFromFile(filePath)
+	if err != nil {
+		return "", err
+	}
+
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+
+	err = enc.Encode(config)
+	if err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}

--- a/internal/config/models.go
+++ b/internal/config/models.go
@@ -1,0 +1,25 @@
+package config
+
+type Configuration struct {
+	Default   DefaultConfig `yaml:"default"`
+	Pipelines []Pipeline    `yaml:"pipelines"`
+}
+
+type DefaultConfig struct {
+	Permissions  []string     `yaml:"permissions"`
+	Repositories []Repository `yaml:"repositories"`
+}
+
+type Permissions struct {
+	Permissions []string `yaml:"permissions"`
+}
+
+type Repository struct {
+	Name        string   `yaml:"name"`
+	Permissions []string `yaml:"permissions,omitempty"`
+}
+
+type Pipeline struct {
+	Name         string       `yaml:"name"`
+	Repositories []Repository `yaml:"repositories"`
+}

--- a/internal/config/parse.go
+++ b/internal/config/parse.go
@@ -1,0 +1,80 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+func ParseConfiguration(data []byte) (*Configuration, error) {
+	config := NewDefaultConfig()
+	err := yaml.Unmarshal([]byte(data), config)
+	if err != nil {
+		return nil, err
+	}
+	sanitizeConfig(config)
+	return config, nil
+}
+
+func sanitizeConfig(config *Configuration) {
+	for i := range config.Default.Permissions {
+		config.Default.Permissions[i] = strings.ToLower(config.Default.Permissions[i])
+	}
+
+	for i := range config.Default.Repositories {
+		for j := range config.Default.Repositories[i].Permissions {
+			config.Default.Repositories[i].Permissions[j] = strings.ToLower(
+				config.Default.Repositories[i].Permissions[j],
+			)
+		}
+	}
+
+	for i := range config.Pipelines {
+		for j := range config.Pipelines[i].Repositories {
+			for k := range config.Pipelines[i].Repositories[j].Permissions {
+				config.Pipelines[i].Repositories[j].Permissions[k] = strings.ToLower(
+					config.Pipelines[i].Repositories[j].Permissions[k],
+				)
+			}
+		}
+	}
+}
+
+func GetConfigValue(config *Configuration, repoName string, defaultValue []string,
+	getValue func(repo Repository) []string) ([]string, error) {
+	for _, repo := range config.Default.Repositories {
+		if repo.Name == repoName {
+			return mergeValues(defaultValue, getValue(repo)), nil
+		}
+	}
+
+	for _, pipeline := range config.Pipelines {
+		for _, repo := range pipeline.Repositories {
+			if repo.Name == repoName {
+				return mergeValues(defaultValue, getValue(repo)), nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("repository %s not found in configuration", repoName)
+}
+
+func mergeValues(defaultValues, repoValues []string) []string {
+	valueSet := make(map[string]struct{})
+
+	for _, value := range defaultValues {
+		valueSet[value] = struct{}{}
+	}
+
+	for _, value := range repoValues {
+		valueSet[value] = struct{}{}
+	}
+
+	merged := make([]string, 0, len(valueSet))
+	for value := range valueSet {
+		merged = append(merged, value)
+	}
+
+	return merged
+}

--- a/internal/config/parse_test.go
+++ b/internal/config/parse_test.go
@@ -1,0 +1,102 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const configStr string = `
+default:
+  permissions:
+    - "content:read"
+  repositories:
+    - name: "org/privaterepo"
+      permissions: ["content:read"]
+    - name: "org/otherrepo"
+
+pipelines:
+  - name: "pipeline name"
+    repositories:
+      - name: "org/repo1"
+        permissions: ["content:read", "pull_request:write"]
+      - name: "org/repo2"
+        permissions: ["content:read", "pull_request:write"]
+`
+
+func TestParseConfiguration(t *testing.T) {
+	for _, scenario := range []struct {
+		name     string
+		data     string
+		expected *Configuration
+	}{
+		{
+			name: "default values",
+			data: "",
+			expected: &Configuration{
+				Default: DefaultConfig{
+					Permissions:  nil,
+					Repositories: nil,
+				},
+				Pipelines: nil,
+			},
+		},
+		{
+			name: "user provided values",
+			data: configStr,
+			expected: &Configuration{
+				Default: DefaultConfig{
+					Permissions: []string{"content:read"},
+					Repositories: []Repository{
+						{Name: "org/privaterepo", Permissions: []string{"content:read"}},
+						{Name: "org/otherrepo"},
+					},
+				},
+				Pipelines: []Pipeline{
+					{
+						Name: "pipeline name",
+						Repositories: []Repository{
+							{Name: "org/repo1", Permissions: []string{"content:read", "pull_request:write"}},
+							{Name: "org/repo2", Permissions: []string{"content:read", "pull_request:write"}},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "user provided empty default permissions",
+			data: `default:
+  permissions: []
+pipelines: []`,
+			expected: &Configuration{
+				Default: DefaultConfig{
+					Permissions:  []string{},
+					Repositories: nil,
+				},
+				Pipelines: []Pipeline{},
+			},
+		},
+		{
+			name: "user provided empty repositories",
+			data: `default:
+  permissions: []
+  repositories: []
+pipelines: []`,
+			expected: &Configuration{
+				Default: DefaultConfig{
+					Permissions:  []string{},
+					Repositories: []Repository{},
+				},
+				Pipelines: []Pipeline{},
+			},
+		},
+	} {
+		t.Run(scenario.name, func(t *testing.T) {
+			config, err := ParseConfiguration([]byte(scenario.data))
+			require.NoError(t, err)
+			assert.Equal(t, scenario.expected.Default, config.Default)
+			assert.Equal(t, scenario.expected.Pipelines, config.Pipelines)
+		})
+	}
+}

--- a/internal/config/service.go
+++ b/internal/config/service.go
@@ -1,0 +1,28 @@
+package config
+
+import (
+	"context"
+	"fmt"
+)
+
+type PermissionsService struct {
+	config *Configuration
+}
+
+func NewPermissionsService(config *Configuration) *PermissionsService {
+	return &PermissionsService{config: config}
+}
+
+func (ps *PermissionsService) GetPermissions(ctx context.Context, pipelineName string) (Permissions, error) {
+	permissions, err := GetPermissionsFromConfig(ps.config, pipelineName)
+	if err != nil {
+		return Permissions{}, fmt.Errorf("could not get permissions for pipeline %s: %w", pipelineName, err)
+	}
+	return Permissions{Permissions: permissions}, nil
+}
+
+func GetPermissionsFromConfig(config *Configuration, repoName string) ([]string, error) {
+	return GetConfigValue(config, repoName, config.Default.Permissions, func(repo Repository) []string {
+		return repo.Permissions
+	})
+}

--- a/internal/github/permissions.go
+++ b/internal/github/permissions.go
@@ -1,0 +1,109 @@
+package github
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/google/go-github/v61/github"
+)
+
+type Permissions struct {
+	Actions            string
+	Checks             string
+	Contents           string
+	Deployments        string
+	Issues             string
+	Metadata           string
+	Packages           string
+	Pages              string
+	PullRequests       string
+	RepositoryProjects string
+	SecurityEvents     string
+	Statuses           string
+}
+
+func (p Permissions) ToGithubPermissions() *github.InstallationPermissions {
+	permissions := &github.InstallationPermissions{}
+
+	setPermission(&permissions.Actions, p.Actions)
+	setPermission(&permissions.Checks, p.Checks)
+	setPermission(&permissions.Contents, p.Contents)
+	setPermission(&permissions.Deployments, p.Deployments)
+	setPermission(&permissions.Issues, p.Issues)
+	setPermission(&permissions.Metadata, p.Metadata)
+	setPermission(&permissions.Packages, p.Packages)
+	setPermission(&permissions.Pages, p.Pages)
+	setPermission(&permissions.PullRequests, p.PullRequests)
+	setPermission(&permissions.RepositoryProjects, p.RepositoryProjects)
+	setPermission(&permissions.SecurityEvents, p.SecurityEvents)
+	setPermission(&permissions.Statuses, p.Statuses)
+
+	return permissions
+}
+
+// GetPermissionsFromEnv retrieves GitHub token permissions from Buildkite
+// environment variables. It reads the permissions for various GitHub features
+// from environment variables that should be set to either "read" or "write". If
+// an environment variable is not set, the permission is omitted.
+func GetPermissionsFromEnv() (Permissions, error) {
+	permissions := Permissions{}
+
+	envVars := map[string]*string{
+		"GITHUB_PERMISSIONS_ACTIONS":             &permissions.Actions,
+		"GITHUB_PERMISSIONS_CHECKS":              &permissions.Checks,
+		"GITHUB_PERMISSIONS_CONTENTS":            &permissions.Contents,
+		"GITHUB_PERMISSIONS_DEPLOYMENTS":         &permissions.Deployments,
+		"GITHUB_PERMISSIONS_ISSUES":              &permissions.Issues,
+		"GITHUB_PERMISSIONS_METADATA":            &permissions.Metadata,
+		"GITHUB_PERMISSIONS_PACKAGES":            &permissions.Packages,
+		"GITHUB_PERMISSIONS_PAGES":               &permissions.Pages,
+		"GITHUB_PERMISSIONS_PULL_REQUESTS":       &permissions.PullRequests,
+		"GITHUB_PERMISSIONS_REPOSITORY_PROJECTS": &permissions.RepositoryProjects,
+		"GITHUB_PERMISSIONS_SECURITY_EVENTS":     &permissions.SecurityEvents,
+		"GITHUB_PERMISSIONS_STATUSES":            &permissions.Statuses,
+	}
+
+	defaultValues := map[string]string{
+		"GITHUB_PERMISSIONS_CONTENTS": "read",
+	}
+
+	for envVar, field := range envVars {
+		defaultValue := defaultValues[envVar]
+		value := getEnv(envVar, defaultValue)
+		err := validatePermission(value, envVar)
+		if err != nil {
+			return permissions, err
+		}
+		*field = value
+	}
+
+	return permissions, nil
+}
+
+func setPermission(field **string, value string) {
+	if value != "" {
+		*field = github.String(value)
+	}
+}
+
+func getEnv(key, defaultValue string) string {
+	if value, exists := os.LookupEnv(key); exists {
+		return value
+	}
+	return defaultValue
+}
+
+var validPermissions = map[string]struct{}{
+	"read":  {},
+	"write": {},
+}
+
+func validatePermission(permission, envVar string) error {
+	if permission == "" {
+		return nil
+	}
+	if _, valid := validPermissions[permission]; !valid {
+		return fmt.Errorf("invalid value for %s: %s", envVar, permission)
+	}
+	return nil
+}

--- a/internal/github/permissions_test.go
+++ b/internal/github/permissions_test.go
@@ -1,0 +1,77 @@
+package github_test
+
+import (
+	"os"
+	"testing"
+
+	gh "github.com/google/go-github/v61/github"
+	"github.com/jamestelfer/chinmina-bridge/internal/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetPermissionsFromEnv(t *testing.T) {
+	// set environment variables for testing
+	os.Setenv("GITHUB_PERMISSIONS_ACTIONS", "read")
+	os.Setenv("GITHUB_PERMISSIONS_CHECKS", "read")
+	os.Setenv("GITHUB_PERMISSIONS_CONTENTS", "write") // overriding default
+	os.Setenv("GITHUB_PERMISSIONS_DEPLOYMENTS", "read")
+	os.Setenv("GITHUB_PERMISSIONS_ISSUES", "read")
+	os.Setenv("GITHUB_PERMISSIONS_METADATA", "read")
+	os.Setenv("GITHUB_PERMISSIONS_PACKAGES", "read")
+	os.Setenv("GITHUB_PERMISSIONS_PAGES", "read")
+	os.Setenv("GITHUB_PERMISSIONS_PULL_REQUESTS", "read")
+	os.Setenv("GITHUB_PERMISSIONS_REPOSITORY_PROJECTS", "read")
+	os.Setenv("GITHUB_PERMISSIONS_SECURITY_EVENTS", "read")
+	os.Setenv("GITHUB_PERMISSIONS_STATUSES", "read")
+
+	permissions, err := github.GetPermissionsFromEnv()
+	require.NoError(t, err)
+
+	assert.Equal(t, "read", permissions.Actions)
+	assert.Equal(t, "read", permissions.Checks)
+	assert.Equal(t, "write", permissions.Contents)
+	assert.Equal(t, "read", permissions.Deployments)
+	assert.Equal(t, "read", permissions.Issues)
+	assert.Equal(t, "read", permissions.Metadata)
+	assert.Equal(t, "read", permissions.Packages)
+	assert.Equal(t, "read", permissions.Pages)
+	assert.Equal(t, "read", permissions.PullRequests)
+	assert.Equal(t, "read", permissions.RepositoryProjects)
+	assert.Equal(t, "read", permissions.SecurityEvents)
+	assert.Equal(t, "read", permissions.Statuses)
+
+	os.Clearenv()
+}
+
+func TestToGithubPermissions(t *testing.T) {
+	permissions := github.Permissions{
+		Actions:            "read",
+		Checks:             "read",
+		Contents:           "write",
+		Deployments:        "read",
+		Issues:             "read",
+		Metadata:           "read",
+		Packages:           "read",
+		Pages:              "read",
+		PullRequests:       "read",
+		RepositoryProjects: "read",
+		SecurityEvents:     "read",
+		Statuses:           "read",
+	}
+
+	githubPermissions := permissions.ToGithubPermissions()
+
+	assert.Equal(t, gh.String("read"), githubPermissions.Actions)
+	assert.Equal(t, gh.String("read"), githubPermissions.Checks)
+	assert.Equal(t, gh.String("write"), githubPermissions.Contents)
+	assert.Equal(t, gh.String("read"), githubPermissions.Deployments)
+	assert.Equal(t, gh.String("read"), githubPermissions.Issues)
+	assert.Equal(t, gh.String("read"), githubPermissions.Metadata)
+	assert.Equal(t, gh.String("read"), githubPermissions.Packages)
+	assert.Equal(t, gh.String("read"), githubPermissions.Pages)
+	assert.Equal(t, gh.String("read"), githubPermissions.PullRequests)
+	assert.Equal(t, gh.String("read"), githubPermissions.RepositoryProjects)
+	assert.Equal(t, gh.String("read"), githubPermissions.SecurityEvents)
+	assert.Equal(t, gh.String("read"), githubPermissions.Statuses)
+}

--- a/internal/github/token.go
+++ b/internal/github/token.go
@@ -15,12 +15,16 @@ import (
 )
 
 type Client struct {
-	client         *github.Client
-	installationID int64
+	client             *github.Client
+	installationID     int64
+	permissionsService PermissionsService
 }
 
-func New(cfg config.GithubConfig) (Client, error) {
+type PermissionsService interface {
+	GetPermissions(ctx context.Context, pipelineName string) (Permissions, error)
+}
 
+func New(cfg config.GithubConfig, ps PermissionsService) (Client, error) {
 	// Create a transport using the JWT authentication method. The endpoints
 	// we're calling require this method.
 	appInstallationTransport, err := ghinstallation.NewAppsTransport(
@@ -53,8 +57,9 @@ func New(cfg config.GithubConfig) (Client, error) {
 	}
 
 	return Client{
-		client,
-		cfg.InstallationID,
+		client:             client,
+		installationID:     cfg.InstallationID,
+		permissionsService: ps,
 	}, nil
 }
 

--- a/internal/github/token.go
+++ b/internal/github/token.go
@@ -58,23 +58,18 @@ func New(cfg config.GithubConfig) (Client, error) {
 	}, nil
 }
 
-func (c Client) CreateAccessToken(ctx context.Context, repositoryURL string) (string, time.Time, error) {
+func (c Client) CreateAccessToken(ctx context.Context, repositoryURL string, p Permissions) (string, time.Time, error) {
 	u, err := url.Parse(repositoryURL)
 	if err != nil {
 		return "", time.Time{}, err
 	}
-
-	// qualifiedIdentifier, _ := strings.CutSuffix(u.Path, ".git")
-	// _, repoName, _ := strings.Cut(qualifiedIdentifier[1:], "/")
 
 	_, repoName := RepoForURL(*u)
 
 	tok, r, err := c.client.Apps.CreateInstallationToken(ctx, c.installationID,
 		&github.InstallationTokenOptions{
 			Repositories: []string{repoName},
-			Permissions: &github.InstallationPermissions{
-				Contents: github.String("read"),
-			},
+			Permissions:  p.ToGithubPermissions(),
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
## Purpose

Allow GitHub token permissions to be conditionally set with Buildkite environment variables. If no variables are found, the token defaults to `contents:read`.

This is an initial pass that likely requires some thought around scoping permissions. For example we may want to explicitly disallow users from creating `write` tokens for repositories that aren't associated with a pipeline.

## Context

DaSe requires `contents:write` and `pull_request:write` for specific Buildkite actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced the ability to adjust GitHub token permissions using environment variables.
  - Added new environment variables for setting specific GitHub permissions (e.g., `GITHUB_PERMISSIONS_ACTIONS`, `GITHUB_PERMISSIONS_ISSUES`).

- **Documentation**
  - Updated README to reflect new token permission defaults and environment variable settings.
  - Enhanced limitations section to include recent changes.

- **Refactor**
  - Refactored access token creation to incorporate permissions from environment variables, enhancing modularity and flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->