### PR TITLE
fix: grant pull-requests read permission to caller workflow

### DIFF
--- a/.github/workflows/conventional-pr-title.yml
+++ b/.github/workflows/conventional-pr-title.yml
@@ -4,7 +4,8 @@ on:
   pull_request:
     types: [opened, reopened, edited]
 
-permissions: {}
+permissions:
+  pull-requests: read
 
 jobs:
   conventional-pr-title:


### PR DESCRIPTION
The caller workflow set `permissions: {}` (all none), which prevents the reusable workflow in chinmina/.github from requesting `pull-requests: read`. Grant the permission explicitly at the caller level.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions configuration to enable pull request data access for automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->