### PR TITLE
build: support runnable worktrees via .worktreeinclude

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,7 @@
+integration/**
+.claude/settings.local.json
+.development/keys/**
+.envrc.private
+.serena/**
+!.serena/logs/
+!.serena/logs/**


### PR DESCRIPTION
## Purpose

Make parallel testing and development with git worktrees practical by ensuring new worktrees are immediately runnable without manual setup.

Currently, creating a worktree for parallel work (e.g. running integration tests on one branch while developing on another) requires manually copying local configuration, test fixtures, and development keys into each new worktree. This friction discourages parallel workflows and makes agent-based development across worktrees unreliable.

Using git's native `.worktreeinclude` mechanism, necessary local files are automatically available in new worktrees — covering integration test fixtures, development signing keys, environment configuration, and tool settings.

## Context

- Uses git's native worktree include format rather than custom scripts or agent-based file copying
- Log directories are excluded to prevent state pollution between worktrees