### PR TITLE
Strengthen organization profile repository validation

### DIFF
--- a/internal/profile/profiles_test.go
+++ b/internal/profile/profiles_test.go
@@ -18,8 +18,8 @@ func TestOrganizationProfileAttr_HasRepository_Match(t *testing.T) {
 	}{
 		{
 			name:         "exact match in list",
-			repositories: []string{"acme/repo1", "acme/repo2"},
-			repo:         "acme/repo1",
+			repositories: []string{"repo1", "repo2"},
+			repo:         "repo1",
 			expected:     true,
 		},
 		{
@@ -48,18 +48,18 @@ func TestOrganizationProfileAttr_HasRepository_NoMatch(t *testing.T) {
 	}{
 		{
 			name:         "partial match fails",
-			repositories: []string{"acme/repo"},
+			repositories: []string{"repo"},
 			repo:         "acme",
 		},
 		{
 			name:         "over-match fails",
-			repositories: []string{"acme/repo"},
-			repo:         "acme/repo-extra",
+			repositories: []string{"repo"},
+			repo:         "repo-extra",
 		},
 		{
 			name:         "empty list fails",
 			repositories: []string{},
-			repo:         "acme/repo",
+			repo:         "repo",
 		},
 	}
 
@@ -82,13 +82,13 @@ func TestOrganizationProfileAttr_GetRepositories_SpecificRepos(t *testing.T) {
 	}{
 		{
 			name:         "single repository",
-			repositories: []string{"acme/repo1"},
-			expected:     []string{"acme/repo1"},
+			repositories: []string{"repo1"},
+			expected:     []string{"repo1"},
 		},
 		{
 			name:         "multiple repositories",
-			repositories: []string{"acme/repo1", "acme/repo2", "other/repo3"},
-			expected:     []string{"acme/repo1", "acme/repo2", "other/repo3"},
+			repositories: []string{"repo1", "repo2", "repo3"},
+			expected:     []string{"repo1", "repo2", "repo3"},
 		},
 		{
 			name:         "empty list",
@@ -120,7 +120,7 @@ func TestOrganizationProfileAttr_GetRepositories_Wildcard(t *testing.T) {
 func TestAuthorizedProfile_Match_Success(t *testing.T) {
 	matcher := ExactMatcher("pipeline_slug", "silk-prod")
 	attrs := OrganizationProfileAttr{
-		Repositories: []string{"acme/silk"},
+		Repositories: []string{"silk"},
 		Permissions:  []string{"contents:read"},
 	}
 	profile := NewAuthorizedProfile(matcher, attrs)
@@ -139,7 +139,7 @@ func TestAuthorizedProfile_Match_Success(t *testing.T) {
 func TestAuthorizedProfile_Match_ClaimValueMismatch(t *testing.T) {
 	matcher := ExactMatcher("pipeline_slug", "silk-prod")
 	attrs := OrganizationProfileAttr{
-		Repositories: []string{"acme/silk"},
+		Repositories: []string{"silk"},
 	}
 	profile := NewAuthorizedProfile(matcher, attrs)
 
@@ -160,7 +160,7 @@ func TestAuthorizedProfile_Match_ClaimValueMismatch(t *testing.T) {
 func TestAuthorizedProfile_Match_ClaimNotFound(t *testing.T) {
 	matcher := ExactMatcher("pipeline_slug", "silk-prod")
 	attrs := OrganizationProfileAttr{
-		Repositories: []string{"acme/silk"},
+		Repositories: []string{"silk"},
 	}
 	profile := NewAuthorizedProfile(matcher, attrs)
 
@@ -181,7 +181,7 @@ func TestAuthorizedProfile_Match_ClaimNotFound(t *testing.T) {
 func TestAuthorizedProfile_Match_ValidationError(t *testing.T) {
 	matcher := ExactMatcher("pipeline_slug", "silk-prod")
 	attrs := OrganizationProfileAttr{
-		Repositories: []string{"acme/silk"},
+		Repositories: []string{"silk"},
 	}
 	profile := NewAuthorizedProfile(matcher, attrs)
 
@@ -205,7 +205,7 @@ func TestProfileStoreOf_NewAndGet_OrganizationProfile(t *testing.T) {
 	matcher := ExactMatcher("pipeline_slug", "silk-prod")
 	profiles := map[string]AuthorizedProfile[OrganizationProfileAttr]{
 		"test-profile": NewAuthorizedProfile(matcher, OrganizationProfileAttr{
-			Repositories: []string{"acme/silk"},
+			Repositories: []string{"silk"},
 			Permissions:  []string{"contents:read"},
 		}),
 	}
@@ -214,7 +214,7 @@ func TestProfileStoreOf_NewAndGet_OrganizationProfile(t *testing.T) {
 
 	profile, err := store.Get("test-profile")
 	require.NoError(t, err)
-	assert.Equal(t, []string{"acme/silk"}, profile.Attrs.Repositories)
+	assert.Equal(t, []string{"silk"}, profile.Attrs.Repositories)
 	assert.Equal(t, []string{"contents:read"}, profile.Attrs.Permissions)
 }
 
@@ -262,7 +262,7 @@ func TestProfileStoreOf_Immutability(t *testing.T) {
 	matcher := ExactMatcher("pipeline_slug", "silk-prod")
 	sourceProfiles := map[string]AuthorizedProfile[OrganizationProfileAttr]{
 		"test-profile": NewAuthorizedProfile(matcher, OrganizationProfileAttr{
-			Repositories: []string{"acme/silk"},
+			Repositories: []string{"silk"},
 			Permissions:  []string{"contents:read"},
 		}),
 	}
@@ -288,7 +288,7 @@ func TestProfiles_NewProfiles(t *testing.T) {
 	orgProfiles := NewProfileStoreOf(
 		map[string]AuthorizedProfile[OrganizationProfileAttr]{
 			"test-profile": NewAuthorizedProfile(matcher, OrganizationProfileAttr{
-				Repositories: []string{"acme/silk"},
+				Repositories: []string{"silk"},
 			}),
 		},
 		nil,
@@ -307,7 +307,7 @@ func TestProfiles_GetOrgProfile_Success(t *testing.T) {
 	orgProfiles := NewProfileStoreOf(
 		map[string]AuthorizedProfile[OrganizationProfileAttr]{
 			"test-profile": NewAuthorizedProfile(matcher, OrganizationProfileAttr{
-				Repositories: []string{"acme/silk"},
+				Repositories: []string{"silk"},
 				Permissions:  []string{"contents:read"},
 			}),
 		},
@@ -319,7 +319,7 @@ func TestProfiles_GetOrgProfile_Success(t *testing.T) {
 
 	profile, err := profiles.GetOrgProfile("test-profile")
 	require.NoError(t, err)
-	assert.Equal(t, []string{"acme/silk"}, profile.Attrs.Repositories)
+	assert.Equal(t, []string{"silk"}, profile.Attrs.Repositories)
 	assert.Equal(t, []string{"contents:read"}, profile.Attrs.Permissions)
 }
 
@@ -361,7 +361,7 @@ func TestProfiles_Methods_Consistency(t *testing.T) {
 	orgProfiles := NewProfileStoreOf(
 		map[string]AuthorizedProfile[OrganizationProfileAttr]{
 			"valid-profile": NewAuthorizedProfile(matcher, OrganizationProfileAttr{
-				Repositories: []string{"acme/test"},
+				Repositories: []string{"test"},
 				Permissions:  []string{"contents:read"},
 			}),
 		},
@@ -386,7 +386,7 @@ func TestProfiles_Methods_Consistency(t *testing.T) {
 	// GetOrgProfile should work for valid profile
 	validProfile, err := profiles.GetOrgProfile("valid-profile")
 	require.NoError(t, err)
-	assert.Equal(t, []string{"acme/test"}, validProfile.Attrs.Repositories)
+	assert.Equal(t, []string{"test"}, validProfile.Attrs.Repositories)
 
 	// GetOrgProfile should return error for invalid profile
 	_, err = profiles.GetOrgProfile("invalid-profile")
@@ -411,11 +411,11 @@ func TestProfiles_Stats(t *testing.T) {
 	orgProfiles := NewProfileStoreOf[OrganizationProfileAttr](
 		map[string]AuthorizedProfile[OrganizationProfileAttr]{
 			"profile-one": NewAuthorizedProfile(matcher, OrganizationProfileAttr{
-				Repositories: []string{"acme/repo1"},
+				Repositories: []string{"repo1"},
 				Permissions:  []string{"contents:read"},
 			}),
 			"profile-two": NewAuthorizedProfile(matcher, OrganizationProfileAttr{
-				Repositories: []string{"acme/repo2"},
+				Repositories: []string{"repo2"},
 				Permissions:  []string{"contents:write"},
 			}),
 		},
@@ -460,7 +460,7 @@ func TestProfiles_Stats(t *testing.T) {
 func TestNewAuthorizedProfile(t *testing.T) {
 	matcher := ExactMatcher("pipeline_slug", "silk-prod")
 	attrs := OrganizationProfileAttr{
-		Repositories: []string{"acme/silk"},
+		Repositories: []string{"silk"},
 		Permissions:  []string{"contents:read"},
 	}
 
@@ -481,7 +481,7 @@ func TestProfileStoreOf_Mixed(t *testing.T) {
 	matcher := ExactMatcher("pipeline_slug", "silk-prod")
 	validProfiles := map[string]AuthorizedProfile[OrganizationProfileAttr]{
 		"valid-profile": NewAuthorizedProfile(matcher, OrganizationProfileAttr{
-			Repositories: []string{"acme/silk"},
+			Repositories: []string{"silk"},
 		}),
 	}
 	invalidProfiles := map[string]error{
@@ -493,7 +493,7 @@ func TestProfileStoreOf_Mixed(t *testing.T) {
 	// Valid profile should be accessible
 	profile, err := store.Get("valid-profile")
 	require.NoError(t, err)
-	assert.Equal(t, []string{"acme/silk"}, profile.Attrs.Repositories)
+	assert.Equal(t, []string{"silk"}, profile.Attrs.Repositories)
 
 	// Invalid profile should return ProfileUnavailableError
 	_, err = store.Get("invalid-profile")

--- a/internal/profile/store_test.go
+++ b/internal/profile/store_test.go
@@ -34,7 +34,7 @@ func TestFetchOrganizationProfile_Success(t *testing.T) {
 	validYAML := `organization:
   profiles:
     - name: "test-profile"
-      repositories: ["acme/silk"]
+      repositories: ["silk"]
       permissions: ["contents:read"]
 
 pipeline:
@@ -56,14 +56,14 @@ pipeline:
 	// Verify profile can be accessed
 	profile, err := profiles.GetOrgProfile("test-profile")
 	require.NoError(t, err)
-	assert.Equal(t, []string{"acme/silk"}, profile.Attrs.Repositories)
+	assert.Equal(t, []string{"silk"}, profile.Attrs.Repositories)
 }
 
 func TestFetchOrganizationProfile_ReturnsCorrectDigest(t *testing.T) {
 	validYAML := `organization:
   profiles:
     - name: "test-profile"
-      repositories: ["acme/test"]
+      repositories: ["test"]
       permissions: ["contents:read"]
 `
 
@@ -89,7 +89,7 @@ func TestFetchOrganizationProfile_CanBeCalledMultipleTimes(t *testing.T) {
 	validYAML := `organization:
   profiles:
     - name: "test-profile"
-      repositories: ["acme/silk"]
+      repositories: ["silk"]
       permissions: ["contents:read"]
 `
 
@@ -121,7 +121,7 @@ func TestProfileStore_GetOrganizationProfile_Success(t *testing.T) {
 	validYAML := `organization:
   profiles:
     - name: "test-profile"
-      repositories: ["acme/silk"]
+      repositories: ["silk"]
       permissions: ["contents:read", "pull_requests:write"]
 `
 
@@ -142,7 +142,7 @@ func TestProfileStore_GetOrganizationProfile_Success(t *testing.T) {
 	// Retrieve profile
 	profile, err := store.GetOrganizationProfile("test-profile")
 	require.NoError(t, err)
-	assert.Equal(t, []string{"acme/silk"}, profile.Attrs.Repositories)
+	assert.Equal(t, []string{"silk"}, profile.Attrs.Repositories)
 	assert.Equal(t, []string{"contents:read", "pull_requests:write"}, profile.Attrs.Permissions)
 }
 
@@ -150,7 +150,7 @@ func TestProfileStore_GetOrganizationProfile_NotFound(t *testing.T) {
 	validYAML := `organization:
   profiles:
     - name: "test-profile"
-      repositories: ["acme/silk"]
+      repositories: ["silk"]
       permissions: ["contents:read"]
 `
 
@@ -208,7 +208,7 @@ func TestProfileStore_GetPipelineProfile_Success(t *testing.T) {
 	validYAML := `organization:
   profiles:
     - name: "test-profile"
-      repositories: ["acme/silk"]
+      repositories: ["silk"]
       permissions: ["contents:read"]
 
 pipeline:
@@ -248,7 +248,7 @@ func TestProfileStore_GetPipelineProfile_NotFound(t *testing.T) {
 	validYAML := `organization:
   profiles:
     - name: "test-profile"
-      repositories: ["acme/silk"]
+      repositories: ["silk"]
       permissions: ["contents:read"]
 
 pipeline:
@@ -282,7 +282,7 @@ func TestProfileStore_Concurrency(t *testing.T) {
 	validYAML := `organization:
   profiles:
     - name: "test-profile"
-      repositories: ["acme/silk"]
+      repositories: ["silk"]
       permissions: ["contents:read"]
 `
 
@@ -330,14 +330,14 @@ func TestProfileStore_Update_MultipleTimes(t *testing.T) {
 	yaml1 := `organization:
   profiles:
     - name: "profile-v1"
-      repositories: ["acme/v1"]
+      repositories: ["v1"]
       permissions: ["contents:read"]
 `
 
 	yaml2 := `organization:
   profiles:
     - name: "profile-v2"
-      repositories: ["acme/v2"]
+      repositories: ["v2"]
       permissions: ["contents:write"]
 `
 
@@ -357,7 +357,7 @@ func TestProfileStore_Update_MultipleTimes(t *testing.T) {
 
 	profile1, err := store.GetOrganizationProfile("profile-v1")
 	require.NoError(t, err)
-	assert.Equal(t, []string{"acme/v1"}, profile1.Attrs.Repositories)
+	assert.Equal(t, []string{"v1"}, profile1.Attrs.Repositories)
 
 	// Update with second version
 	profiles2, err := FetchOrganizationProfile(context.Background(), "acme:test:v2.yaml", gh)
@@ -371,14 +371,14 @@ func TestProfileStore_Update_MultipleTimes(t *testing.T) {
 	// New profile should be accessible
 	profile2, err := store.GetOrganizationProfile("profile-v2")
 	require.NoError(t, err)
-	assert.Equal(t, []string{"acme/v2"}, profile2.Attrs.Repositories)
+	assert.Equal(t, []string{"v2"}, profile2.Attrs.Repositories)
 }
 
 func TestProfileStore_Update_NoChange(t *testing.T) {
 	yaml1 := `organization:
   profiles:
     - name: "profile-v1"
-      repositories: ["acme/v1"]
+      repositories: ["v1"]
       permissions: ["contents:read"]
 `
 
@@ -402,7 +402,7 @@ func TestProfileStore_Update_NoChange(t *testing.T) {
 	// Verify profile is still accessible
 	profile, err := store.GetOrganizationProfile("profile-v1")
 	require.NoError(t, err)
-	assert.Equal(t, []string{"acme/v1"}, profile.Attrs.Repositories)
+	assert.Equal(t, []string{"v1"}, profile.Attrs.Repositories)
 }
 
 func TestFetchOrganizationProfile_InvalidYAML(t *testing.T) {
@@ -424,14 +424,14 @@ func TestLoad_EndToEnd(t *testing.T) {
       match:
         - claim: pipeline_slug
           value: "silk-prod"
-      repositories: ["acme/silk"]
+      repositories: ["silk"]
       permissions: ["contents:write"]
 
     - name: "staging-profile"
       match:
         - claim: pipeline_slug
           valuePattern: ".*-staging"
-      repositories: ["acme/silk", "acme/cotton"]
+      repositories: ["silk", "cotton"]
       permissions: ["contents:read"]
 
 pipeline:
@@ -455,7 +455,7 @@ pipeline:
 	// Verify prod profile
 	prodProfile, err := profiles.GetOrgProfile("prod-profile")
 	require.NoError(t, err)
-	assert.Equal(t, []string{"acme/silk"}, prodProfile.Attrs.Repositories)
+	assert.Equal(t, []string{"silk"}, prodProfile.Attrs.Repositories)
 	assert.Equal(t, []string{"contents:write"}, prodProfile.Attrs.Permissions)
 
 	// Test prod profile matching
@@ -466,7 +466,7 @@ pipeline:
 	// Verify staging profile
 	stagingProfile, err := profiles.GetOrgProfile("staging-profile")
 	require.NoError(t, err)
-	assert.Equal(t, []string{"acme/silk", "acme/cotton"}, stagingProfile.Attrs.Repositories)
+	assert.Equal(t, []string{"silk", "cotton"}, stagingProfile.Attrs.Repositories)
 
 	// Test staging profile matching with regex
 	claims = mapClaimLookup{"pipeline_slug": "silk-staging"}

--- a/internal/profile/testdata/profile/profile_with_duplicate_names.yaml
+++ b/internal/profile/testdata/profile/profile_with_duplicate_names.yaml
@@ -4,14 +4,14 @@ organization:
       match:
         - claim: pipeline_slug
           value: "silk-prod"
-      repositories: ["acme/silk"]
+      repositories: ["silk"]
       permissions: ["contents:write"]
 
     - name: "staging"
       match:
         - claim: pipeline_slug
           value: "silk-staging"
-      repositories: ["acme/silk"]
+      repositories: ["silk"]
       permissions: ["contents:write"]
 
     # Duplicate name - should be marked as invalid
@@ -19,5 +19,5 @@ organization:
       match:
         - claim: pipeline_slug
           value: "cotton-prod"
-      repositories: ["acme/cotton"]
+      repositories: ["cotton"]
       permissions: ["contents:read"]

--- a/internal/profile/testdata/profile/profile_with_empty_lists.yaml
+++ b/internal/profile/testdata/profile/profile_with_empty_lists.yaml
@@ -5,7 +5,7 @@ organization:
       match:
         - claim: pipeline_slug
           value: "test-pipeline"
-      repositories: ["acme/test"]
+      repositories: ["test"]
       permissions: ["contents:read"]
 
     # Invalid - empty repositories
@@ -21,7 +21,7 @@ organization:
       match:
         - claim: pipeline_slug
           value: "test-pipeline"
-      repositories: ["acme/test"]
+      repositories: ["test"]
       permissions: []
 
     # Invalid - both empty

--- a/internal/profile/testdata/profile/profile_with_match_rules.yaml
+++ b/internal/profile/testdata/profile/profile_with_match_rules.yaml
@@ -5,7 +5,7 @@ organization:
       match:
         - claim: pipeline_slug
           value: "silk-prod"
-      repositories: ["acme/silk"]
+      repositories: ["silk"]
       permissions: ["contents:write"]
 
     # Profile with regex pattern match
@@ -13,7 +13,7 @@ organization:
       match:
         - claim: pipeline_slug
           valuePattern: "(silk|cotton)-(staging|stg)"
-      repositories: ["acme/silk", "acme/cotton"]
+      repositories: ["silk", "cotton"]
       permissions: ["contents:write"]
 
     # Profile with multiple match rules (AND logic)
@@ -23,11 +23,11 @@ organization:
           valuePattern: "silk-.*"
         - claim: build_branch
           value: "main"
-      repositories: ["acme/silk"]
+      repositories: ["silk"]
       permissions: ["contents:write"]
 
     # Profile with no match rules (available to all)
     - name: "shared-utilities-read"
       match: []
-      repositories: ["acme/shared-utilities"]
+      repositories: ["shared-utilities"]
       permissions: ["contents:read"]

--- a/internal/profile/testdata/profile/profile_with_mixed_validation.yaml
+++ b/internal/profile/testdata/profile/profile_with_mixed_validation.yaml
@@ -5,7 +5,7 @@ organization:
       match:
         - claim: pipeline_slug
           value: "silk-prod"
-      repositories: ["acme/silk"]
+      repositories: ["silk"]
       permissions: ["contents:write"]
 
     # Invalid profile - both value and valuePattern specified
@@ -14,7 +14,7 @@ organization:
         - claim: pipeline_slug
           value: "silk-prod"
           valuePattern: "silk-.*"
-      repositories: ["acme/silk"]
+      repositories: ["silk"]
       permissions: ["contents:write"]
 
     # Valid profile with regex
@@ -22,7 +22,7 @@ organization:
       match:
         - claim: pipeline_slug
           valuePattern: "(silk|cotton)-(staging|stg)"
-      repositories: ["acme/silk", "acme/cotton"]
+      repositories: ["silk", "cotton"]
       permissions: ["contents:write"]
 
     # Invalid profile - disallowed claim
@@ -30,13 +30,13 @@ organization:
       match:
         - claim: not_allowed_claim
           value: "test"
-      repositories: ["acme/test"]
+      repositories: ["test"]
       permissions: ["contents:read"]
 
     # Valid profile with no match rules
     - name: "valid-no-match"
       match: []
-      repositories: ["acme/shared"]
+      repositories: ["shared"]
       permissions: ["contents:read"]
 
     # Invalid profile - invalid regex pattern
@@ -44,5 +44,5 @@ organization:
       match:
         - claim: pipeline_slug
           valuePattern: "(?P<invalid)"
-      repositories: ["acme/test"]
+      repositories: ["test"]
       permissions: ["contents:read"]

--- a/main.go
+++ b/main.go
@@ -146,7 +146,7 @@ func launchServer() error {
 	server := &http.Server{
 		Addr:              fmt.Sprintf(":%d", cfg.Server.Port),
 		Handler:           handler,
-		MaxHeaderBytes:    20 << 10,      // 20 KB
+		MaxHeaderBytes:    20 << 10,         // 20 KB
 		ReadHeaderTimeout: 20 * time.Second, // Prevent Slowloris attacks
 	}
 


### PR DESCRIPTION
## Purpose

Prevents runtime token vending failures by validating organization profile repository configurations at compile time. Invalid repository formats (such as including owner prefixes like "owner/repo") now trigger clear validation errors during profile compilation rather than causing cryptic failures when tokens are requested in production.

This strengthens the validation boundary, ensuring misconfigurations are caught immediately when profiles are loaded rather than discovered later during pipeline execution.

## Context

Organization profile repositories must follow specific format rules:
- Wildcard `*` must be the only entry if present (cannot mix with specific repo names)
- Repository names must not contain `/` character (no owner prefix allowed)

These constraints are required for the token vending system to correctly match repositories. Previously, invalid configurations would pass validation but fail at runtime with unclear error messages.

Changes include:
- New `validateRepositories()` function in `internal/profile/compilation.go`
- Test coverage for validation rules in `internal/profile/compilation_test.go`
- Updated all existing tests and examples to use valid repository name format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced repository validation to enforce stricter formatting rules: wildcard patterns cannot be combined with other repositories, and owner prefixes are no longer supported in repository identifiers.

* **Chores**
  * Simplified repository identifier format for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->