### PR TITLE
feat: add conventional PR title workflow

### DIFF
--- a/.github/workflows/conventional-pr-title.yml
+++ b/.github/workflows/conventional-pr-title.yml
@@ -1,0 +1,11 @@
+name: Conventional PR Title
+
+on:
+  pull_request:
+    types: [opened, reopened, edited]
+
+permissions: {}
+
+jobs:
+  conventional-pr-title:
+    uses: chinmina/.github/.github/workflows/conventional-pr-title.yml@verified-actions


### PR DESCRIPTION
Adds the org-wide conventional PR title check via the shared reusable workflow in chinmina/.github.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated validation for pull request titles to enforce conventional commit naming standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->