### PR TITLE
ci(renovate): keep jwx aligned with auth0 and release dependency updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -72,6 +72,21 @@
       enabled: false,
     },
     {
+      // auth0's middleware exchanges jwx types across its API, so jwx and the
+      // middleware must move as one.
+      groupName: "jwx-and-auth0-jwt-middleware",
+      matchDepNames: [
+        "github.com/lestrrat-go/jwx/v3",
+        "github.com/auth0/go-jwt-middleware/v3",
+      ],
+    },
+    {
+      // auth0's middleware pins jwx v3; a lone v4 bump ships both majors and
+      // silently breaks JWKS validation. Unblock when auth0 supports v4.
+      matchDepNames: ["github.com/lestrrat-go/jwx/v3"],
+      allowedVersions: "<4.0.0",
+    },
+    {
       // OpenTelemetry modules must be updated together: they have inter-module
       // version constraints and mixing versions causes build failures.
       groupName: "opentelemetry",

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,6 +1,11 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   description: "Golang config",
+  // Emit "fix(deps): ..." so dependency updates trigger a release-please patch
+  // release and ship, rather than sitting unreleased.
+  semanticCommits: "enabled",
+  semanticCommitType: "fix",
+  semanticCommitScope: "deps",
   postUpdateOptions: [
     // Tidy mod after updates: keeps compatibility with our go.mod checks.
     "gomodTidy",


### PR DESCRIPTION
## Purpose

auth0's JWT middleware pins jwx v3 and exchanges jwx types across its API, so a lone jwx v4 bump ships both majors and silently breaks JWKS validation at runtime despite compiling. This blocks jwx v4 until auth0 supports it and groups the two so they can only move together, and supersedes the automated jwx v4 PR (which should be closed).

It also switches renovate from the default `chore(deps)` to `fix(deps)`. Under release-please, `chore` updates are hidden and never trigger a release, leaving dependency fixes — including security patches — merged but unshipped; `fix(deps)` makes each update a patch release that actually deploys.

## Context

- Supersedes renovate branch `renovate/github.com-lestrrat-go-jwx-v3-4.x`.
- v3/v4 interop confirmed against the jwx v4 migration guide and the auth0 validator, whose type switch matches only the v3 `jwk.Set`.
- No auth0/go-jwt-middleware release (through v3.2.0) targets jwx v4; the eventual migration is tracked as deliberate work.

See commit history for the specific rule changes.