### PR TITLE
chore: update Chinmina plugins to demonstrate simplified agent configuration

### DIFF
--- a/agent/hooks/environment
+++ b/agent/hooks/environment
@@ -16,16 +16,15 @@ TMPDIR=$(mktemp -d)
 export TMPDIR
 echo "Using temp dir: ${TMPDIR}"
 
-BUILDKITE_PLUGIN_CHINMINA_GIT_CREDENTIALS_CHINMINA_URL="http://chinmina-bridge" \
-BUILDKITE_PLUGIN_CHINMINA_GIT_CREDENTIALS_AUDIENCE="github-app-auth:chinmina" \
-BUILDKITE_PLUGIN_CHINMINA_GIT_CREDENTIALS_PROFILES_0="repo:default" \
+export CHINMINA_DEFAULT_URL="http://chinmina-bridge"
+export CHINMINA_DEFAULT_AUDIENCE="github-app-auth:chinmina"
+
+BUILDKITE_PLUGIN_CHINMINA_GIT_CREDENTIALS_PROFILES_0="pipeline:default" \
 BUILDKITE_PLUGIN_CHINMINA_GIT_CREDENTIALS_PROFILES_1="org:buildkite-plugin-testing" \
     source /buildkite/plugins/chinmina-git-credentials-buildkite-plugin/hooks/environment
 
 # References the local instance of chinmina service
-BUILDKITE_PLUGIN_CHINMINA_TOKEN_CHINMINA_URL="http://chinmina-bridge" \
-BUILDKITE_PLUGIN_CHINMINA_TOKEN_AUDIENCE="github-app-auth:chinmina" \
-    source /buildkite/plugins/chinmina-token-buildkite-plugin/hooks/environment
+source /buildkite/plugins/chinmina-token-buildkite-plugin/hooks/environment
 
 # optional: it is possible to change the git URL, converting it from SSH to
 # HTTPS if that is desired.

--- a/agent/startup/bootstrap-git-auth
+++ b/agent/startup/bootstrap-git-auth
@@ -5,7 +5,7 @@ set -euo pipefail
 echo "installing Github credential plugin"
 
 plugin_repo="https://github.com/chinmina/chinmina-git-credentials-buildkite-plugin.git"
-plugin_version="v1.3.0"
+plugin_version="v1.6.0"
 plugin_dir="/buildkite/plugins/chinmina-git-credentials-buildkite-plugin"
 
 [[ -d "${plugin_dir}" ]] && rm -rf "${plugin_dir}"

--- a/agent/startup/bootstrap-token-library
+++ b/agent/startup/bootstrap-token-library
@@ -5,7 +5,7 @@ set -euo pipefail
 echo "installing Chinmina token library plugin"
 
 plugin_repo="https://github.com/chinmina/chinmina-token-buildkite-plugin.git"
-plugin_version="v1.2.0"
+plugin_version="v1.4.0"
 plugin_dir="/buildkite/plugins/chinmina-token-buildkite-plugin"
 
 [[ -d "${plugin_dir}" ]] && rm -rf "${plugin_dir}"


### PR DESCRIPTION
## Purpose

Updates the integration test agent configuration to demonstrate best practices for configuring Chinmina plugins in Buildkite agents. The newer plugin versions support default environment variables (CHINMINA_DEFAULT_URL and CHINMINA_DEFAULT_AUDIENCE), eliminating configuration duplication and making agent setup simpler.

This serves as a reference implementation for users setting up Chinmina, showing how to configure multiple plugins without repeating common values like the bridge URL and OIDC audience for each plugin invocation.

## Context

- Updates chinmina-git-credentials plugin: v1.3.0 → v1.6.0
- Updates chinmina-token plugin: v1.2.0 → v1.4.0
- Integration test agent configuration in `agent/` directory serves as documentation by example
- Default environment variables feature introduced in newer plugin versions
- Also updates profile reference from "repo:default" to "pipeline:default" to align with current profile resolution behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default environment configuration for authentication and credential management.
  * Upgraded authentication and token library plugins to latest versions for improved compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->