### PR TITLE
refactor: use explicit VendorResult type in TokenVendor

### DIFF
--- a/handlers_test.go
+++ b/handlers_test.go
@@ -138,8 +138,8 @@ func TestHandlePostGitCredentials_ReturnsTokenOnSuccess(t *testing.T) {
 }
 
 func TestHandlePostGitCredentials_ReturnsEmptySuccessWhenNoToken(t *testing.T) {
-	tokenVendor := vendor.ProfileTokenVendor(func(_ context.Context, ref profile.ProfileRef, repoUrl string) (*vendor.ProfileToken, error) {
-		return nil, nil
+	tokenVendor := vendor.ProfileTokenVendor(func(_ context.Context, ref profile.ProfileRef, repoUrl string) vendor.VendorResult {
+		return vendor.NewVendorUnmatched()
 	})
 
 	ctx := claimsContext()
@@ -276,14 +276,14 @@ func TestHandleHealthCheck_Success(t *testing.T) {
 }
 
 func tv(token string) vendor.ProfileTokenVendor {
-	return vendor.ProfileTokenVendor(func(_ context.Context, ref profile.ProfileRef, repoUrl string) (*vendor.ProfileToken, error) {
-		return &vendor.ProfileToken{
+	return vendor.ProfileTokenVendor(func(_ context.Context, ref profile.ProfileRef, repoUrl string) vendor.VendorResult {
+		return vendor.NewVendorSuccess(vendor.ProfileToken{
 			Token:               token,
 			Expiry:              defaultExpiry,
 			Profile:             ref.ShortString(),
 			OrganizationSlug:    ref.Organization,
 			VendedRepositoryURL: repoUrl,
-		}, nil
+		})
 	})
 }
 
@@ -318,8 +318,8 @@ func TestHandlePostGitCredentialsWithProfile_ReturnsTokenOnSuccess(t *testing.T)
 }
 
 func tvFails(err error) vendor.ProfileTokenVendor {
-	return vendor.ProfileTokenVendor(func(_ context.Context, ref profile.ProfileRef, repoUrl string) (*vendor.ProfileToken, error) {
-		return nil, err
+	return vendor.ProfileTokenVendor(func(_ context.Context, ref profile.ProfileRef, repoUrl string) vendor.VendorResult {
+		return vendor.NewVendorFailed(err)
 	})
 }
 

--- a/internal/vendor/testhelpers_test.go
+++ b/internal/vendor/testhelpers_test.go
@@ -1,0 +1,45 @@
+package vendor_test
+
+import (
+	"testing"
+
+	"github.com/chinmina/chinmina-bridge/internal/vendor"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// assertVendorSuccess verifies that vending succeeded and returns the expected token
+func assertVendorSuccess(t *testing.T, result vendor.VendorResult, expected vendor.ProfileToken) {
+	t.Helper()
+	_, failed := result.Failed()
+	require.False(t, failed, "expected vendor to succeed")
+	token, ok := result.Token()
+	require.True(t, ok, "expected token to be present")
+	assert.Equal(t, expected, token)
+}
+
+func assertVendorTokenValue(t *testing.T, result vendor.VendorResult, expected string) {
+	t.Helper()
+	_, failed := result.Failed()
+	require.False(t, failed, "expected vendor to succeed")
+	token, ok := result.Token()
+	require.True(t, ok, "expected token to be present")
+	assert.Equal(t, expected, token.Token)
+}
+
+// assertVendorUnmatched verifies that vending succeeded but no token was returned (unmatched case)
+func assertVendorUnmatched(t *testing.T, result vendor.VendorResult) {
+	t.Helper()
+	_, failed := result.Failed()
+	require.False(t, failed, "expected vendor to succeed with no match")
+	_, ok := result.Token()
+	require.False(t, ok, "expected no token for unmatched case")
+}
+
+// assertVendorFailure verifies that vending failed with the expected error
+func assertVendorFailure(t *testing.T, result vendor.VendorResult, expectedErrorSubstring string) {
+	t.Helper()
+	err, failed := result.Failed()
+	require.True(t, failed, "expected vendor to fail")
+	require.ErrorContains(t, err, expectedErrorSubstring)
+}

--- a/internal/vendor/vendor.go
+++ b/internal/vendor/vendor.go
@@ -11,7 +11,7 @@ import (
 	"github.com/chinmina/chinmina-bridge/internal/profile"
 )
 
-type ProfileTokenVendor func(ctx context.Context, ref profile.ProfileRef, repo string) (*ProfileToken, error)
+type ProfileTokenVendor func(ctx context.Context, ref profile.ProfileRef, repo string) VendorResult
 
 // Given a pipeline, return the https version of the repository URL
 type RepositoryLookup func(ctx context.Context, organizationSlug, pipelineSlug string) (string, error)

--- a/internal/vendor/vendor_test.go
+++ b/internal/vendor/vendor_test.go
@@ -168,43 +168,19 @@ func TestNewVendorSuccess(t *testing.T) {
 
 	result := vendor.NewVendorSuccess(token)
 
-	// Verify Failed() returns false
-	err, failed := result.Failed()
-	assert.False(t, failed)
-	assert.Nil(t, err)
-
-	// Verify Token() returns the token and true
-	gotToken, ok := result.Token()
-	assert.True(t, ok)
-	assert.Equal(t, token, gotToken)
+	assertVendorSuccess(t, result, token)
 }
 
 func TestNewVendorUnmatched(t *testing.T) {
 	result := vendor.NewVendorUnmatched()
 
-	// Verify Failed() returns false
-	err, failed := result.Failed()
-	assert.False(t, failed)
-	assert.Nil(t, err)
-
-	// Verify Token() returns false
-	_, ok := result.Token()
-	assert.False(t, ok)
+	assertVendorUnmatched(t, result)
 }
 
 func TestNewVendorFailed(t *testing.T) {
-	testErr := assert.AnError
+	result := vendor.NewVendorFailed(assert.AnError)
 
-	result := vendor.NewVendorFailed(testErr)
-
-	// Verify Failed() returns true with the error
-	err, failed := result.Failed()
-	assert.True(t, failed)
-	assert.Equal(t, testErr, err)
-
-	// Verify Token() returns false
-	_, ok := result.Token()
-	assert.False(t, ok)
+	assertVendorFailure(t, result, "general error for testing")
 }
 
 func TestVendorResult_Failed(t *testing.T) {


### PR DESCRIPTION
## Purpose

Eliminates a subtle bug pattern in token vending by replacing the implicit (*ProfileToken, error) return type with an explicit VendorResult type. The current implementation has three implicit states: success with token, successful no-match, and failure. The no-match case uses (nil, nil), which causes handlePostToken to incorrectly return "null" JSON instead of 204 No Content when no profile matches.

The explicit VendorResult type makes these three states clear through named constructors (NewVendorSuccess, NewVendorUnmatched, NewVendorFailed) and accessor methods, preventing misinterpretation and making the control flow obvious to readers.

## Context

Implementation completed in two atomic commits: type system addition followed by migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized token vending to a unified result model representing success, unmatched, and failure outcomes across the system.

* **Behavior Change**
  * Token endpoint returns 204 No Content when no token is matched; credentials endpoint returns 200 with an empty body when no credentials are available.

* **Tests**
  * Updated and added tests and helpers to validate the new result-driven vending flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->