### PR TITLE
test: improve integration test environment setup

### DIFF
--- a/agent/hooks/environment
+++ b/agent/hooks/environment
@@ -11,15 +11,12 @@ BUILDKITE_PLUGIN_CHINMINA_GIT_CREDENTIALS_CHINMINA_URL="http://chinmina-bridge" 
 BUILDKITE_PLUGIN_CHINMINA_GIT_CREDENTIALS_AUDIENCE="github-app-auth:chinmina" \
 BUILDKITE_PLUGIN_CHINMINA_GIT_CREDENTIALS_PROFILES_0="repo:default" \
 BUILDKITE_PLUGIN_CHINMINA_GIT_CREDENTIALS_PROFILES_1="org:buildkite-plugin-testing" \
-    source /buildkite/plugins/chinmina-git-credentials-buildkite-plugin/hooks/environment 
+    source /buildkite/plugins/chinmina-git-credentials-buildkite-plugin/hooks/environment
 
 # References the local instance of chinmina service
 BUILDKITE_PLUGIN_CHINMINA_TOKEN_CHINMINA_URL="http://chinmina-bridge" \
 BUILDKITE_PLUGIN_CHINMINA_TOKEN_AUDIENCE="github-app-auth:chinmina" \
-    source /buildkite/plugins/chinmina-token-buildkite-plugin/hooks/environment 
-#Installing gh cli
-echo "@community http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
-apk add github-cli@community
+    source /buildkite/plugins/chinmina-token-buildkite-plugin/hooks/environment
 
 # optional: it is possible to change the git URL, converting it from SSH to
 # HTTPS if that is desired.

--- a/agent/startup/bootstrap-github-auth
+++ b/agent/startup/bootstrap-github-auth
@@ -29,3 +29,7 @@ GIT_CONFIG_VALUE_0=false \
   git clone --depth 1 --single-branch --no-tags \
     --branch "${plugin_version}" -- \
     "${plugin_repo}" "${plugin_dir}"
+
+# Installing gh cli
+echo "@community http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
+apk add github-cli@community


### PR DESCRIPTION
## Purpose

Improves the integration test environment by moving GitHub CLI installation from the environment hook to the bootstrap script. This provides a more accurate example of how installations should be implemented in production Buildkite environments, where bootstrap scripts are the appropriate place for tool installation rather than environment hooks that run on every step.

## Context

- Integration tests use a simulated Buildkite agent environment
- The environment hook runs for every build step, making it inappropriate for installations
- Bootstrap scripts run once during agent initialization, which is the correct place for tool setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized GitHub CLI installation steps within the initialization process for improved build efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->