### PR TITLE
fix: CreateAccessToken is more generic for other use cases

### DIFF
--- a/internal/github/token.go
+++ b/internal/github/token.go
@@ -183,7 +183,7 @@ func GetRepoNames(repositoryURLs []string) ([]string, error) {
 		if repoName == "" {
 			log.Warn().
 				Str("repoURL", repoURL).
-				Msg("failed to extract repo name from URL, skipping this repository. Ensure that this repository URL is of the format: 'https://github.com/<org-name>/<repo-name>'")
+				Msg("failed to extract repo name from URL, skipping this repository")
 			continue
 		}
 
@@ -209,7 +209,7 @@ func ScopesToPermissions(scopes []string) (*github.InstallationPermissions, erro
 		if len(parts) != 2 {
 			log.Warn().
 				Str("scope", scope).
-				Msg("malformed scope detected, skipping permission. Ensure that the permissions follows the convention of <aspect>:<action>")
+				Msg("malformed scope detected, skipping permission")
 			continue
 		}
 
@@ -225,7 +225,7 @@ func ScopesToPermissions(scopes []string) (*github.InstallationPermissions, erro
 			isValidAspect = false
 			log.Warn().
 				Str("field", field.String()).
-				Msg("invalid permission aspect detected, skipping permission. Ensure that your permission aspect is a valid InstallationPermissions field and is snake-cased (an valid example is 'pull_request:write')")
+				Msg("invalid permission aspect detected, skipping permission")
 		}
 
 		// Check if the scope includes one of the valid permission actions
@@ -233,7 +233,7 @@ func ScopesToPermissions(scopes []string) (*github.InstallationPermissions, erro
 			isValidAction = false
 			log.Warn().
 				Str("permission", value).
-				Msg("invalid permission action detected, skipping permission. Ensure that your action is one of the following: [read, write]")
+				Msg("invalid permission action detected, skipping permission")
 		}
 
 		// If both are valid the scope is valid, so set this permission

--- a/internal/github/token.go
+++ b/internal/github/token.go
@@ -213,6 +213,7 @@ func ScopesToPermissions(scopes []string) (*github.InstallationPermissions, erro
 			continue
 		}
 
+		// Snake case is how fields are represented in the struct, so this ensures the first part of the scope matches
 		key := snakeToPascalCase(parts[0])
 		value := parts[1]
 		field := permissionsValue.FieldByName(key)
@@ -224,7 +225,7 @@ func ScopesToPermissions(scopes []string) (*github.InstallationPermissions, erro
 			isValidAspect = false
 			log.Warn().
 				Str("field", field.String()).
-				Msg("invalid permission aspect detected, skipping permission. Ensure that you use aspects as defined here: https://pkg.go.dev/github.com/google/go-github/v61@v61.0.0/github#InstallationPermissions")
+				Msg("invalid permission aspect detected, skipping permission. Ensure that your permission aspect is a valid InstallationPermissions field and is snake-cased (an valid example is 'pull_request:write')")
 		}
 
 		// Check if the scope includes one of the valid permission actions

--- a/internal/github/token.go
+++ b/internal/github/token.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
+	"slices"
 	"strings"
 	"time"
 
@@ -215,7 +216,7 @@ func ScopesToPermissions(scopes []string) (*github.InstallationPermissions, erro
 
 		// Snake case is how fields are represented in the struct, so this ensures the first part of the scope matches
 		key := snakeToPascalCase(parts[0])
-		value := parts[1]
+		action := parts[1]
 		field := permissionsValue.FieldByName(key)
 
 		isValidAspect := true
@@ -228,17 +229,17 @@ func ScopesToPermissions(scopes []string) (*github.InstallationPermissions, erro
 				Msg("invalid permission aspect detected, skipping permission")
 		}
 
-		// Check if the scope includes one of the valid permission actions
-		if !contains(validPermissionActions, value) {
+		// Check if the scope's action includes one of the valid permission actions
+		if !slices.Contains(validPermissionActions, action) {
 			isValidAction = false
 			log.Warn().
-				Str("permission", value).
+				Str("permission", action).
 				Msg("invalid permission action detected, skipping permission")
 		}
 
 		// If both are valid the scope is valid, so set this permission
 		if isValidAspect && isValidAction {
-			field.Set(reflect.ValueOf(github.String(value)))
+			field.Set(reflect.ValueOf(github.String(action)))
 			validScopes++
 		}
 	}
@@ -262,13 +263,4 @@ func snakeToPascalCase(input string) string {
 	}
 
 	return result
-}
-
-func contains(slice []string, item string) bool {
-	for _, element := range slice {
-		if element == item {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/github/token.go
+++ b/internal/github/token.go
@@ -213,9 +213,7 @@ func ScopesToPermissions(scopes []string) (*github.InstallationPermissions, erro
 			continue
 		}
 
-		// Capitalise the key so it matches the field name in the struct
-		c := cases.Title(language.English)
-		key := c.String(parts[0])
+		key := snakeToPascalCase(parts[0])
 		value := parts[1]
 		field := permissionsValue.FieldByName(key)
 
@@ -249,6 +247,20 @@ func ScopesToPermissions(scopes []string) (*github.InstallationPermissions, erro
 	}
 
 	return permissions, nil
+}
+
+func snakeToPascalCase(input string) string {
+	c := cases.Title(language.English)
+
+	parts := strings.Split(input, "_")
+	var result string
+
+	// Capitalises the first letter of each substring and append to the result
+	for _, part := range parts {
+		result += c.String(part)
+	}
+
+	return result
 }
 
 func contains(slice []string, item string) bool {

--- a/internal/github/token_test.go
+++ b/internal/github/token_test.go
@@ -148,8 +148,9 @@ func TestCreateAccessToken_Fails_On_Invalid_URL(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	_, _, err = gh.CreateAccessToken(context.Background(), []string{"sch_eme://invalid_url/"}, []string{"contents:read"})
+	tok, _, err := gh.CreateAccessToken(context.Background(), []string{"sch_eme://invalid_url/"}, []string{"contents:read"})
 
+	assert.Equal(t, "", tok)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "no valid repository URLs found")
 }
@@ -178,8 +179,9 @@ func TestCreateAccessToken_Fails_On_Failed_Request(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	_, _, err = gh.CreateAccessToken(context.Background(), []string{"https://github.com/org/repo"}, []string{"contents:read"})
+	tok, _, err := gh.CreateAccessToken(context.Background(), []string{"https://github.com/org/repo"}, []string{"contents:read"})
 
+	assert.Equal(t, "", tok)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, ": 418")
 }

--- a/internal/vendor/vendor.go
+++ b/internal/vendor/vendor.go
@@ -21,7 +21,7 @@ type RepositoryLookup func(ctx context.Context, organizationSlug, pipelineSlug s
 
 // Vend a token for the given repository URL. The URL must be a https URL to a
 // GitHub repository that the vendor has permissions to access.
-type TokenVendor func(ctx context.Context, repositoryURL string) (string, time.Time, error)
+type TokenVendor func(ctx context.Context, repositoryURLs []string, scopes []string) (string, time.Time, error)
 
 type PipelineRepositoryToken struct {
 	OrganizationSlug string    `json:"organizationSlug"`
@@ -77,7 +77,7 @@ func New(
 		}
 
 		// use the github api to vend a token for the repository
-		token, expiry, err := tokenVendor(ctx, pipelineRepoURL)
+		token, expiry, err := tokenVendor(ctx, []string{pipelineRepoURL}, []string{"contents:read"})
 		if err != nil {
 			return nil, fmt.Errorf("could not issue token for repository %s: %w", pipelineRepoURL, err)
 		}

--- a/internal/vendor/vendor_test.go
+++ b/internal/vendor/vendor_test.go
@@ -45,7 +45,7 @@ func TestVendor_FailsWhenTokenVendorFails(t *testing.T) {
 	repoLookup := vendor.RepositoryLookup(func(ctx context.Context, org string, pipeline string) (string, error) {
 		return "repo-url", nil
 	})
-	tokenVendor := vendor.TokenVendor(func(ctx context.Context, repositoryURL string) (string, time.Time, error) {
+	tokenVendor := vendor.TokenVendor(func(ctx context.Context, repositoryURLs []string, scopes []string) (string, time.Time, error) {
 		return "", time.Time{}, errors.New("token vendor failed")
 	})
 	v := vendor.New(repoLookup, tokenVendor, nil)
@@ -61,7 +61,7 @@ func TestVendor_SucceedsWithTokenWhenPossible(t *testing.T) {
 	repoLookup := vendor.RepositoryLookup(func(ctx context.Context, org string, pipeline string) (string, error) {
 		return "repo-url", nil
 	})
-	tokenVendor := vendor.TokenVendor(func(ctx context.Context, repositoryURL string) (string, time.Time, error) {
+	tokenVendor := vendor.TokenVendor(func(ctx context.Context, repositoryURLs []string, scopes []string) (string, time.Time, error) {
 		return "vended-token-value", vendedDate, nil
 	})
 	v := vendor.New(repoLookup, tokenVendor, nil)


### PR DESCRIPTION
## Purpose
- Ensures that `CreateAccessToken` is a more general-purpose function
- Currently it's very specifically designed to:
  - Take in only a single repo
  - Only supplies the `contents:read` scope
- Making this function more general-purpose allows chinmina to dynamically generate access tokens for varying repos with different scopes, also avoiding repetition

## Rationale
- I've made the decision to allow `ScopesToPermissions` and `GetRepoNames` to not return an error if at least one scope and repo is valid respectively. I've done this as without implementing this, a single typo somewhere would cause the entire token vending process to fail. Skipping invalid scopes/repos and logging these as warnings reduces the blast radius of incorrect changes, and makes rolling out changes to organisation profiles less stressful.
- I've also decided that if either repos and/or scopes are empty, token generation will fail. The reason I've decided on this approach is if no errors are reported this may lead to some confusing downstream behaviour during token generation, or when consumers attempt to use the chinmina token.
  - I don't think there's any security concerns around having empty fields, as looking at these [docs](https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#create-an-installation-access-token-for-an-app) both `repositories` and `permissions` are optional, so it appears that a token would be generated successfully but have no permissions/access to repos. That being said, failing early reduces the confusion from the token vending process, as even if token was generated successfully, it wouldn't work for consumers.

## Context
- Making it easier to support vending tokens [for a given profile](https://github.com/chinmina/chinmina-bridge/issues/75)
- Pairing with @liamstevens, a local deployment of Chinmina shows that it works without issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Access token generation now supports multiple repository inputs.
  - Token permissions are dynamically set based on customizable scopes.
  - Vendor functionality is enhanced to process multi-repository token requests.
- **Bug Fixes**
  - Updated tests to reflect changes in method signatures and ensure proper functionality with multiple inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->