### PR TITLE
feat(profile): add types for runtime profile model

### DIFF
--- a/internal/profile/authorized.go
+++ b/internal/profile/authorized.go
@@ -1,0 +1,39 @@
+package profile
+
+// OrganizationProfileAttr contains the attributes for an organization profile.
+// Slice fields are expected to be treated as immutable after construction.
+// Callers should not modify slice contents after passing to NewAuthorizedProfile or NewProfileStoreOf.
+type OrganizationProfileAttr struct {
+	Repositories []string
+	Permissions  []string
+}
+
+// PipelineProfileAttr is a placeholder for future pipeline profile attributes.
+// Any future slice fields should be treated as immutable after construction.
+type PipelineProfileAttr struct {
+	// TODO: Add pipeline-specific attributes when implementing pipeline profiles
+}
+
+// AuthorizedProfile encapsulates a matcher with typed profile attributes.
+// The generic parameter T allows type-safe access to profile-specific attributes.
+type AuthorizedProfile[T any] struct {
+	matcher Matcher
+	Attrs   T
+}
+
+// NewAuthorizedProfile creates a new AuthorizedProfile with the given matcher and attributes.
+func NewAuthorizedProfile[T any](matcher Matcher, attrs T) AuthorizedProfile[T] {
+	return AuthorizedProfile[T]{
+		matcher: matcher,
+		Attrs:   attrs,
+	}
+}
+
+// Match evaluates the profile's match conditions against the provided claims.
+// Returns a MatchResult containing:
+// - Success: Matched=true, Matches populated
+// - Pattern mismatch: Matched=false, Attempt populated
+// - Validation error: Err populated
+func (ap AuthorizedProfile[T]) Match(claims ClaimValueLookup) MatchResult {
+	return ap.matcher(claims)
+}

--- a/internal/profile/authorized_test.go
+++ b/internal/profile/authorized_test.go
@@ -1,0 +1,148 @@
+package profile_test
+
+import (
+	"testing"
+
+	"github.com/chinmina/chinmina-bridge/internal/profile"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestNewAuthorizedProfile_OrganizationProfile creates an authorized profile with organization attributes.
+func TestNewAuthorizedProfile_OrganizationProfile(t *testing.T) {
+	matcher := profile.ExactMatcher("pipeline_slug", "my-pipeline")
+	attrs := profile.OrganizationProfileAttr{
+		Repositories: []string{"chinmina/chinmina-bridge"},
+		Permissions:  []string{"contents:read"},
+	}
+
+	authProfile := profile.NewAuthorizedProfile(matcher, attrs)
+
+	assert.Equal(t, attrs, authProfile.Attrs)
+}
+
+// TestNewAuthorizedProfile_PipelineProfile creates an authorized profile with pipeline attributes.
+func TestNewAuthorizedProfile_PipelineProfile(t *testing.T) {
+	matcher := profile.ExactMatcher("pipeline_slug", "my-pipeline")
+	attrs := profile.PipelineProfileAttr{}
+
+	authProfile := profile.NewAuthorizedProfile(matcher, attrs)
+
+	assert.Equal(t, attrs, authProfile.Attrs)
+}
+
+// TestAuthorizedProfile_Match_Success verifies Match delegates to underlying matcher on success.
+func TestAuthorizedProfile_Match_Success(t *testing.T) {
+	matcher := profile.ExactMatcher("pipeline_slug", "my-pipeline")
+	attrs := profile.OrganizationProfileAttr{
+		Repositories: []string{"chinmina/chinmina-bridge"},
+		Permissions:  []string{"contents:read"},
+	}
+	authProfile := profile.NewAuthorizedProfile(matcher, attrs)
+
+	lookup := mockClaimLookup{
+		claims: map[string]string{
+			"pipeline_slug": "my-pipeline",
+		},
+	}
+
+	result := authProfile.Match(lookup)
+
+	expected := profile.MatchResult{
+		Matched: true,
+		Matches: []profile.ClaimMatch{
+			{Claim: "pipeline_slug", Value: "my-pipeline"},
+		},
+	}
+	assert.Equal(t, expected, result)
+}
+
+// TestAuthorizedProfile_Match_Failure verifies Match delegates to underlying matcher on failure.
+func TestAuthorizedProfile_Match_Failure(t *testing.T) {
+	tests := []struct {
+		name     string
+		matcher  profile.Matcher
+		lookup   profile.ClaimValueLookup
+		expected profile.MatchResult
+	}{
+		{
+			name:    "claim value mismatch",
+			matcher: profile.ExactMatcher("pipeline_slug", "my-pipeline"),
+			lookup: mockClaimLookup{
+				claims: map[string]string{
+					"pipeline_slug": "other-pipeline",
+				},
+			},
+			expected: profile.MatchResult{
+				Matched: false,
+				Attempt: &profile.MatchAttempt{
+					Claim:       "pipeline_slug",
+					Pattern:     "my-pipeline",
+					ActualValue: "other-pipeline",
+				},
+			},
+		},
+		{
+			name:    "claim not found",
+			matcher: profile.ExactMatcher("pipeline_slug", "my-pipeline"),
+			lookup: mockClaimLookup{
+				claims: map[string]string{},
+			},
+			expected: profile.MatchResult{
+				Matched: false,
+				Attempt: &profile.MatchAttempt{
+					Claim:       "pipeline_slug",
+					Pattern:     "my-pipeline",
+					ActualValue: "",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attrs := profile.OrganizationProfileAttr{
+				Repositories: []string{"chinmina/chinmina-bridge"},
+				Permissions:  []string{"contents:read"},
+			}
+			authProfile := profile.NewAuthorizedProfile(tt.matcher, attrs)
+
+			result := authProfile.Match(tt.lookup)
+
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestAuthorizedProfile_Match_ValidationError verifies Match handles validation errors.
+func TestAuthorizedProfile_Match_ValidationError(t *testing.T) {
+	matcher := profile.ExactMatcher("pipeline_slug", "my-pipeline")
+	attrs := profile.OrganizationProfileAttr{
+		Repositories: []string{"chinmina/chinmina-bridge"},
+		Permissions:  []string{"contents:read"},
+	}
+	authProfile := profile.NewAuthorizedProfile(matcher, attrs)
+
+	// Mock lookup that returns a validation error
+	lookup := mockErrorLookup{
+		err: profile.ClaimValidationError{
+			Claim: "pipeline_slug",
+			Value: "invalid\x00value",
+		},
+	}
+
+	result := authProfile.Match(lookup)
+
+	assert.False(t, result.Matched)
+	assert.NotNil(t, result.Err)
+	var validationErr profile.ClaimValidationError
+	assert.ErrorAs(t, result.Err, &validationErr)
+}
+
+// mockErrorLookup is a ClaimValueLookup that returns an error.
+type mockErrorLookup struct {
+	err error
+}
+
+func (m mockErrorLookup) Lookup(claim string) (string, error) {
+	return "", m.err
+}

--- a/internal/profile/profilestore.go
+++ b/internal/profile/profilestore.go
@@ -1,0 +1,53 @@
+package profile
+
+// ProfileStoreOf provides immutable type-safe storage and retrieval of authorized profiles.
+// The generic parameter T constrains the type of profile attributes stored.
+// Once created, ProfileStoreOf cannot be modified.
+type ProfileStoreOf[T any] struct {
+	profiles        map[string]AuthorizedProfile[T]
+	invalidProfiles map[string]error
+}
+
+// NewProfileStoreOf creates a new immutable ProfileStoreOf instance with the given profiles.
+// Invalid profiles are tracked separately and returned as ProfileUnavailableError on Get().
+// The maps are copied to ensure immutability.
+// Note: Profile attributes of type T are shallow copied. Callers should treat attribute
+// contents (e.g., slices) as immutable after passing them to this function.
+func NewProfileStoreOf[T any](profiles map[string]AuthorizedProfile[T], invalidProfiles map[string]error) ProfileStoreOf[T] {
+	// Copy the profiles map to ensure immutability
+	profilesCopy := make(map[string]AuthorizedProfile[T], len(profiles))
+	for k, v := range profiles {
+		profilesCopy[k] = v
+	}
+
+	// Copy the invalidProfiles map to ensure immutability
+	invalidProfilesCopy := make(map[string]error, len(invalidProfiles))
+	for k, v := range invalidProfiles {
+		invalidProfilesCopy[k] = v
+	}
+
+	return ProfileStoreOf[T]{
+		profiles:        profilesCopy,
+		invalidProfiles: invalidProfilesCopy,
+	}
+}
+
+// Get retrieves an authorized profile by name.
+// Returns ProfileUnavailableError if the profile failed validation.
+// Returns ProfileNotFoundError if the profile does not exist.
+func (ps ProfileStoreOf[T]) Get(name string) (AuthorizedProfile[T], error) {
+	// Check invalid profiles first
+	if err, found := ps.invalidProfiles[name]; found {
+		return AuthorizedProfile[T]{}, ProfileUnavailableError{
+			Name:  name,
+			Cause: err,
+		}
+	}
+
+	profile, found := ps.profiles[name]
+	if !found {
+		return AuthorizedProfile[T]{}, ProfileNotFoundError{Name: name}
+	}
+
+	return profile, nil
+}

--- a/internal/profile/profilestore_test.go
+++ b/internal/profile/profilestore_test.go
@@ -1,0 +1,172 @@
+package profile_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/chinmina/chinmina-bridge/internal/profile"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewProfileStoreOf_OrganizationProfile verifies NewProfileStoreOf creates an immutable store for organization profiles.
+func TestNewProfileStoreOf_OrganizationProfile(t *testing.T) {
+	profiles := map[string]profile.AuthorizedProfile[profile.OrganizationProfileAttr]{
+		"test": profile.NewAuthorizedProfile(
+			profile.ExactMatcher("pipeline_slug", "my-pipeline"),
+			profile.OrganizationProfileAttr{
+				Repositories: []string{"chinmina/chinmina-bridge"},
+				Permissions:  []string{"contents:read"},
+			},
+		),
+	}
+	invalidProfiles := map[string]error{
+		"invalid-profile": errors.New("validation error"),
+	}
+
+	store := profile.NewProfileStoreOf(profiles, invalidProfiles)
+
+	// Verify the store was created (non-nil check not needed for value type)
+	_, err := store.Get("test")
+	assert.NoError(t, err)
+}
+
+// TestNewProfileStoreOf_PipelineProfile verifies NewProfileStoreOf creates an immutable store for pipeline profiles.
+func TestNewProfileStoreOf_PipelineProfile(t *testing.T) {
+	profiles := map[string]profile.AuthorizedProfile[profile.PipelineProfileAttr]{
+		"test": profile.NewAuthorizedProfile(
+			profile.ExactMatcher("pipeline_slug", "my-pipeline"),
+			profile.PipelineProfileAttr{},
+		),
+	}
+	invalidProfiles := map[string]error{}
+
+	store := profile.NewProfileStoreOf(profiles, invalidProfiles)
+
+	// Verify the store was created
+	_, err := store.Get("test")
+	assert.NoError(t, err)
+}
+
+// TestProfileStoreOf_Get_Success verifies successful retrieval of a profile.
+func TestProfileStoreOf_Get_Success(t *testing.T) {
+	matcher := profile.ExactMatcher("pipeline_slug", "my-pipeline")
+	attrs := profile.OrganizationProfileAttr{
+		Repositories: []string{"chinmina/chinmina-bridge"},
+		Permissions:  []string{"contents:read"},
+	}
+	authProfile := profile.NewAuthorizedProfile(matcher, attrs)
+
+	profiles := map[string]profile.AuthorizedProfile[profile.OrganizationProfileAttr]{
+		"test-profile": authProfile,
+	}
+	store := profile.NewProfileStoreOf(profiles, map[string]error{})
+
+	// Retrieve the profile
+	retrieved, err := store.Get("test-profile")
+	require.NoError(t, err)
+	assert.Equal(t, attrs, retrieved.Attrs)
+}
+
+// TestProfileStoreOf_Get_NotFound verifies ProfileNotFoundError is returned for missing profiles.
+func TestProfileStoreOf_Get_NotFound(t *testing.T) {
+	store := profile.NewProfileStoreOf(
+		map[string]profile.AuthorizedProfile[profile.OrganizationProfileAttr]{},
+		map[string]error{},
+	)
+
+	// Try to get a non-existent profile
+	_, err := store.Get("nonexistent")
+
+	require.Error(t, err)
+	var notFoundErr profile.ProfileNotFoundError
+	require.ErrorAs(t, err, &notFoundErr)
+	assert.Equal(t, "nonexistent", notFoundErr.Name)
+}
+
+// TestProfileStoreOf_Get_InvalidProfile verifies ProfileUnavailableError is returned for invalid profiles.
+func TestProfileStoreOf_Get_InvalidProfile(t *testing.T) {
+	validationErr := errors.New("invalid selector: missing required field")
+	invalidProfiles := map[string]error{
+		"invalid-profile": validationErr,
+	}
+	store := profile.NewProfileStoreOf(
+		map[string]profile.AuthorizedProfile[profile.OrganizationProfileAttr]{},
+		invalidProfiles,
+	)
+
+	// Try to get an invalid profile
+	_, err := store.Get("invalid-profile")
+
+	require.Error(t, err)
+	var unavailableErr profile.ProfileUnavailableError
+	require.ErrorAs(t, err, &unavailableErr)
+	assert.Equal(t, "invalid-profile", unavailableErr.Name)
+	assert.ErrorIs(t, unavailableErr, validationErr)
+}
+
+// TestProfileStoreOf_Get_InvalidProfileTakesPrecedence verifies that invalid profiles are checked before valid profiles.
+func TestProfileStoreOf_Get_InvalidProfileTakesPrecedence(t *testing.T) {
+	validationErr := errors.New("profile failed validation")
+
+	// Create a profile with the same name in both maps
+	matcher := profile.ExactMatcher("pipeline_slug", "my-pipeline")
+	attrs := profile.OrganizationProfileAttr{
+		Repositories: []string{"chinmina/chinmina-bridge"},
+		Permissions:  []string{"contents:read"},
+	}
+	authProfile := profile.NewAuthorizedProfile(matcher, attrs)
+
+	profiles := map[string]profile.AuthorizedProfile[profile.OrganizationProfileAttr]{
+		"test-profile": authProfile,
+	}
+	invalidProfiles := map[string]error{
+		"test-profile": validationErr,
+	}
+
+	store := profile.NewProfileStoreOf(profiles, invalidProfiles)
+
+	// Invalid should take precedence
+	_, err := store.Get("test-profile")
+
+	require.Error(t, err)
+	var unavailableErr profile.ProfileUnavailableError
+	require.ErrorAs(t, err, &unavailableErr)
+	assert.Equal(t, "test-profile", unavailableErr.Name)
+	assert.ErrorIs(t, unavailableErr, validationErr)
+}
+
+// TestProfileStoreOf_Immutable verifies that ProfileStoreOf is immutable after creation.
+func TestProfileStoreOf_Immutable(t *testing.T) {
+	matcher := profile.ExactMatcher("pipeline_slug", "my-pipeline")
+	attrs := profile.OrganizationProfileAttr{
+		Repositories: []string{"chinmina/chinmina-bridge"},
+		Permissions:  []string{"contents:read"},
+	}
+	authProfile := profile.NewAuthorizedProfile(matcher, attrs)
+
+	profiles := map[string]profile.AuthorizedProfile[profile.OrganizationProfileAttr]{
+		"test-profile": authProfile,
+	}
+	store := profile.NewProfileStoreOf(profiles, map[string]error{})
+
+	// Retrieve the profile
+	retrieved, err := store.Get("test-profile")
+	require.NoError(t, err)
+	assert.Equal(t, "chinmina/chinmina-bridge", retrieved.Attrs.Repositories[0])
+
+	// Modify the source map (should not affect the store since it's immutable)
+	newMatcher := profile.ExactMatcher("pipeline_slug", "other-pipeline")
+	newAttrs := profile.OrganizationProfileAttr{
+		Repositories: []string{"chinmina/other-repo"},
+		Permissions:  []string{"packages:write"},
+	}
+	newAuthProfile := profile.NewAuthorizedProfile(newMatcher, newAttrs)
+	profiles["test-profile"] = newAuthProfile
+
+	// The store should still return the original profile
+	retrieved2, err := store.Get("test-profile")
+	require.NoError(t, err)
+	assert.Equal(t, "chinmina/chinmina-bridge", retrieved2.Attrs.Repositories[0])
+	assert.NotEqual(t, "chinmina/other-repo", retrieved2.Attrs.Repositories[0])
+}


### PR DESCRIPTION
## Purpose

Adds the basis type infrastructure for a runtime profile model that will be used in place of the current structures that are closely coupled to the configuration format.

The type design is centred on their usage patterns in client code instead, leading to a less complicated API, and allowing for pipeline profiles in a more straightforward manner.

## Context

Part of the pipeline profiles implementation initiative documented in `pipeline-profiles.md`. Pipeline profiles work like organization profiles but grant permissions only for the pipeline's repository.

- Depends on: PR #160 (store extraction completed)
- Enables: Future bridge method implementation and complete separation between stored configuration and the runtime type model representing the current configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added typed profile wrapper and attributes for organization and pipeline profiles, with a Match method for claim-based matching.
  * Added a generic, immutable profile store with validation, error reporting, and precedence rules for invalid entries.

* **Tests**
  * Added comprehensive tests covering profile creation, matching success/failure paths, store retrieval, not-found/invalid cases, precedence and immutability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->