### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -103,6 +103,15 @@
       groupName: "github-actions",
       groupSlug: "github-actions",
       matchManagers: ["github-actions"],
+      // Pin actions to commit SHAs so a moved tag can't change what CI runs.
+      pinDigests: true,
+    },
+    {
+      // Keep the "verified-actions" branch pin: this repo SHA-pins its own
+      // transitive actions, so trust extends to one org-owned repo only.
+      // Must stay after the github-actions rule; last matching rule wins.
+      matchDepNames: ["chinmina/.github"],
+      pinDigests: false,
     },
   ],
 }


### PR DESCRIPTION
## Purpose

Close a supply-chain gap in CI. Today the workflows reference third-party GitHub Actions by floating tags (e.g. `actions/checkout@v7`), which means a compromised or force-moved tag would silently change the code executing in our pipelines — the same pipelines that mint short-lived GitHub tokens. Pinning every action to an immutable commit SHA ensures CI runs exactly the reviewed code, and only changes when a Renovate PR proposes (and we approve) a new digest.

This enables Renovate's `pinDigests` for the `github-actions` manager so the pinning — and future digest bumps — happen automatically, with a human-readable `# vX.Y.Z` comment retained on each pin.

`chinmina/.github` is deliberately exempted: it is pinned to the org-owned `verified-actions` branch and SHA-pins its own transitive actions, so trust is anchored to a single organisation-controlled repository rather than the wider ecosystem. The exemption depends on package-rule ordering (last matching rule wins), so it is placed after the github-actions rule.

## Context

- Surfaced while triaging the github-actions major update (#335), which arrived with plain tag references because this config was not yet on `main`.
- Once merged, the next Renovate run will rewrite existing tag-based `uses:` lines to `@<sha> # <version>` in a single grouped github-actions PR.
- Scope is limited to the `github-actions` manager; the repo's custom `regexManagers` (go-version, golangci-lint) are unaffected.