### PR TITLE
fix: organization profiles marked for any repository aren't working

### DIFF
--- a/internal/profile/profiles.go
+++ b/internal/profile/profiles.go
@@ -6,7 +6,8 @@ import "slices"
 
 // OrganizationProfileAttr contains the attributes for an organization profile.
 // Slice fields are expected to be treated as immutable after construction.
-// Callers should not modify slice contents after passing to NewAuthorizedProfile or NewProfileStoreOf.
+// Callers should not modify slice contents after passing to
+// NewAuthorizedProfile or NewProfileStoreOf.
 type OrganizationProfileAttr struct {
 	Repositories []string
 	Permissions  []string
@@ -15,11 +16,24 @@ type OrganizationProfileAttr struct {
 // HasRepository checks if the given repository is included in the profile's
 // repositories. Supports wildcard "*" to match any repository.
 func (attr OrganizationProfileAttr) HasRepository(repo string) bool {
-	if len(attr.Repositories) == 1 && attr.Repositories[0] == "*" {
-		return true
-	}
+	return attr.allowAllRepositories() ||
+		slices.Contains(attr.Repositories, repo)
+}
 
-	return slices.Contains(attr.Repositories, repo)
+// GetRepositories returns the list of repositories allowed by the profile.
+// If the profile allows all repositories, it returns nil to signify this.
+func (attr OrganizationProfileAttr) GetRepositories() []string {
+	if attr.allowAllRepositories() {
+		return nil // nil means all repositories
+	}
+	return attr.Repositories
+}
+
+// allowAllRepositories returns true if the profile allows access to all
+// repositories accessible to the Chinmina installation. This is signified by
+// the single "*" entry.
+func (attr OrganizationProfileAttr) allowAllRepositories() bool {
+	return len(attr.Repositories) == 1 && attr.Repositories[0] == "*"
 }
 
 // PipelineProfileAttr is a placeholder for future pipeline profile attributes.

--- a/internal/profile/profiles_test.go
+++ b/internal/profile/profiles_test.go
@@ -73,6 +73,49 @@ func TestOrganizationProfileAttr_HasRepository_NoMatch(t *testing.T) {
 	}
 }
 
+// TestOrganizationProfileAttr_GetRepositories tests the GetRepositories method
+func TestOrganizationProfileAttr_GetRepositories_SpecificRepos(t *testing.T) {
+	tests := []struct {
+		name         string
+		repositories []string
+		expected     []string
+	}{
+		{
+			name:         "single repository",
+			repositories: []string{"acme/repo1"},
+			expected:     []string{"acme/repo1"},
+		},
+		{
+			name:         "multiple repositories",
+			repositories: []string{"acme/repo1", "acme/repo2", "other/repo3"},
+			expected:     []string{"acme/repo1", "acme/repo2", "other/repo3"},
+		},
+		{
+			name:         "empty list",
+			repositories: []string{},
+			expected:     []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attr := OrganizationProfileAttr{
+				Repositories: tt.repositories,
+			}
+			assert.Equal(t, tt.expected, attr.GetRepositories())
+		})
+	}
+}
+
+func TestOrganizationProfileAttr_GetRepositories_Wildcard(t *testing.T) {
+	attr := OrganizationProfileAttr{
+		Repositories: []string{"*"},
+	}
+
+	// nil indicates all repositories
+	assert.Nil(t, attr.GetRepositories())
+}
+
 // TestAuthorizedProfile_Match tests the Match method behavior
 func TestAuthorizedProfile_Match_Success(t *testing.T) {
 	matcher := ExactMatcher("pipeline_slug", "silk-prod")

--- a/internal/vendor/orgvendor.go
+++ b/internal/vendor/orgvendor.go
@@ -74,7 +74,8 @@ func NewOrgVendor(profileStore *profile.ProfileStore, tokenVendor TokenVendor) P
 		}
 
 		// Use the GitHub API to vend a token for the repository
-		token, expiry, err := tokenVendor(ctx, authProfile.Attrs.Repositories, authProfile.Attrs.Permissions)
+		repositories := authProfile.Attrs.GetRepositories()
+		token, expiry, err := tokenVendor(ctx, repositories, authProfile.Attrs.Permissions)
 		if err != nil {
 			return NewVendorFailed(fmt.Errorf("could not issue token for profile %s: %w", ref, err))
 		}
@@ -84,7 +85,7 @@ func NewOrgVendor(profileStore *profile.ProfileStore, tokenVendor TokenVendor) P
 		return NewVendorSuccess(ProfileToken{
 			OrganizationSlug:    ref.Organization,
 			VendedRepositoryURL: requestedRepoURL,
-			Repositories:        authProfile.Attrs.Repositories,
+			Repositories:        repositories,
 			Permissions:         authProfile.Attrs.Permissions,
 			Profile:             ref.ShortString(),
 			Token:               token,


### PR DESCRIPTION
## Purpose

Fixes token vending failures for organization profiles configured to grant access to all repositories. When an organization profile uses the wildcard marker (`repositories: ["*"]`), the system now correctly indicates unrestricted repository access to the GitHub token vendor instead of treating the literal `"*"` string as a repository name, which caused vending failures.

## Context

This bug prevented pipelines from using wildcard-configured organization profiles. The token vendor would receive `["*"]` as a repository list and attempt to create tokens for a repository named `"*"`, which doesn't exist in GitHub's API. The fix introduces dedicated methods to detect wildcard configurations and translate them to `nil` (indicating unrestricted access) before passing to the token vendor.

The implementation:
- Adds `allowAllRepositories()` to check for wildcard marker
- Adds `GetRepositories()` to return `nil` when wildcard is detected
- Updates organization vendor to use `GetRepositories()` before token creation
- Maintains existing immutability guarantees while providing clean abstraction

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Profiles support wildcard repository specification ("*") to grant access to all repositories.
  * Profile statistics method reporting counts, digest info, and location metadata.

* **Changes**
  * Profile creation now captures location information.
  * Repository membership checks now correctly treat "*" as "all repos" when issuing tokens and responses.

* **Tests**
  * Added coverage for wildcard repository behavior and token vending with wildcard repositories.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->