### PR TITLE
feat: add conventional PR title workflow

### DIFF
--- a/.github/workflows/conventional-pr-title.yml
+++ b/.github/workflows/conventional-pr-title.yml
@@ -4,7 +4,8 @@ on:
   pull_request:
     types: [opened, reopened, edited]
 
-permissions: {}
+permissions:
+  pull-requests: read
 
 jobs:
   conventional-pr-title:


### PR DESCRIPTION
## Purpose

Enforces Conventional Commits formatting on PR titles across the repo.
Consistent PR titles keep the commit history machine-readable when using a
squash-merge workflow, making changelog generation reliable and the project
history easy to navigate.

The check is implemented via a shared reusable workflow in `chinmina/.github`,
so the enforcement rule and its underlying action are maintained in one place
across the org.

## Context

- Reusable workflow: https://github.com/chinmina/.github/blob/verified-actions/.github/workflows/conventional-pr-title.yml
- Uses `amannn/action-semantic-pull-request` v6.1.1 pinned by SHA