### PR TITLE
Add support for multiple GitHub App associations in profiles

### DIFF
--- a/docs/github-app-association.design-notes.md
+++ b/docs/github-app-association.design-notes.md
@@ -1,0 +1,262 @@
+# Multiple GitHub App Association — implementation design
+
+Implementation direction for `docs/prd-github-app-association.md`. Requirement
+numbers refer to that document.
+
+## Registry
+
+The registry lives in `internal/github`, alongside `Client`, the signer and the
+token sources, so app authentication stays in one package and no new import edge
+is created. It is built once at startup and immutable thereafter: value receivers
+over an unexported map set in the constructor and never written afterwards.
+
+**A disabled app is not resolvable.** Lookup by name returns not-found; enabled
+state is exposed only for logging. This lets Reqs 27 and 36 share one enforcement
+point — compilation asks for the set of usable names, the request path asks to
+resolve a name, and both call the same function. A lookup returning a minter
+alongside an `enabled` flag would mean a disabled app's lookup succeeds and every
+caller must remember to check.
+
+Two entry types. A configuration entry holds key material and implements
+`slog.LogValuer` exposing only name, application ID, installation ID and key
+source, which is how Req 49 holds by construction rather than by vigilance. A
+resolved entry holds verification results, never key material, and is what Req 48
+logs. One type would see its `LogValuer` grow until it constrained nothing.
+
+Req 50 requires that configuration errors never echo key material. The project
+convention of wrapping with `%w` conflicts with this on the key-parsing path,
+where the wrapped error comes from a third-party library whose message content is
+outside our control and may change on any dependency bump. Key-parsing failures
+must be wrapped with a sentinel that discards the underlying message — a
+deliberate, documented exception.
+
+## Client construction and signing keys
+
+**The signing key must not capture a short-lived context.** `kmsSigningKey`
+captures a context at construction and reuses it for every signature, and signing
+is lazy and recurring — a fresh App JWT roughly every ten minutes for the life of
+the process. A context scoped to startup or verification that reaches key
+construction produces a clean boot, a clean verification, then `context canceled`
+on every mint once the first JWT expires, permanently, and only for apps using
+`privateKeyArn`.
+
+Registry construction therefore takes the long-lived server context.
+`createKMSSigningKey` should not capture a context at all: it takes a shared
+`aws.Config` — one credential resolution for all apps rather than N concurrent
+ones at boot — and the signing call carries its own.
+
+This bears on Req 15's scope. KMS key handling contacts nothing at construction;
+the first network call is the signing operation. So every network-shaped failure
+— bad ARN, IAM denial, KMS outage, GitHub unreachable — arrives on the
+verification path and is disabled under Req 16, and what remains at construction
+is offline and deterministic.
+
+The outgoing connection pool is shared, so with more apps than
+`SERVER_OUTGOING_MAX_CONNS_PER_HOST` the concurrent queries of Req 13 proceed in
+waves. At realistic app counts this is one wave.
+
+## Startup sequence
+
+Separate configuration validation from route construction. Everything offline —
+base path normalisation, JWT middleware, the Buildkite client, the cache — is
+validated before any GitHub call, so a configuration error is reported
+immediately rather than behind a network phase. Routes are built after the
+registry exists, so it is never mutated after the handlers capture it.
+
+Construct the registry **after** `http.DefaultTransport` is replaced with the
+instrumented, pool-tuned transport, because the GitHub client captures the
+transport by value. Building it earlier leaves registry traffic untraced and
+untuned, with no error and no log.
+
+The default app is served by two clients: the registry's app-transport client for
+minting and installation queries, and the existing token-transport client for
+retrieving the profile configuration (Req 34).
+
+`PeriodicRefresh` performs its first load immediately, before its first interval,
+so Req 40's gate needs a first-load signal from it. Prefer a synchronous first
+load followed by a refresh loop with a delayed start over a readiness channel: it
+makes the gate a plain function testable with synthetic time, and avoids every
+instance fetching the profile twice at boot.
+
+Shutdown hooks currently run only via the HTTP server's shutdown path, so any
+exit before serving — Req 17's, and a gate failure — discards buffered telemetry
+describing the failure and leaks a distributed cache connection per restart. Req
+42 requires them on those paths, which means guarding execution so the normal
+path does not run them twice.
+
+No timeout governs verification or the first load. A hung upstream blocks
+startup, the service does not accept connections, and the platform's startup
+grace period terminates the container. Req 41's per-attempt log is the
+diagnostic, and it does not depend on winning a race against a platform timeout
+we do not own.
+
+## Resolution and the vendor chain
+
+Profile attributes stay pure data: `OrganizationProfileAttr` and
+`PipelineProfileAttr` gain the app *name*, a string, not a live client.
+
+**Normalise in compilation, not at the request boundary.** An omitted `app` and
+an explicit `app: default` must be indistinguishable downstream, so `compile`
+resolves both to the default app's name and a valid profile's app name is never
+empty. Normalising at the resolver would give the two spellings different
+compiled attributes, and so different audit attribution for identical behaviour.
+
+The name resolves to an app identity — name, application ID, installation ID — at
+the handler boundary, in the profile resolver, and travels on the resolved
+request value. The identity is data, not a closure, so `vendor.Resolved` stays
+loggable and no credential is captured in a value that flows into a cache
+payload. `Vending` resolves identity to a minter through the registry: an O(1)
+lookup against an immutable value.
+
+**Resolution must happen in the resolver, not in `Vending`.** The chain is Audit →
+Authorized → Cached → Vending, and `Cached` short-circuits on a hit before the
+wrapped vendor runs — the hazard already documented on `Authorized`, which must
+be composed outside `Cached` for the same reason. A registry check inside
+`Vending` is absent on every cache hit, which is exactly the state where a
+profile that was valid long enough to warm an entry has since had its app
+disabled. Resolving in the resolver makes the lookup that populates the identity
+*the* guard, running on every request. This is what Req 36's final clause
+requires.
+
+Its failure is a 500, not a 403: reaching it means a profile was resolved that
+compilation should have invalidated — our defect, not GitHub's denial. The
+existing guards for unresolved scope and an uncompiled matcher have the same
+shape.
+
+Only the resolver reads the app name off the typed attributes, so only it is
+constrained on that method. Cache, authorizer, auditor and vendor read the
+identity from the resolved value and stay generic.
+
+Compilation needs the registry's usable names threaded through
+`FetchOrganizationProfile` → `load` → `compile`, and through `PeriodicRefresh`
+for the background path. Req 30 exists because missing the second path is easy
+and silent: profiles would be valid for the first refresh interval and invalid
+after, with an unchanged digest, so the generation swap logs at debug level while
+profiles become unavailable.
+
+## Invalid-profile logging
+
+Compilation logs its batched invalid-profile warning on every compile, and
+compilation runs on every refresh, so one permanently-invalid profile produces a
+warning every interval for the life of the process.
+
+Req 28 places the comparison in the profile store — the only component holding
+both generations, already under a write lock, already branching on change. Diff
+the profile-name-to-reason mapping rather than names alone, so a profile whose
+reason changes is reported. Do not diff on the digest: the case worth catching is
+one where the YAML is unchanged and validity flips. The store update runs even
+when the digest is unchanged, which is what makes this catch the Req 30 failure.
+
+Req 44 requires the audit entry to carry why a profile is invalid.
+`ProfileUnavailableError` currently discards its cause; the caller-facing message
+comes from a separate method, so including it changes nothing a caller sees. This
+becomes load-bearing once Req 28 is edge-triggered, because the audit entry is
+then the only timely record.
+
+## Cache
+
+The key is `digest:applicationID:installationID:profileURN`. Numeric identifiers
+cannot contain the separator, so the key stays unambiguous.
+
+No consistency check is performed between the app recorded in an entry and the
+app implied by its key. Against an attacker it is worth nothing: with encryption
+enabled the key is authenticated associated data, so an entry cannot be forged or
+relocated without the keyset; with encryption disabled, anyone able to write an
+entry can write a consistent one, and the dominant risk there is reading, since
+every entry holds a live token. As a defect canary it would duplicate an
+invariant the key already enforces, on a branch reachable only through a change
+the required cache-key test detects first.
+
+Old and new key formats are disjoint keyspaces, so during a rolling deployment
+each warms independently and neither misreads the other. The cost is a bounded
+increase in mint volume for one cache lifetime. Nothing reaps orphaned entries;
+they expire. The in-memory capacity bound does not apply to the distributed
+cache, so two live keyspaces do not interact with it.
+
+## Testing
+
+**Harness.** The GitHub mock exposes only the installation token endpoint, with
+one status code and one counter shared across requests. Verification testing
+needs the installation endpoint, per-installation responses and per-installation
+counters, so one boot can exercise an app that matches, an app on a different
+account and an app whose query fails. Req 19 asserts which calls were made, so it
+needs the per-installation counter independently. The harness needs a way to
+supply registry configuration, and registry entries must inherit the internal API
+URL or none of this can be pointed at the mock.
+
+**Registry construction and verification** (`internal/github`) — table-driven
+over configuration inputs: a valid multi-app registry; duplicate names; an entry
+named `default`; a name failing the allowlist; both key sources; neither; a
+non-positive identifier; malformed JSON; unknown fields. Each asserts startup
+failure or success as a whole (Reqs 5–11, 15). Then verification outcomes against
+the mocked endpoint: matching account enables, differing account disables, query
+failure disables, default-app query failure exits (Reqs 12–17). One test asserts
+no installation call when no registry is configured (Req 19).
+
+**The signing key outlives verification** (`internal/github`) — construct the
+registry under a context that is then cancelled, mint a token, assert success.
+Without this the defect is invisible: it does not reproduce with PEM keys, and
+every existing test uses PEM.
+
+**Profile compilation** (`internal/profile`) — extends the existing tables: `app`
+accepted on an organization profile and on a named pipeline profile; `default`
+accepted as an alias; empty string, unknown name and disabled app's name
+rejected; omitted yields the default app. A behaviour test asserts two
+configurations differing only in the presence of `app: default` compile to equal
+attributes. Each invalid case asserts the profile is invalid and that others in
+the same configuration remain valid — the isolation property is the point of Reqs
+26–28. A refresh test drives a refresh and asserts a profile naming an enabled
+app is still valid (Req 30).
+
+**Cache key includes app identity** (`internal/vendor`) — two resolved requests
+identical in profile and digest but differing in identity must not share an entry
+(Req 38), and a single request round-trips through its own key. Assert observable
+cache behaviour rather than the key string. This also discharges the absence of a
+payload consistency check: it fails if a future change stops the key determining
+identity.
+
+**A warm entry does not bypass app resolution** — prime the cache, make the
+registry unable to resolve that profile's app, repeat the request, assert 500 and
+that the cached token was not served (Req 36). This is the test that fails if
+resolution is placed inside the vendor chain.
+
+**Vending through the resolved app** (`internal/vendor`) — a request carrying a
+non-default identity mints through that app; one carrying the default identity
+mints through the default.
+
+**The startup gate** — extract the wait for a first generation as a function, so
+it can be tested with synthetic time as the refresh daemon already is. The
+integration harness constructs routes directly rather than booting the server, so
+a gate tested only through the harness is not tested at all.
+
+**Invalid-profile logging is edge-triggered** (`internal/profile`) — two
+successive updates with the same invalid set log once; a change logs again.
+
+**Concurrency** — an integration test issuing parallel requests across two apps,
+under the race detector, so a future change introducing lazily populated registry
+state is caught.
+
+**End-to-end** (`api_integration_test.go`) — a request against a profile bound to
+a second app produces a token minted via that app's installation, with the app
+name in the response and the audit entry (Reqs 33, 43, 45). A request against a
+profile naming a disabled app returns 404 (Reqs 27, 29) with the reason on the
+audit entry (Req 44).
+
+Tests document behaviour, not struct shape.
+
+## Suggested order
+
+1. Edge-triggered invalid-profile logging; `ProfileUnavailableError` carries its
+   cause.
+2. Shutdown hooks on startup exit paths.
+3. Split configuration validation from route construction; fix transport
+   ordering.
+4. Registry construction, with the shared `aws.Config` and no captured context.
+5. Resolution and guard in the profile resolver; alias normalisation in
+   compilation.
+6. The startup gate, with the refresh daemon's delayed-start option.
+7. Cache key, response and audit fields, name allowlist.
+8. Span attributes for profile counts.
+9. Documentation, the error-sentinel test, the race test.
+
+Items 1 and 2 are independent of the feature and unblock the rest.

--- a/docs/prd-github-app-association.md
+++ b/docs/prd-github-app-association.md
@@ -278,11 +278,51 @@ the separation of the pipeline and organization chains.
 The key becomes configuration digest, application ID, installation ID, profile
 URN. Numeric IDs cannot contain the separator, so the key stays unambiguous.
 
-The YAML digest alone is insufficient: remapping a logical name to different
-credentials in deployment configuration does not change the YAML, so a
-distributed Valkey cache could serve tokens minted by the previous app after a
-redeploy. Including the resolved identity rather than the name means only
-entries for the genuinely remapped app are orphaned.
+The digest alone is insufficient, and the reason is specific to this design's
+split between where credentials are declared and where they are selected. The
+YAML says `app: packages`; the mapping from that name to an application and
+installation lives in deployment configuration. Repointing the name at
+different credentials therefore leaves the YAML — and so the digest, and so the
+key — completely unchanged, and a cache that survives the change keeps serving
+tokens minted by the previous app.
+
+This is a staleness defect, not an exploitable weakness, and it is worth being
+precise about which. No caller input reaches the name-to-credential mapping, so
+nothing here is attacker-triggerable; a caller that receives a stale token
+matched the profile legitimately and is entitled to a token for it. What fails
+is the operator's intent: a configuration change does not take effect when they
+believe it has. Three preconditions must all hold — a distributed cache (an
+in-process cache dies with the restart that any environment change requires), a
+logical name *reused* for different credentials rather than a new name added,
+and an operator-initiated remap.
+
+The window is bounded but not small. Cache entries live 45 minutes and GitHub
+installation tokens live 60 minutes from mint, so a token handed out just
+before an entry expires remains usable for roughly a further quarter hour. A
+rolling deployment widens this further: instances not yet replaced continue
+minting through the old credential and writing to the shared key, so replaced
+instances actively consume their entries rather than merely draining a
+pre-existing backlog.
+
+The scenario that motivates the fix is remap-as-privilege-reduction —
+repointing a name from a broad app to a narrow one precisely in order to shrink
+what a set of pipelines can do. For up to an hour afterwards, some builds still
+receive the wide credential. Remap-as-incident-response is less exposed than it
+appears, because uninstalling the suspect app revokes its outstanding
+installation tokens; note though that *rotating an app's private key does not*,
+so "rotate the key and repoint the name" leaves cached tokens working.
+
+Two things justify fixing it despite the narrow preconditions. It costs two
+integers in a key string, so there is no design tension to weigh. More
+importantly, the indirection actively invites the triggering action: the
+principal benefit of a logical name is that what sits behind it can be swapped
+without touching the YAML, which is exactly the operation the cache cannot
+observe. A feature whose main convenience is the thing that breaks it warrants
+the guard.
+
+Keying on the resolved identity rather than a registry-wide fingerprint means
+only the genuinely remapped app's entries are orphaned; every other profile
+stays warm across the change.
 
 Deploying this change orphans every existing cache entry once, because the key
 format changes for the default app too. This is a one-time cold cache, not a
@@ -346,12 +386,13 @@ invalid case asserts the profile lands in `invalidProfiles` and that other
 profiles in the same configuration remain valid — the isolation property is the
 point of Reqs 27–29. A refresh test asserts re-evaluation (Req 31).
 
-**Cache key includes app identity** (`internal/vendor`) — the key guard for the
-hole this design introduces. Two resolved requests identical in profile and
-digest but differing in resolved app must not share an entry (Req 38), and a
-single request round-trips through its own key. Prefer asserting observable
-cache behaviour over asserting the key string, so the format stays free to
-change.
+**Cache key includes app identity** (`internal/vendor`) — guards the staleness
+defect described under Cache key, which is otherwise invisible until an
+operator remaps a name in production. Two resolved requests identical in
+profile and digest but differing in resolved app must not share an entry
+(Req 38), and a single request round-trips through its own key. Prefer
+asserting observable cache behaviour over asserting the key string, so the
+format stays free to change.
 
 **Vending through the resolved app** (`internal/vendor`) — a resolved request
 carrying a non-default app mints through that app's function, not the default's;

--- a/docs/prd-github-app-association.md
+++ b/docs/prd-github-app-association.md
@@ -2,46 +2,62 @@
 
 ## Problem Statement
 
-Chinmina Bridge vends every token through a single GitHub App installation,
-fixed at deployment time by `GITHUB_APP_ID` and `GITHUB_APP_INSTALLATION_ID`.
-Every profile — organization or pipeline — draws on that one installation's
-permission grant and repository selection.
+Chinmina Bridge vends every token through a single GitHub App installation, fixed
+at deployment time by `GITHUB_APP_ID` and `GITHUB_APP_INSTALLATION_ID`. Every
+profile draws on that one installation's permission grant and repository
+selection.
 
-This forces an operator who needs a genuinely separate credential to choose
-between two bad options: widen the single app's permissions until it can serve
-every use case (so every pipeline's token is minted by an app that *could*
-write packages, administer repositories, or whatever the broadest consumer
-needed), or run a second Chinmina deployment. The first collapses the blast
-radius that profiles exist to control; the second duplicates configuration,
-telemetry and operational burden.
+An operator needing a genuinely separate credential must either widen the single
+app until it serves every use case — so every pipeline's token is minted by an
+app that *could* write packages or administer repositories — or run a second
+deployment. The first collapses the blast radius that profiles exist to control;
+the second duplicates configuration, telemetry and operational burden.
 
-The permission grant of a GitHub App is also not the only thing that differs
-between use cases. Apps differ in their repository selection, their rate limit
-budget, and who owns and audits them. A team that owns a packages-publishing
-app reasonably wants that app to remain theirs, rather than having its
-permissions folded into a shared credential.
+Permissions are not the only difference. Apps differ in repository selection,
+rate limit budget, and who owns and audits them. A team that owns a
+packages-publishing app reasonably wants it to remain theirs.
 
 ## Solution
 
-An operator may declare additional GitHub Apps in deployment configuration,
-each under a logical name. A profile in the organization profile YAML may then
-name one of those apps, and tokens vended for that profile are minted through
-that app's installation. Profiles that name no app continue to use the existing
-app, which remains the default.
+An operator may declare additional GitHub Apps in deployment configuration, each
+under a logical name. A profile may then name one, and tokens vended for that
+profile are minted through that app's installation. Profiles naming no app use
+the existing app, which remains the default.
 
 All configured apps must be installed on the same GitHub organization as the
-default app. This is verified once at startup; an app that fails verification
-is disabled, and profiles naming it become unavailable rather than silently
-falling back to a different credential.
+default app. This is verified once at startup; an app that fails verification is
+disabled, and profiles naming it become unavailable rather than silently falling
+back to a different credential.
 
-Credentials stay in deployment configuration. The profile YAML — which is
-typically writable by a broader group than the deployment environment —
-can only *select* from apps the operator has already installed. Introducing a
-new credential remains a deploy-time privilege.
+Credentials stay in deployment configuration. The profile YAML — typically
+writable by a broader group than the deployment environment — can only *select*
+from apps the operator has already installed. Introducing a credential remains a
+deploy-time privilege.
+
+### Trust and the profile repository
+
+Registering an app raises the privilege ceiling of the profile repository to the
+union of every registered app's grant, for as long as that app remains
+registered.
+
+Profile-repo write access is already full authority over the default app's grant:
+a profile may omit `match` entirely and claim every repository the installation
+reaches. This feature raises that ceiling. The deploy-time split protects against
+*credential introduction*, not *privilege selection*, so `GITHUB_APPS` is a
+decision about how far the profile repository is trusted. Whoever reviews it must
+understand each registered app's grant and repository selection.
+
+### Service boundary
+
+The service owns its own configuration, decisions and state. It does not own the
+contents of the profile YAML, nor the configuration of a GitHub App. Profile
+review happens in the profile repository; app permissions and repository
+selection live in GitHub and change there without notice.
+
+The service therefore records what it did and decided, when it did it. It does
+not snapshot external state it neither owns nor rechecks.
 
 ### Configuration shape
-
-Deployment environment:
 
 ```sh
 # unchanged: the default app
@@ -56,7 +72,7 @@ export GITHUB_APPS='[
 ]'
 ```
 
-Organization profile YAML:
+`GITHUB_APPS` is the only new configuration variable.
 
 ```yaml
 organization:
@@ -66,7 +82,7 @@ organization:
       match:
         - claim: pipeline_slug
           value: release
-      repositories: [{{all-repositories}}]
+      repositories: ["{{all-repositories}}"]
       permissions: [packages:write]
 
 pipeline:
@@ -89,376 +105,307 @@ pipeline:
    authenticated GitHub App client for each entry it contains.
 3. Where `GITHUB_APPS` is not configured, the service shall vend every token
    through the default app.
-4. Each registry entry shall declare a name, an application ID, an
-   installation ID, and exactly one of a private key or a private key ARN.
-5. If `GITHUB_APPS` is not well-formed JSON, then the service shall fail to
-   start.
-6. If a registry entry declares neither a private key nor a private key ARN,
+4. Each registry entry shall declare a name, an application ID, an installation
+   ID, and exactly one of a private key or a private key ARN.
+5. If `GITHUB_APPS` is not well-formed JSON, or contains an unrecognised field,
    then the service shall fail to start.
+6. If a registry entry declares neither a private key nor a private key ARN, then
+   the service shall fail to start.
 7. If a registry entry declares both a private key and a private key ARN, then
    the service shall fail to start.
-8. If two registry entries declare the same name, then the service shall fail
-   to start.
-9. If a registry entry is named `default`, then the service shall fail to
+8. If two registry entries declare the same name, then the service shall fail to
    start.
-10. If a registry entry's name is empty or contains `/`, `:`, whitespace or
-    control characters, then the service shall fail to start.
-11. If a registry entry omits its application ID or its installation ID, then
-    the service shall fail to start.
+9. If a registry entry is named `default`, then the service shall fail to start.
+10. If a registry entry's name does not match
+    `^[a-z0-9]([a-z0-9._-]*[a-z0-9])?$`, or exceeds 64 characters, then the
+    service shall fail to start.
+11. If a registry entry's application ID or installation ID is not a positive
+    integer, then the service shall fail to start.
 
 ### Organization verification
 
 12. When the service starts with a configured registry, the service shall
-    determine the default app's installation account login by querying its
+    determine the default app's installation account ID by querying its
     installation.
 13. When the service starts with a configured registry, the service shall
-    determine each registry app's installation account login by querying its
-    installation.
-14. The service shall compare installation account logins case-insensitively.
-15. If a registry app's installation account login differs from the default
-    app's, then the service shall mark that app disabled.
-16. If a registry app's client cannot be constructed or its installation cannot
-    be queried, then the service shall mark that app disabled.
+    determine each registry app's installation account ID by querying its
+    installation, and shall issue those queries concurrently.
+14. If a registry app's installation account ID differs from the default app's,
+    then the service shall mark that app disabled.
+15. If a registry entry's private key cannot be parsed, or its GitHub client
+    cannot be constructed, then the service shall fail to start.
+16. If a registry app's installation cannot be queried, then the service shall
+    mark that app disabled and shall continue starting.
 17. If the default app's installation cannot be queried, then the service shall
-    mark every registry app disabled.
-18. While an app is disabled, the service shall refuse to vend tokens through
-    it.
-19. The service shall not re-verify a disabled app until the service is
+    exit with a non-zero status.
+18. The service shall not re-verify a disabled app until the service is
     restarted.
-20. Where `GITHUB_APPS` is not configured, the service shall query no
+19. Where `GITHUB_APPS` is not configured, the service shall query no
     installation at startup.
 
 ### Profile schema and compilation
 
-21. An organization profile shall accept an optional `app` property naming the
+20. An organization profile shall accept an optional `app` property naming the
     app its tokens are minted through.
-22. A named pipeline profile shall accept an optional `app` property naming the
+21. A named pipeline profile shall accept an optional `app` property naming the
     app its tokens are minted through.
-23. Where a profile declares no `app` property, the service shall mint that
+22. Where a profile declares no `app` property, the service shall mint that
+    profile's tokens through the default app.
+23. Where a profile's `app` property is `default`, the service shall mint that
     profile's tokens through the default app.
 24. The default pipeline profile shall mint its tokens through the default app.
-25. If a profile's `app` property is `default`, then the service shall treat
-    that profile as invalid.
-26. If a profile's `app` property is present and empty, then the service shall
+25. If a profile's `app` property is present and empty, then the service shall
     treat that profile as invalid.
-27. If a profile's `app` property names an app absent from the registry, then
-    the service shall treat that profile as invalid.
-28. If a profile's `app` property names a disabled app, then the service shall
+26. If a profile's `app` property names an app absent from the registry, then the
+    service shall treat that profile as invalid.
+27. If a profile's `app` property names a disabled app, then the service shall
     treat that profile as invalid.
-29. When profile compilation marks a profile invalid because of its `app`
-    property, the service shall log a warning naming the profile and the
-    reason.
-30. If a request names a profile that is invalid, then the service shall
-    respond with 404 and a profile-unavailable message.
-31. When the profile configuration is refreshed, the service shall re-evaluate
-    each profile's `app` property against the registry.
+28. When the set of invalid profiles differs between profile generations, the
+    service shall log each invalid profile and the reason it is invalid.
+29. If a request names a profile that is invalid, then the service shall respond
+    with 404 and a profile-unavailable message.
+30. While the service is running, a profile naming an enabled registry app shall
+    remain valid across profile refreshes.
 
 ### Token vending
 
-32. When a request resolves a profile, the service shall resolve that profile's
-    app to a single minting client at the handler boundary.
-33. The service shall carry the resolved app through the vendor chain in the
-    resolved request value.
-34. When a token is vended, the service shall mint it through the installation
-    of the resolved profile's app.
-35. The service shall retrieve the organization profile configuration file
+31. When a request resolves a profile, the service shall resolve that profile's
+    app to a single app identity at the handler boundary.
+32. The service shall carry the resolved app's identity in the resolved request
+    value.
+33. When a token is vended, the service shall mint it through the installation of
+    the resolved profile's app.
+34. The service shall retrieve the organization profile configuration file
     through the default app.
-36. The service shall not check a requested repository's owner against the
+35. The service shall not check a requested repository's owner against the
     resolved app's organization.
+36. If a request resolves a profile whose app cannot be resolved in the registry,
+    then the service shall respond with 500 and shall not vend a token, whether
+    or not a cached token exists for that request.
 
 ### Caching
 
-37. The service shall include the resolved app's application ID and
-    installation ID in the token cache key.
+37. The service shall include the resolved app's application ID and installation
+    ID in the token cache key.
 38. If two requests resolve the same profile from the same configuration
-    generation but through different apps, then the service shall not serve
-    either request's cached token to the other.
+    generation but through different app identities, then the service shall not
+    serve either request's cached token to the other.
 39. The service shall record the app a cached token was minted through in the
     cached entry.
 
+### Startup
+
+40. Where an organization profile location is configured, the service shall not
+    accept connections until a profile generation has been loaded from that
+    location.
+41. While waiting for the first profile generation, the service shall log each
+    failed load attempt.
+42. When the service exits during startup, the service shall execute its
+    registered shutdown hooks.
+
 ### Observability
 
-40. When a token request completes, the service shall record the resolved app's
-    name on the audit entry.
-41. When a token is vended, the service shall include the minting app's name in
+43. When a request resolves a profile, the service shall record the resolved
+    app's name on the audit entry.
+44. If a profile is unavailable, then the service shall record on the audit entry
+    the reason that profile is invalid.
+45. When a token is vended, the service shall include the minting app's name in
     the token response.
-42. The service shall attribute token cache outcome and token issuance metrics
-    with the app name.
-43. When the service starts, the service shall log each configured app's name,
+46. The service shall attribute the token cache outcome metric with the app name.
+47. When the service updates the profile generation, the trace span shall record
+    the counts of valid and invalid profiles by profile type.
+48. When the service starts, the service shall log each configured app's name,
     application ID, installation ID, verified organization and enabled state.
-44. The service shall exclude private key material from all log output.
+49. When the service logs a registry entry, the log record shall contain only the
+    entry's name, application ID, installation ID and key source, and shall
+    contain no private key material and no private key ARN.
+50. When the service reports a registry configuration error, the error message
+    shall identify the faulty entry by name or index, and shall contain no
+    substring of the entry's private key or private key ARN.
 
 ### Documentation
 
-45. The `.envrc` reference block shall document `GITHUB_APPS` with a commented
+51. The `.envrc` reference block shall document `GITHUB_APPS` with a commented
     example alongside the existing `GITHUB_APP_*` variables.
-46. The profile schema documentation shall document the `app` property,
-    including that it may not name `default` and is unavailable on the default
-    pipeline profile.
-47. The documentation shall state the same-organization constraint, how it is
+52. The profile schema documentation shall document the `app` property, including
+    that `default` may be named explicitly and that the property is unavailable
+    on the default pipeline profile.
+53. The documentation shall state the same-organization constraint, how it is
     verified, and what a disabled app means operationally.
-48. The documentation shall state that a profile configuration using `app`
-    requires a binary that supports it, and that rolling the binary back while
-    such a configuration is published rejects the entire configuration.
+54. The documentation shall state that a profile configuration using `app`
+    requires a binary that supports it; that rolling the binary back while such a
+    configuration is published rejects the entire configuration; and that
+    rollback restores pre-gate cold-start behaviour and is not a remedy for an
+    upstream outage.
+55. The documentation shall state that narrowing a GitHub App's permissions does
+    not revoke tokens already issued, and that uninstalling the app does.
+56. The documentation shall state that the token response body, the audit entry
+    and the token cache outcome metric each carry the minting app's name.
+57. The documentation shall state how a deployment scales with app count: metric
+    series and KMS signing calls scale linearly; the outgoing connection pool
+    does not.
 
-## Implementation Decisions
+## Rationale
 
-### Registry placement and shape
+**The default app defines the organization.** Its installation account is the
+reference the others are compared against, so no new variable is required of
+existing deployments. The account ID is compared rather than the login, because
+logins are renameable and, once released, claimable by another account. Target
+type is unconstrained, so an installation on a user account continues to work
+provided all apps share it.
 
-The registry lives in `internal/github`, alongside `Client`, the signer and the
-token sources. Everything about authenticating as a GitHub App stays in one
-package and no new import edge is created.
+**Startup failure versus a disabled app.** Configuration with no single
+unambiguous meaning fails startup: malformed JSON, neither or both key sources, a
+duplicate name, a non-positive identifier, an unparseable key. These outcomes are
+deterministic and identical on every instance. An app whose installation cannot
+be queried is disabled and the service starts — the configuration is
+interpretable, one credential could not be checked, and one unreachable app must
+not take down vending for every other profile.
 
-The registry is built once during startup and is immutable thereafter. It
-exposes lookup by name, returning a value that carries both the minting
-function and the app's resolved identity (application ID, installation ID,
-verified organization). Construction, KMS/PEM key handling, installation
-verification and the disabled-state decision all stay behind that boundary —
-callers only ask "give me the minter for this name".
+The default app is the exception (Req 17). If the service cannot query its own
+installation it cannot authenticate to GitHub as itself, so minting is broken
+regardless and a process that continued would serve failures while appearing
+healthy. Per Req 19, deployments not using the feature are unaffected.
 
-Two distinct failure classes, deliberately separated:
+**Disabled is terminal until restart** (Req 18). Re-verification would make an
+instance's enabled set a function of when its timer fired rather than of its
+configuration, so instances with identical configuration could disagree
+indefinitely. Installation suspension is not checked for the same reason: an
+instance started before a suspension would answer 403 while one started after
+answered 404, and unsuspending would restore nothing until every instance
+restarted. A suspended app surfaces as a 403 at mint time carrying GitHub's own
+message, on an audit entry naming the app.
 
-- **Malformed configuration** (Reqs 5–11) fails startup, consistent with how
-  `config.Load` already treats invalid configuration. The operator has written
-  something that cannot be interpreted.
-- **An unhealthy app** (Reqs 15–17) disables that app and lets the service
-  start. The configuration is interpretable; one credential is not usable. A
-  single broken app must not take down token vending for every other profile.
+**Verification concurrency.** Queries are issued concurrently (Req 13), so the
+phase completes in roughly the time of the slowest one. A query that does not
+complete is a query failure, and Reqs 16 and 17 determine the outcome. No
+separate time budget governs the phase: its expiry would be evidence about the
+service rather than about any app, which is the wrong basis on which to disable
+one.
 
-There is no background re-verification. A disabled app stays disabled until
-restart, which keeps the registry genuinely immutable after boot and avoids a
-second code path that mutates authorization-relevant state at runtime.
+**Serving requires a loaded profile generation.** Until one has loaded, the
+service has no configuration to serve, so Req 40 prevents it accepting
+connections and a request is never answered from a generation the operator did
+not publish. Not listening is the readiness signal, leaving the healthcheck
+contract unchanged. The gate is a latch on the first load only: a service that
+has a generation and later loses access to its source keeps serving it.
 
-### The default app defines the organization
+This couples startup to the availability of the profile source. That cost is
+accepted because the alternative failure is silent: an instance serving before it
+has loaded answers organization profiles with 404 and pipeline profiles with a
+built-in permission set, while reporting healthy and counting as ready during a
+rolling deployment.
 
-The default app's installation account login is the reference the others are
-compared against. There is no separately configured organization literal —
-adding a required variable to every existing deployment to express something
-already discoverable is not worth it.
+**Cache key.** The key is the configuration digest, application ID, installation
+ID and profile URN. The digest alone is insufficient: the YAML names an app, but
+the mapping from that name to a credential lives in deployment configuration, so
+repointing a name leaves the YAML — and the digest, and the key — unchanged while
+the cache keeps serving tokens from the previous app. Exposure is bounded by the
+45-minute entry lifetime against a 60-minute token lifetime, and requires a
+distributed cache, a name reused rather than added, and an operator-initiated
+remap. It is included because the indirection invites exactly that operation: the
+benefit of a logical name is that what sits behind it can be swapped without
+touching the YAML.
 
-If the default app's own installation cannot be queried, there is nothing to
-compare against, so every registry app is disabled and the default app
-continues to serve (Req 17). This preserves today's behaviour for the default
-app exactly: it has never been verified, and this change does not start gating
-it on a successful GitHub call at boot.
+The key carries identity rather than the name, so only a remapped app's entries
+are orphaned. A name is a label on an identity: two names for one application and
+installation share entries, differing only in attribution. Granted permissions
+are not part of the key — they are observable only through a GitHub call, and
+narrowing a grant does not revoke issued tokens, so token lifetime rather than
+the cache is the binding constraint.
 
-Target type is not constrained. Only the account login is compared, so an
-installation on a user account continues to work as it does today, provided all
-apps share it.
+Deploying this change orphans every existing entry once, because the key format
+changes for the default app too. This is a one-time cold cache and is accepted.
 
-### Where the app name is stored, and where it is resolved
+**Response, audit and telemetry.** The cached payload is the response, so Req 39
+keeps a cache hit and a cache miss returning the same shape. The audit entry
+records the app at resolution rather than at vend, so every outcome downstream of
+resolution carries it, including failures; a profile invalid because its app is
+disabled fails before an app is resolved, so Req 44 records the reason instead.
+Profile generation changes are already traced, and Req 47 adds the valid and
+invalid counts to those span attributes rather than introducing metrics that
+duplicate them — the counts are the only part of profile state not already
+observable, and are what makes a partly-invalid generation visible.
 
-Profile attributes stay pure data. `OrganizationProfileAttr` and
-`PipelineProfileAttr` gain the app *name* — a string — not a live client.
-Compilation validates that name against the registry's known-and-enabled names
-and invalidates the profile if it does not resolve.
+**Compatibility and deployment ordering.** A deployment with no `GITHUB_APPS` and
+no `app` properties behaves as it does today and makes no additional GitHub calls
+at startup (Reqs 3, 19). Profile parsing rejects unrecognised properties so a
+typo cannot grant unintended access, so a YAML containing `app:` is rejected in
+its entirety by a binary predating this change — as is `app:` written under
+`pipeline.defaults`, which is not a profile.
 
-The name is turned into a minting client at the handler boundary, in the
-profile resolver, and travels on the resolved request value. This follows the
-doctrine already documented on `vendor.Resolved`: everything a request needs is
-established once, at the boundary, so no downstream stage re-consults mutable
-state and no request can combine one generation's authorization with another's
-credential. It also means the cache key can be computed from the resolved value
-without a second lookup.
-
-Compilation therefore needs the set of usable app names threaded through from
-the registry: `FetchOrganizationProfile` → `load` → `compile`, and through
-`PeriodicRefresh` for the background refresh path. The registry is immutable,
-so this is a value passed at wiring time, not a live dependency.
-
-### Vendor chain
-
-`Vending` currently closes over a single `TokenVendor` bound at wiring time. It
-instead reads the minting function from the resolved request. The composition
-order in `main.go` — Audit → Authorized → Cached → Vending — is unchanged, as is
-the separation of the pipeline and organization chains.
-
-### Cache key
-
-The key becomes configuration digest, application ID, installation ID, profile
-URN. Numeric IDs cannot contain the separator, so the key stays unambiguous.
-
-The digest alone is insufficient, and the reason is specific to this design's
-split between where credentials are declared and where they are selected. The
-YAML says `app: packages`; the mapping from that name to an application and
-installation lives in deployment configuration. Repointing the name at
-different credentials therefore leaves the YAML — and so the digest, and so the
-key — completely unchanged, and a cache that survives the change keeps serving
-tokens minted by the previous app.
-
-This is a staleness defect, not an exploitable weakness, and it is worth being
-precise about which. No caller input reaches the name-to-credential mapping, so
-nothing here is attacker-triggerable; a caller that receives a stale token
-matched the profile legitimately and is entitled to a token for it. What fails
-is the operator's intent: a configuration change does not take effect when they
-believe it has. Three preconditions must all hold — a distributed cache (an
-in-process cache dies with the restart that any environment change requires), a
-logical name *reused* for different credentials rather than a new name added,
-and an operator-initiated remap.
-
-The window is bounded but not small. Cache entries live 45 minutes and GitHub
-installation tokens live 60 minutes from mint, so a token handed out just
-before an entry expires remains usable for roughly a further quarter hour. A
-rolling deployment widens this further: instances not yet replaced continue
-minting through the old credential and writing to the shared key, so replaced
-instances actively consume their entries rather than merely draining a
-pre-existing backlog.
-
-The scenario that motivates the fix is remap-as-privilege-reduction —
-repointing a name from a broad app to a narrow one precisely in order to shrink
-what a set of pipelines can do. For up to an hour afterwards, some builds still
-receive the wide credential. Remap-as-incident-response is less exposed than it
-appears, because uninstalling the suspect app revokes its outstanding
-installation tokens; note though that *rotating an app's private key does not*,
-so "rotate the key and repoint the name" leaves cached tokens working.
-
-Two things justify fixing it despite the narrow preconditions. It costs two
-integers in a key string, so there is no design tension to weigh. More
-importantly, the indirection actively invites the triggering action: the
-principal benefit of a logical name is that what sits behind it can be swapped
-without touching the YAML, which is exactly the operation the cache cannot
-observe. A feature whose main convenience is the thing that breaks it warrants
-the guard.
-
-Keying on the resolved identity rather than a registry-wide fingerprint means
-only the genuinely remapped app's entries are orphaned; every other profile
-stays warm across the change.
-
-Deploying this change orphans every existing cache entry once, because the key
-format changes for the default app too. This is a one-time cold cache, not a
-correctness problem, and is accepted.
-
-### Response and audit
-
-`ProfileToken` gains an `app` field. This is an additive change to a public
-response contract and it lands in the cached payload; entries written by an
-older version deserialize with an empty app, which is harmless because the key
-format changed at the same time and those entries are unreachable.
-
-`audit.Entry` gains the app name. Metrics gain an app-name attribute on the
-existing instruments rather than new instruments — series count multiplies by
-the configured app count, which is bounded and small.
-
-### Compatibility and deployment ordering
-
-A deployment with no `GITHUB_APPS` and a profile configuration with no `app`
-properties behaves as it does today, and makes no additional GitHub API calls
-at startup (Reqs 3, 20).
-
-`parse` sets `KnownFields(true)` so that an unrecognised property fails the
-whole configuration rather than being silently ignored — a deliberate choice to
-prevent a typo from granting unintended access. The consequence for this
-feature is that a profile YAML containing `app:` is rejected *in its entirety*
-by a binary that predates this change, not merely for the profile carrying the
-property. A server that has already loaded a good generation keeps serving it,
-but a cold start drops to `NewDefaultProfiles()` — the default pipeline profile
-with `contents:read` only.
-
-Deployment must therefore roll the binary first and publish the YAML second,
-and a binary rollback requires reverting the YAML too. Req 48 exists to make
-this explicit to operators rather than leaving it to be discovered.
-
-## Testing Decisions
-
-Every module changed by this work gets tests. Prior art:
-`internal/profile/compilation_test.go` for table-driven compilation cases,
-`internal/profile/ref_test.go` for table structure with `expected` struct
-fields, `internal/github/token_test.go` for black-box package testing against a
-mocked GitHub, `internal/vendor/cached_test.go` for cache behaviour, and
-`api_integration_test.go` with `APITestHarness` for full-chain tests.
-
-**Registry construction and organization verification** (`internal/github`) —
-table-driven over configuration inputs: a valid multi-app registry; duplicate
-names; an entry named `default`; a name containing forbidden characters; both
-key sources; neither key source; missing IDs; malformed JSON. Each asserts
-startup failure or success as a whole, per Reqs 5–11. Separately, verification
-outcomes against a mocked installation endpoint: matching login enables,
-differing login disables, case difference still matches, installation query
-failure disables, default-app query failure disables everything (Reqs 12–17).
-A test asserts no installation call is made when no registry is configured
-(Req 20).
-
-**Profile compilation with `app`** (`internal/profile`) — extends the existing
-compilation tables: `app` accepted on an organization profile; accepted on a
-named pipeline profile; `default` rejected; empty string rejected; unknown name
-rejected; disabled app's name rejected; omitted yields the default app. Each
-invalid case asserts the profile lands in `invalidProfiles` and that other
-profiles in the same configuration remain valid — the isolation property is the
-point of Reqs 27–29. A refresh test asserts re-evaluation (Req 31).
-
-**Cache key includes app identity** (`internal/vendor`) — guards the staleness
-defect described under Cache key, which is otherwise invisible until an
-operator remaps a name in production. Two resolved requests identical in
-profile and digest but differing in resolved app must not share an entry
-(Req 38), and a single request round-trips through its own key. Prefer
-asserting observable cache behaviour over asserting the key string, so the
-format stays free to change.
-
-**Vending through the resolved app** (`internal/vendor`) — a resolved request
-carrying a non-default app mints through that app's function, not the default's;
-a resolved request carrying no app mints through the default.
-
-**End-to-end** (`api_integration_test.go`, `TestIntegration` prefix) — a request
-against a profile bound to a second app produces a token minted via that app's
-installation, with the app name present in the response and the audit entry
-(Reqs 34, 40, 41). A request against a profile naming a disabled app returns
-404 (Reqs 28, 30).
-
-Tests document behaviour, not struct shape: no test should assert merely that a
-field exists or is copied where the compiler already guarantees it.
+Roll the binary first and publish the YAML second. `GITHUB_APPS` is
+deploy-blocking: a malformed entry or unparseable key halts a rollout rather than
+degrading it. Rollback requires reverting the YAML first, and restores pre-gate
+cold-start behaviour, so an instance that cannot reach the profile source will
+again serve without a loaded generation. Rollback is not a remedy for an upstream
+outage.
 
 ## Out of Scope
 
-- **Caller-selected apps.** A request-path selector (`/token/{app}/{profile}`
-  or `?app=`) was considered and rejected: it inverts the trust model by
-  letting the caller choose the privilege source, allowing a caller matched to
-  a low-privilege profile to pair it with a high-privilege installation.
-  Association is a property of the profile.
-- **Apps declared in the profile YAML.** Declaring app IDs and key references
-  in YAML would make the profile file a single source of truth and would make
-  the cache key correct for free, but it turns profile-repo write access into
-  credential-selection power, and closing that needs a deployment-side
-  allow-list — which reinstates the split it was meant to remove.
-- **Cross-organization apps.** All apps must share the default app's
-  installation account. Multi-org support is a distinct problem: it would
-  require the repository owner to participate in app selection and in
-  authorization, neither of which this design introduces.
+- **Caller-selected apps.** Association is a property of the profile. A
+  request-path selector would let a caller matched to a low-privilege profile
+  pair it with a high-privilege installation.
+- **Apps declared in the profile YAML.** This would turn profile-repo write
+  access into credential-introduction power. Constraining that requires a
+  deployment-side allow-list, which reinstates the split it would remove.
+- **Deployment-side constraints on which profiles may use an app.** Constraining
+  by profile name does not hold, because the name is chosen by the party being
+  constrained. Constraining which repository scopes an app may be paired with
+  bounds breadth but not depth — a static repository list carries the same
+  permission to the repository that matters — leaves the default app
+  unconstrained, and would appear to describe an app's reach while constraining
+  only what the YAML may say.
+- **Cross-organization apps.** All apps share the default app's installation
+  account. The constraint is organisational rather than protective, since GitHub
+  already prevents an installation token reaching a repository outside its own
+  installation; what it buys is one organization, one audit story, and one
+  meaning for "the organization" in the profile YAML. Multi-organization support
+  is blocked on consent: authorization rests on Buildkite claims, and nothing
+  would establish that a second organization agreed to the first's pipelines
+  minting against it.
 - **Multiple installations of one app.** The registry keys on a credential set,
-  not on an app identity; two entries could legitimately reference the same
-  application ID with different installations, but nothing in this work treats
-  that as a first-class case.
-- **Permission cross-checking.** `GetInstallation` returns the permissions an
-  installation actually holds, and a profile requesting more could be detected
-  at compile time. Not done: GitHub is already the enforcement boundary, and
-  validating profiles against a cached snapshot of GitHub state introduces
-  drift between what a profile says and whether it works.
-- **Repository owner verification.** Deliberately unchanged (Req 36). The
-  installation is the boundary — an app cannot mint for a repository outside
-  its own installation, so a cross-organization repository already fails at
-  GitHub.
-- **Background re-verification or hot registry reload.** Disabled is terminal
-  until restart (Req 19).
-- **Per-app rate limit handling.** Metrics gain an app dimension (Req 42) so
-  per-app pressure is visible, but no rate-limit-aware routing or backoff is
-  introduced.
+  so two entries may reference one application ID with different installations,
+  but this is not treated as a first-class case.
+- **Permission cross-checking.** Neither a profile's requested permissions nor an
+  operator-declared set is validated against the installation's grant. GitHub is
+  the enforcement boundary, and a local check is a copy of state this service
+  does not own — one that would disable an app at an unrelated later restart in
+  response to a change made elsewhere.
+- **Repository owner verification.** The installation is the boundary, so a
+  cross-organization repository fails at GitHub. Caller-scoped profiles do not
+  change this: the caller supplies a bare repository name and the owner is
+  implied by the installation.
+- **Background re-verification and hot registry reload.**
+- **Per-app rate limit handling.** A throttled mint surfaces as a token issuance
+  error carrying GitHub's message, on an audit entry naming the resolved app.
+  Installation token rate limits scale with installation size, so a second app
+  adds budget rather than dividing it.
+- **Flushing cached tokens.** A cached entry may be re-served for the remainder
+  of its 45-minute lifetime, which sits inside the 60-minute token lifetime, so
+  the cache re-delivers a credential that is already live and never extends it
+  beyond expiry. Revoking early means uninstalling the app.
 
-## Further Notes
+## Notes
 
-The site documentation (profile schema, same-organization constraint,
-operational meaning of a disabled app) is published from a separate repository.
-Reqs 46–48 are stated here as deliverables of this feature, but land there;
-Req 45 (`.envrc`) is in this repository.
+Site documentation — profile schema, the same-organization constraint, the
+operational meaning of a disabled app, and the response, audit and telemetry
+contracts — is published from a separate repository. Reqs 52–57 land there; Req
+51 is in this repository.
 
 Multi-line PEM keys inside a JSON environment variable require `\n` escaping.
-This is workable but unpleasant, and it will push realistic multi-app
-deployments toward `privateKeyArn`. Worth watching: if operators struggle with
-it, name-suffixed environment variables
-(`GITHUB_APP_PACKAGES_ID`, `GITHUB_APP_PACKAGES_PRIVATE_KEY`, …) remain
-available as an additive alternative encoding without changing anything else in
-this design.
+This is workable but unpleasant, and multi-app deployments will prefer
+`privateKeyArn` — also recommended because one variable holds every private key,
+so a single disclosure compromises every registered app, and recovery is an
+uninstall and reinstall per app rather than a key rotation, since rotation does
+not revoke outstanding tokens.
 
-The registry deliberately holds no notion of which app *should* serve a given
-repository — that mapping lives entirely in profiles, where the match rules
-that authorize a caller already live. Keeping app selection adjacent to
-permission granting means a reviewer reading one profile sees the complete
-answer to "what can this caller get, and from which credential".
+The registry holds no notion of which app should serve a given repository. That
+mapping lives in profiles, alongside the match rules that authorize a caller, so
+a reviewer reading one profile sees which credential a caller draws on and with
+what permissions. It does not show them the reach: the installation's repository
+selection lives in GitHub, and a profile using `{{all-repositories}}` or
+`{{caller-scoped-repository}}` claims whatever that installation covers.
+
+Implementation direction is in `docs/design-github-app-association.md`.
+

--- a/docs/prd-github-app-association.md
+++ b/docs/prd-github-app-association.md
@@ -1,0 +1,423 @@
+# Multiple GitHub App Association
+
+## Problem Statement
+
+Chinmina Bridge vends every token through a single GitHub App installation,
+fixed at deployment time by `GITHUB_APP_ID` and `GITHUB_APP_INSTALLATION_ID`.
+Every profile — organization or pipeline — draws on that one installation's
+permission grant and repository selection.
+
+This forces an operator who needs a genuinely separate credential to choose
+between two bad options: widen the single app's permissions until it can serve
+every use case (so every pipeline's token is minted by an app that *could*
+write packages, administer repositories, or whatever the broadest consumer
+needed), or run a second Chinmina deployment. The first collapses the blast
+radius that profiles exist to control; the second duplicates configuration,
+telemetry and operational burden.
+
+The permission grant of a GitHub App is also not the only thing that differs
+between use cases. Apps differ in their repository selection, their rate limit
+budget, and who owns and audits them. A team that owns a packages-publishing
+app reasonably wants that app to remain theirs, rather than having its
+permissions folded into a shared credential.
+
+## Solution
+
+An operator may declare additional GitHub Apps in deployment configuration,
+each under a logical name. A profile in the organization profile YAML may then
+name one of those apps, and tokens vended for that profile are minted through
+that app's installation. Profiles that name no app continue to use the existing
+app, which remains the default.
+
+All configured apps must be installed on the same GitHub organization as the
+default app. This is verified once at startup; an app that fails verification
+is disabled, and profiles naming it become unavailable rather than silently
+falling back to a different credential.
+
+Credentials stay in deployment configuration. The profile YAML — which is
+typically writable by a broader group than the deployment environment —
+can only *select* from apps the operator has already installed. Introducing a
+new credential remains a deploy-time privilege.
+
+### Configuration shape
+
+Deployment environment:
+
+```sh
+# unchanged: the default app
+export GITHUB_APP_ID="111"
+export GITHUB_APP_INSTALLATION_ID="222"
+export GITHUB_APP_PRIVATE_KEY_ARN="arn:aws:kms:..."
+
+# new: additional named apps
+export GITHUB_APPS='[
+  {"name":"packages","appId":333,"installationId":444,
+   "privateKeyArn":"arn:aws:kms:..."}
+]'
+```
+
+Organization profile YAML:
+
+```yaml
+organization:
+  profiles:
+    - name: publish-packages
+      app: packages
+      match:
+        - claim: pipeline_slug
+          value: release
+      repositories: [{{all-repositories}}]
+      permissions: [packages:write]
+
+pipeline:
+  defaults:
+    permissions: [contents:read]   # always the default app
+  profiles:
+    - name: build-images
+      app: packages
+      permissions: [packages:write]
+```
+
+## Requirements
+
+### App registry configuration
+
+1. The service shall treat the app described by `GITHUB_APP_ID`,
+   `GITHUB_APP_INSTALLATION_ID` and the existing private key variables as the
+   default app.
+2. Where `GITHUB_APPS` is configured, the service shall construct one
+   authenticated GitHub App client for each entry it contains.
+3. Where `GITHUB_APPS` is not configured, the service shall vend every token
+   through the default app.
+4. Each registry entry shall declare a name, an application ID, an
+   installation ID, and exactly one of a private key or a private key ARN.
+5. If `GITHUB_APPS` is not well-formed JSON, then the service shall fail to
+   start.
+6. If a registry entry declares neither a private key nor a private key ARN,
+   then the service shall fail to start.
+7. If a registry entry declares both a private key and a private key ARN, then
+   the service shall fail to start.
+8. If two registry entries declare the same name, then the service shall fail
+   to start.
+9. If a registry entry is named `default`, then the service shall fail to
+   start.
+10. If a registry entry's name is empty or contains `/`, `:`, whitespace or
+    control characters, then the service shall fail to start.
+11. If a registry entry omits its application ID or its installation ID, then
+    the service shall fail to start.
+
+### Organization verification
+
+12. When the service starts with a configured registry, the service shall
+    determine the default app's installation account login by querying its
+    installation.
+13. When the service starts with a configured registry, the service shall
+    determine each registry app's installation account login by querying its
+    installation.
+14. The service shall compare installation account logins case-insensitively.
+15. If a registry app's installation account login differs from the default
+    app's, then the service shall mark that app disabled.
+16. If a registry app's client cannot be constructed or its installation cannot
+    be queried, then the service shall mark that app disabled.
+17. If the default app's installation cannot be queried, then the service shall
+    mark every registry app disabled.
+18. While an app is disabled, the service shall refuse to vend tokens through
+    it.
+19. The service shall not re-verify a disabled app until the service is
+    restarted.
+20. Where `GITHUB_APPS` is not configured, the service shall query no
+    installation at startup.
+
+### Profile schema and compilation
+
+21. An organization profile shall accept an optional `app` property naming the
+    app its tokens are minted through.
+22. A named pipeline profile shall accept an optional `app` property naming the
+    app its tokens are minted through.
+23. Where a profile declares no `app` property, the service shall mint that
+    profile's tokens through the default app.
+24. The default pipeline profile shall mint its tokens through the default app.
+25. If a profile's `app` property is `default`, then the service shall treat
+    that profile as invalid.
+26. If a profile's `app` property is present and empty, then the service shall
+    treat that profile as invalid.
+27. If a profile's `app` property names an app absent from the registry, then
+    the service shall treat that profile as invalid.
+28. If a profile's `app` property names a disabled app, then the service shall
+    treat that profile as invalid.
+29. When profile compilation marks a profile invalid because of its `app`
+    property, the service shall log a warning naming the profile and the
+    reason.
+30. If a request names a profile that is invalid, then the service shall
+    respond with 404 and a profile-unavailable message.
+31. When the profile configuration is refreshed, the service shall re-evaluate
+    each profile's `app` property against the registry.
+
+### Token vending
+
+32. When a request resolves a profile, the service shall resolve that profile's
+    app to a single minting client at the handler boundary.
+33. The service shall carry the resolved app through the vendor chain in the
+    resolved request value.
+34. When a token is vended, the service shall mint it through the installation
+    of the resolved profile's app.
+35. The service shall retrieve the organization profile configuration file
+    through the default app.
+36. The service shall not check a requested repository's owner against the
+    resolved app's organization.
+
+### Caching
+
+37. The service shall include the resolved app's application ID and
+    installation ID in the token cache key.
+38. If two requests resolve the same profile from the same configuration
+    generation but through different apps, then the service shall not serve
+    either request's cached token to the other.
+39. The service shall record the app a cached token was minted through in the
+    cached entry.
+
+### Observability
+
+40. When a token request completes, the service shall record the resolved app's
+    name on the audit entry.
+41. When a token is vended, the service shall include the minting app's name in
+    the token response.
+42. The service shall attribute token cache outcome and token issuance metrics
+    with the app name.
+43. When the service starts, the service shall log each configured app's name,
+    application ID, installation ID, verified organization and enabled state.
+44. The service shall exclude private key material from all log output.
+
+### Documentation
+
+45. The `.envrc` reference block shall document `GITHUB_APPS` with a commented
+    example alongside the existing `GITHUB_APP_*` variables.
+46. The profile schema documentation shall document the `app` property,
+    including that it may not name `default` and is unavailable on the default
+    pipeline profile.
+47. The documentation shall state the same-organization constraint, how it is
+    verified, and what a disabled app means operationally.
+48. The documentation shall state that a profile configuration using `app`
+    requires a binary that supports it, and that rolling the binary back while
+    such a configuration is published rejects the entire configuration.
+
+## Implementation Decisions
+
+### Registry placement and shape
+
+The registry lives in `internal/github`, alongside `Client`, the signer and the
+token sources. Everything about authenticating as a GitHub App stays in one
+package and no new import edge is created.
+
+The registry is built once during startup and is immutable thereafter. It
+exposes lookup by name, returning a value that carries both the minting
+function and the app's resolved identity (application ID, installation ID,
+verified organization). Construction, KMS/PEM key handling, installation
+verification and the disabled-state decision all stay behind that boundary —
+callers only ask "give me the minter for this name".
+
+Two distinct failure classes, deliberately separated:
+
+- **Malformed configuration** (Reqs 5–11) fails startup, consistent with how
+  `config.Load` already treats invalid configuration. The operator has written
+  something that cannot be interpreted.
+- **An unhealthy app** (Reqs 15–17) disables that app and lets the service
+  start. The configuration is interpretable; one credential is not usable. A
+  single broken app must not take down token vending for every other profile.
+
+There is no background re-verification. A disabled app stays disabled until
+restart, which keeps the registry genuinely immutable after boot and avoids a
+second code path that mutates authorization-relevant state at runtime.
+
+### The default app defines the organization
+
+The default app's installation account login is the reference the others are
+compared against. There is no separately configured organization literal —
+adding a required variable to every existing deployment to express something
+already discoverable is not worth it.
+
+If the default app's own installation cannot be queried, there is nothing to
+compare against, so every registry app is disabled and the default app
+continues to serve (Req 17). This preserves today's behaviour for the default
+app exactly: it has never been verified, and this change does not start gating
+it on a successful GitHub call at boot.
+
+Target type is not constrained. Only the account login is compared, so an
+installation on a user account continues to work as it does today, provided all
+apps share it.
+
+### Where the app name is stored, and where it is resolved
+
+Profile attributes stay pure data. `OrganizationProfileAttr` and
+`PipelineProfileAttr` gain the app *name* — a string — not a live client.
+Compilation validates that name against the registry's known-and-enabled names
+and invalidates the profile if it does not resolve.
+
+The name is turned into a minting client at the handler boundary, in the
+profile resolver, and travels on the resolved request value. This follows the
+doctrine already documented on `vendor.Resolved`: everything a request needs is
+established once, at the boundary, so no downstream stage re-consults mutable
+state and no request can combine one generation's authorization with another's
+credential. It also means the cache key can be computed from the resolved value
+without a second lookup.
+
+Compilation therefore needs the set of usable app names threaded through from
+the registry: `FetchOrganizationProfile` → `load` → `compile`, and through
+`PeriodicRefresh` for the background refresh path. The registry is immutable,
+so this is a value passed at wiring time, not a live dependency.
+
+### Vendor chain
+
+`Vending` currently closes over a single `TokenVendor` bound at wiring time. It
+instead reads the minting function from the resolved request. The composition
+order in `main.go` — Audit → Authorized → Cached → Vending — is unchanged, as is
+the separation of the pipeline and organization chains.
+
+### Cache key
+
+The key becomes configuration digest, application ID, installation ID, profile
+URN. Numeric IDs cannot contain the separator, so the key stays unambiguous.
+
+The YAML digest alone is insufficient: remapping a logical name to different
+credentials in deployment configuration does not change the YAML, so a
+distributed Valkey cache could serve tokens minted by the previous app after a
+redeploy. Including the resolved identity rather than the name means only
+entries for the genuinely remapped app are orphaned.
+
+Deploying this change orphans every existing cache entry once, because the key
+format changes for the default app too. This is a one-time cold cache, not a
+correctness problem, and is accepted.
+
+### Response and audit
+
+`ProfileToken` gains an `app` field. This is an additive change to a public
+response contract and it lands in the cached payload; entries written by an
+older version deserialize with an empty app, which is harmless because the key
+format changed at the same time and those entries are unreachable.
+
+`audit.Entry` gains the app name. Metrics gain an app-name attribute on the
+existing instruments rather than new instruments — series count multiplies by
+the configured app count, which is bounded and small.
+
+### Compatibility and deployment ordering
+
+A deployment with no `GITHUB_APPS` and a profile configuration with no `app`
+properties behaves as it does today, and makes no additional GitHub API calls
+at startup (Reqs 3, 20).
+
+`parse` sets `KnownFields(true)` so that an unrecognised property fails the
+whole configuration rather than being silently ignored — a deliberate choice to
+prevent a typo from granting unintended access. The consequence for this
+feature is that a profile YAML containing `app:` is rejected *in its entirety*
+by a binary that predates this change, not merely for the profile carrying the
+property. A server that has already loaded a good generation keeps serving it,
+but a cold start drops to `NewDefaultProfiles()` — the default pipeline profile
+with `contents:read` only.
+
+Deployment must therefore roll the binary first and publish the YAML second,
+and a binary rollback requires reverting the YAML too. Req 48 exists to make
+this explicit to operators rather than leaving it to be discovered.
+
+## Testing Decisions
+
+Every module changed by this work gets tests. Prior art:
+`internal/profile/compilation_test.go` for table-driven compilation cases,
+`internal/profile/ref_test.go` for table structure with `expected` struct
+fields, `internal/github/token_test.go` for black-box package testing against a
+mocked GitHub, `internal/vendor/cached_test.go` for cache behaviour, and
+`api_integration_test.go` with `APITestHarness` for full-chain tests.
+
+**Registry construction and organization verification** (`internal/github`) —
+table-driven over configuration inputs: a valid multi-app registry; duplicate
+names; an entry named `default`; a name containing forbidden characters; both
+key sources; neither key source; missing IDs; malformed JSON. Each asserts
+startup failure or success as a whole, per Reqs 5–11. Separately, verification
+outcomes against a mocked installation endpoint: matching login enables,
+differing login disables, case difference still matches, installation query
+failure disables, default-app query failure disables everything (Reqs 12–17).
+A test asserts no installation call is made when no registry is configured
+(Req 20).
+
+**Profile compilation with `app`** (`internal/profile`) — extends the existing
+compilation tables: `app` accepted on an organization profile; accepted on a
+named pipeline profile; `default` rejected; empty string rejected; unknown name
+rejected; disabled app's name rejected; omitted yields the default app. Each
+invalid case asserts the profile lands in `invalidProfiles` and that other
+profiles in the same configuration remain valid — the isolation property is the
+point of Reqs 27–29. A refresh test asserts re-evaluation (Req 31).
+
+**Cache key includes app identity** (`internal/vendor`) — the key guard for the
+hole this design introduces. Two resolved requests identical in profile and
+digest but differing in resolved app must not share an entry (Req 38), and a
+single request round-trips through its own key. Prefer asserting observable
+cache behaviour over asserting the key string, so the format stays free to
+change.
+
+**Vending through the resolved app** (`internal/vendor`) — a resolved request
+carrying a non-default app mints through that app's function, not the default's;
+a resolved request carrying no app mints through the default.
+
+**End-to-end** (`api_integration_test.go`, `TestIntegration` prefix) — a request
+against a profile bound to a second app produces a token minted via that app's
+installation, with the app name present in the response and the audit entry
+(Reqs 34, 40, 41). A request against a profile naming a disabled app returns
+404 (Reqs 28, 30).
+
+Tests document behaviour, not struct shape: no test should assert merely that a
+field exists or is copied where the compiler already guarantees it.
+
+## Out of Scope
+
+- **Caller-selected apps.** A request-path selector (`/token/{app}/{profile}`
+  or `?app=`) was considered and rejected: it inverts the trust model by
+  letting the caller choose the privilege source, allowing a caller matched to
+  a low-privilege profile to pair it with a high-privilege installation.
+  Association is a property of the profile.
+- **Apps declared in the profile YAML.** Declaring app IDs and key references
+  in YAML would make the profile file a single source of truth and would make
+  the cache key correct for free, but it turns profile-repo write access into
+  credential-selection power, and closing that needs a deployment-side
+  allow-list — which reinstates the split it was meant to remove.
+- **Cross-organization apps.** All apps must share the default app's
+  installation account. Multi-org support is a distinct problem: it would
+  require the repository owner to participate in app selection and in
+  authorization, neither of which this design introduces.
+- **Multiple installations of one app.** The registry keys on a credential set,
+  not on an app identity; two entries could legitimately reference the same
+  application ID with different installations, but nothing in this work treats
+  that as a first-class case.
+- **Permission cross-checking.** `GetInstallation` returns the permissions an
+  installation actually holds, and a profile requesting more could be detected
+  at compile time. Not done: GitHub is already the enforcement boundary, and
+  validating profiles against a cached snapshot of GitHub state introduces
+  drift between what a profile says and whether it works.
+- **Repository owner verification.** Deliberately unchanged (Req 36). The
+  installation is the boundary — an app cannot mint for a repository outside
+  its own installation, so a cross-organization repository already fails at
+  GitHub.
+- **Background re-verification or hot registry reload.** Disabled is terminal
+  until restart (Req 19).
+- **Per-app rate limit handling.** Metrics gain an app dimension (Req 42) so
+  per-app pressure is visible, but no rate-limit-aware routing or backoff is
+  introduced.
+
+## Further Notes
+
+The site documentation (profile schema, same-organization constraint,
+operational meaning of a disabled app) is published from a separate repository.
+Reqs 46–48 are stated here as deliverables of this feature, but land there;
+Req 45 (`.envrc`) is in this repository.
+
+Multi-line PEM keys inside a JSON environment variable require `\n` escaping.
+This is workable but unpleasant, and it will push realistic multi-app
+deployments toward `privateKeyArn`. Worth watching: if operators struggle with
+it, name-suffixed environment variables
+(`GITHUB_APP_PACKAGES_ID`, `GITHUB_APP_PACKAGES_PRIVATE_KEY`, …) remain
+available as an additive alternative encoding without changing anything else in
+this design.
+
+The registry deliberately holds no notion of which app *should* serve a given
+repository — that mapping lives entirely in profiles, where the match rules
+that authorize a caller already live. Keeping app selection adjacent to
+permission granting means a reviewer reading one profile sees the complete
+answer to "what can this caller get, and from which credential".

--- a/plans/github-app-association.md
+++ b/plans/github-app-association.md
@@ -52,7 +52,7 @@ rewording; no separate traceability mapping is needed.
 Phases are the planning/acceptance-criteria unit; PRs may combine phases where
 they are not independently shippable:
 
-- **PR 1** — Phase 1 (edge-triggered invalid-profile logging)
+- **PR 1** — Phase 1 (invalidity reason on the audit entry)
 - **PR 2** — Phase 2 (shutdown hooks on every startup exit path)
 - **PR 3** — Phase 3 (startup gate)
 - **PR 4** — Phase 4 (config-validation/route-construction split, transport
@@ -81,64 +81,46 @@ relative to each other, ahead of the feature itself.
 
 ---
 
-## Phase 1: Edge-triggered invalid-profile logging; `ProfileUnavailableError` carries its cause
+## Phase 1: `ProfileUnavailableError` carries its cause onto the audit entry
 
-**EARS requirements**: R28, R44
+**EARS requirements**: R44
 
 ### Why this phase exists
 
-Compilation logs its batched invalid-profile warning on every compile, and
-compilation runs on every refresh — so today, one permanently-invalid profile
-(for any existing reason, e.g. a bad match rule) produces a warning every
-refresh interval for the life of the process. This is worth fixing on its own,
-and it becomes load-bearing once app-caused invalidity exists in Phase 6:
-`ProfileUnavailableError` currently discards its cause, and once logging is
-edge-triggered, the audit entry becomes the only timely record of *why* a
-profile is invalid. Both the cause-capture mechanism and its wiring onto the
-audit entry land here — neither needs an app or a registry to exist, since
-profiles can already be invalid today for pre-existing reasons (e.g. a bad
-match rule).
+`ProfileUnavailableError` currently discards its cause — the caller-facing
+message comes from a separate method, so a request against an unavailable
+profile gives no durable record of *why*. This phase wires that reason onto
+the audit entry. It doesn't need an app or a registry to exist: profiles can
+already be invalid today for pre-existing reasons (e.g. a bad match rule), so
+this lands and is verifiable independent of the rest of the feature.
+
+Compilation's batched invalid-profile warning still logs on every compile, as
+it does today — this phase does not touch that logging path or attempt to
+deduplicate it. That's a deliberate scope cut: only the audit-entry wiring is
+in scope here.
 
 ### Locked decisions (non-negotiable)
 
-- The comparison lives in the profile store (`ProfileStoreOf`) — the only
-  component holding both the old and new generation, already under a write
-  lock.
-- Diff the profile-name-to-reason mapping, not just the set of invalid names —
-  a profile whose reason changes must be logged again.
-- Diff on the mapping, not the digest — an unchanged YAML whose validity flips
-  must still be caught; the store update runs even when the digest is
-  unchanged.
 - `ProfileUnavailableError` gains its wrapped cause without changing the
   caller-facing message or HTTP behavior it already produces.
 - When a request resolves an unavailable profile, the audit entry for that
   request records the invalidity reason from the error's cause (R44) — this
   wiring does not depend on the app registry existing; it applies to any
   invalidity reason, today's included.
-- No sensitive data enters the logged reason string or the audit entry.
+- No sensitive data enters the audit entry.
 
 ### Flex zone (implementation choice allowed)
 
-- Exact diffing data structure (map vs. sorted slice comparison).
 - Whether the cause is exposed via `Unwrap()` or a dedicated accessor.
-- Log level and field layout for the batched warning.
 
 ### End-to-end behaviour to implement
 
-Two successive profile refreshes with the same invalid profile (same name,
-same reason) log the warning once, not twice. A refresh whose invalid set or
-reasons change logs again. `ProfileUnavailableError` retains its cause
-internally even though the HTTP response and caller-facing message are
-unchanged.
+`ProfileUnavailableError` retains its cause internally even though the HTTP
+response and caller-facing message are unchanged. A request against an
+unavailable profile has the invalidity reason recorded on its audit entry.
 
 ### Acceptance criteria
 
-- [ ] `[observable]` A profile invalid for the same reason across two
-      consecutive refreshes produces exactly one warning log line.
-- [ ] `[observable]` A profile whose invalidity reason changes between
-      refreshes (same name, different cause) produces a new warning log line.
-- [ ] `[observable]` A profile that becomes valid, then invalid again, is
-      logged again (not permanently suppressed).
 - [ ] `[structural]` `ProfileUnavailableError` exposes its wrapped cause
       without changing the string returned to callers.
 - [ ] `[structural]` Existing 404 behavior and caller-facing message for an
@@ -149,22 +131,18 @@ unchanged.
 
 ### Verification
 
-`just test` on `internal/profile`; a new table-driven test asserting log-call
-counts across synthetic refresh sequences (unchanged invalid set → one log;
-changed reason → second log).
+`just test` on `internal/profile`, asserting the audit entry's recorded
+reason for a request against an invalid profile.
 
 ### Regression watchpoints
 
-Existing profile refresh tests (e.g.
-`TestIntegrationProfileRefresh_ServesNoMixedGeneration`) must keep passing;
-the *first* log of a newly-invalid profile must not be accidentally
-suppressed.
+Existing profile refresh and invalid-profile tests (e.g.
+`TestIntegrationProfileRefresh_ServesNoMixedGeneration`) must keep passing
+unchanged — this phase adds a field to the audit entry, nothing else.
 
 ### Replan triggers
 
-If diffing by reason string proves unstable (e.g. a wrapped error's message
-contains non-deterministic content), revisit the comparison key before
-proceeding.
+None expected — narrow, low-risk change.
 
 ---
 
@@ -826,7 +804,7 @@ None.
 | R1–R11 | Phase 5 | App registry configuration |
 | R12–R19 | Phase 5 | Organization verification |
 | R20–R27 | Phase 6 | Profile schema and compilation |
-| R28 | Phase 1 | Edge-triggered invalid-profile logging |
+| R28 | *(descoped)* | Edge-triggered dedup logging was cut from Phase 1 by explicit decision — the batched invalid-profile warning keeps logging on every compile, as it does today; not implemented by this plan |
 | R29–R30 | Phase 6 | Invalid-profile request handling; refresh-path validity |
 | R31–R36 | Phase 7 | Token vending, resolution and the cache-bypass guard |
 | R37–R39 | Phase 7 | Caching |

--- a/plans/github-app-association.md
+++ b/plans/github-app-association.md
@@ -57,11 +57,13 @@ they are not independently shippable:
 - **PR 3** — Phase 3 (startup gate)
 - **PR 4** — Phase 4 (config-validation/route-construction split, transport
   ordering)
-- **PR 5** — Phases 5–7 combined (registry; profile schema, resolution,
-  cache-safe vending, response/audit attribution; span attributes for profile
-  counts) — combined because Phase 6 cannot exist without Phase 5's registry,
-  and Phase 7 is a small addition once Phase 6's compilation changes land.
-- **PR 6** — Phase 8 (`.envrc` documentation only — R51). Reqs 52–57 are
+- **PR 5** — Phases 5–8 combined (registry; profile schema and compilation;
+  request-time resolution and cache-safe vending; span attributes for profile
+  counts) — combined because Phase 6 cannot validate an `app` property without
+  Phase 5's registry, Phase 7 cannot resolve or cache-key an identity without
+  Phase 6's compiled attribute, and Phase 8 is a small addition once Phase 6's
+  compilation changes exist.
+- **PR 6** — Phase 9 (`.envrc` documentation only — R51). Reqs 52–57 are
   out of scope for this repository; they are published from the separate
   `chinmina.github.io` documentation repository.
 
@@ -81,8 +83,7 @@ relative to each other, ahead of the feature itself.
 
 ## Phase 1: Edge-triggered invalid-profile logging; `ProfileUnavailableError` carries its cause
 
-**EARS requirements**: R28, R44 (foundation — full audit-entry wiring lands in
-Phase 6)
+**EARS requirements**: R28, R44
 
 ### Why this phase exists
 
@@ -93,7 +94,10 @@ refresh interval for the life of the process. This is worth fixing on its own,
 and it becomes load-bearing once app-caused invalidity exists in Phase 6:
 `ProfileUnavailableError` currently discards its cause, and once logging is
 edge-triggered, the audit entry becomes the only timely record of *why* a
-profile is invalid.
+profile is invalid. Both the cause-capture mechanism and its wiring onto the
+audit entry land here — neither needs an app or a registry to exist, since
+profiles can already be invalid today for pre-existing reasons (e.g. a bad
+match rule).
 
 ### Locked decisions (non-negotiable)
 
@@ -107,7 +111,11 @@ profile is invalid.
   unchanged.
 - `ProfileUnavailableError` gains its wrapped cause without changing the
   caller-facing message or HTTP behavior it already produces.
-- No sensitive data enters the logged reason string.
+- When a request resolves an unavailable profile, the audit entry for that
+  request records the invalidity reason from the error's cause (R44) — this
+  wiring does not depend on the app registry existing; it applies to any
+  invalidity reason, today's included.
+- No sensitive data enters the logged reason string or the audit entry.
 
 ### Flex zone (implementation choice allowed)
 
@@ -135,6 +143,9 @@ unchanged.
       without changing the string returned to callers.
 - [ ] `[structural]` Existing 404 behavior and caller-facing message for an
       unavailable profile are unchanged.
+- [ ] `[observable]` A request against a profile invalid for an existing
+      reason (e.g. a bad match rule) has that reason recorded on the audit
+      entry.
 
 ### Verification
 
@@ -258,7 +269,7 @@ exactly what R40/R41 require.
 
 This couples startup to profile-source availability for existing deployments
 using an organization profile location — a real behavior change. Confirmed
-intentional per the PRD; Phase 8's documentation should call it out so it
+intentional per the PRD; Phase 9's documentation should call it out so it
 isn't mistaken for a regression during rollout.
 
 ### End-to-end behaviour to implement
@@ -500,23 +511,21 @@ sub-step with its own estimate before continuing into verification tests.
 
 ---
 
-## Phase 6: Profile schema (`app`), resolution, cache-safe vending, response/audit attribution
+## Phase 6: Profile schema — `app` property & compilation
 
-**EARS requirements**: R20–R27, R29–R39, R43, R45, R46
+**EARS requirements**: R20–R27, R29, R30
 
 **Carry-forward**: re-verify Phase 5 in full (`just test` on `internal/github`,
 `just integration`) — this phase is the registry's first consumer.
 
 ### Why this phase exists
 
-This is where the registry becomes usable: profiles can name an app, requests
-resolve that name to an identity at the handler boundary, tokens mint through
-the resolved installation, and every downstream surface — cache, response,
-audit — reflects which app served the request. Resolution and the cache key
-are inseparable: a resolved identity that isn't part of the cache key means a
-cache hit can serve a token minted through an app that has since been
-disabled, which is exactly what R36 forbids. Splitting this into two phases
-would let one land in a state where that guarantee doesn't hold.
+Before requests can resolve or mint through a named app, profiles need a way
+to declare one, and the service needs to validate that declaration against the
+registry at compile time. This is deliberately scoped to compilation only —
+no request-serving code changes here — so it can be fully exercised through
+table-driven compilation tests and a refresh test, without touching the
+request-serving hot path that Phase 7 owns.
 
 ### Locked decisions (non-negotiable)
 
@@ -525,14 +534,93 @@ would let one land in a state where that guarantee doesn't hold.
   (R20, R21).
 - Normalize in compilation, not at the request boundary: an omitted `app` and
   an explicit `app: default` compile to the same attribute value, so they are
-  indistinguishable downstream and produce identical audit attribution (R22,
-  R23).
+  indistinguishable downstream and produce identical audit attribution once
+  Phase 7 reads it (R22, R23).
 - The default pipeline profile always mints through the default app and has no
   `app` property (R24).
 - Empty `app` string is invalid; a name absent from the registry is invalid; a
   name naming a disabled app is invalid (R25, R26, R27). Compilation asks the
-  registry for its set of usable names — the same function the request path
-  uses to resolve — so both share one enforcement point.
+  registry for its set of usable names — the same function Phase 7's request
+  path will use to resolve — so both share one enforcement point.
+- Compilation threads the registry's usable-names set through
+  `FetchOrganizationProfile` → `load` → `compile`, *and* through
+  `PeriodicRefresh` for the background refresh path — missing the background
+  path is the specific failure R30 exists to prevent (profiles valid for one
+  refresh interval, invalid after, unchanged digest, generation swap logging
+  only at debug level).
+- A request naming an invalid profile (including one whose app is unknown or
+  disabled) returns 404 with the reason on the audit entry, using the
+  cause-capture and audit wiring already built in Phase 1 (R29).
+  Other profiles in the same configuration remain valid (isolation).
+- No sensitive data in any surface this phase touches.
+
+### Flex zone (implementation choice allowed)
+
+- Exact plumbing of the registry's usable-names set through the compilation
+  call chain.
+- How validation error messages describe the rejection reason (feeds Phase 1's
+  logging and audit-entry wiring).
+
+### End-to-end behaviour to implement
+
+An organization or named pipeline profile may declare `app: <name>`.
+Compilation validates the name against the registry's usable-names set,
+normalizes an omitted `app` and an explicit `app: default` to the same
+attribute value, and revalidates on every background refresh.
+
+### Acceptance criteria
+
+- [ ] `[observable]` A profile declaring `app: <enabled-name>` compiles valid.
+- [ ] `[observable]` Two configurations differing only in the presence of
+      `app: default` compile to equal profile attributes.
+- [ ] `[observable]` A profile with an empty `app` string, an unknown app
+      name, or a disabled app's name is invalid; other profiles in the same
+      configuration remain valid; a request against it returns 404 with the
+      reason on the audit entry.
+- [ ] `[observable]` The default pipeline profile mints through the default
+      app and does not accept an `app` property.
+- [ ] `[observable]` A profile naming an enabled app remains valid across a
+      background profile refresh (R30 regression guard).
+
+### Verification
+
+`just test` on `internal/profile` — extends the existing compilation tables
+with `app`-bearing cases; a refresh test driving `PeriodicRefresh` and
+asserting continued validity.
+
+### Regression watchpoints
+
+Existing profile compilation tests without an `app` property must keep
+passing unchanged.
+
+### Replan triggers
+
+If threading the registry's usable-names set through both the synchronous
+load path and `PeriodicRefresh`'s background path needs a broader interface
+change than expected, pause before R30's guarantee ends up only
+half-implemented.
+
+---
+
+## Phase 7: Request-time app resolution & cache-safe vending
+
+**EARS requirements**: R31–R39, R43, R45, R46
+
+**Carry-forward**: re-verify Phase 6 in full (`just test` on
+`internal/profile`) — this phase is Phase 6's first consumer at request time.
+
+### Why this phase exists
+
+Resolution and the cache key are inseparable, which is why they're one phase
+rather than two: a resolved identity that isn't part of the cache key means a
+cache hit can serve a token minted through an app that has since been
+disabled, which is exactly what R36 forbids. This is where the registry and
+the compiled `app` attribute from Phase 6 become live at request time — an app
+name resolves to an identity, tokens mint through it, and the cache, response,
+and audit entry all key off that same identity.
+
+### Locked decisions (non-negotiable)
+
 - The name resolves to an app identity (name, application ID, installation ID)
   at the handler boundary, in the profile resolver — never inside the
   `Vending` stage. The chain is Audit → Authorized → Cached → Vending, and
@@ -541,18 +629,12 @@ would let one land in a state where that guarantee doesn't hold.
   that lookup the guard that runs on every request (R31; satisfies R36's
   final clause).
 - A profile resolved but whose app cannot be resolved in the registry is a
-  500, not a 403/404: reaching that state means compilation should already
-  have invalidated the profile — the service's defect, not GitHub's denial,
-  matching the shape of existing unresolved-scope guards (R36).
+  500, not a 403/404: reaching that state means Phase 6's compilation should
+  already have invalidated the profile — the service's defect, not GitHub's
+  denial, matching the shape of existing unresolved-scope guards (R36).
 - The resolved identity is data (name, application ID, installation ID), not a
   closure — no credential is captured in a value that flows into a cache
   payload (R32).
-- Compilation threads the registry's usable-names set through
-  `FetchOrganizationProfile` → `load` → `compile`, *and* through
-  `PeriodicRefresh` for the background refresh path — missing the background
-  path is the specific failure Req 30 exists to prevent (profiles valid for
-  one refresh interval, invalid after, unchanged digest, generation swap
-  logging only at debug level).
 - The organization profile configuration file is always retrieved through the
   default app, never a per-profile app (R34).
 - The service does not check a requested repository's owner against the
@@ -568,20 +650,14 @@ would let one land in a state where that guarantee doesn't hold.
   test rather than a runtime check.
 - Token response includes the minting app's name (R45); the audit entry
   records the resolved app's name at resolution time, so every downstream
-  outcome — including failures — carries it (R43); the token cache outcome
-  metric is attributed with the app name (R46).
-- A profile invalid because its named app is disabled fails *before* an app is
-  resolved, so its audit entry carries the invalidity reason from Phase 1
-  (R44) rather than an app name — now load-bearing, since Phase 1's
-  edge-triggered logging means the audit entry is the only timely record.
+  outcome — including failures reached after resolution — carries it (R43);
+  the token cache outcome metric is attributed with the app name (R46).
 - Deploying this orphans every existing cache entry once (key format changes
   for the default app too) — accepted as a one-time cold cache.
 - No sensitive data in any surface this phase touches.
 
 ### Flex zone (implementation choice allowed)
 
-- Exact plumbing of the registry's usable-names set through the compilation
-  call chain.
 - Internal shape of the resolved identity value and where in the resolver it
   attaches to the resolved request value.
 
@@ -598,13 +674,11 @@ on this phase, not just one acceptance criterion among many.
 
 ### End-to-end behaviour to implement
 
-An organization or named pipeline profile may declare `app: <name>`. A
-request against such a profile resolves the name to an app identity, mints
-its token through that app's installation, includes the app's name in the
-response and audit entry, and caches the result under a key that includes the
-app's identity. A profile naming a disabled or unknown app is invalid and
-returns 404 with the reason on the audit entry. A previously cached token is
-never served once its app becomes unresolvable.
+A request against a profile bound to an app (from Phase 6) resolves the name
+to an app identity, mints its token through that app's installation, includes
+the app's name in the response and audit entry, and caches the result under a
+key that includes the app's identity. A previously cached token is never
+served once its app becomes unresolvable.
 
 ### Acceptance criteria
 
@@ -614,47 +688,37 @@ never served once its app becomes unresolvable.
 - [ ] `[observable]` A request against the default pipeline profile, and one
       against a profile with no `app` property, both mint through the default
       app.
-- [ ] `[observable]` Two configurations differing only in the presence of
-      `app: default` compile to equal profile attributes.
-- [ ] `[observable]` A profile naming an unknown or disabled app is invalid;
-      the request returns 404 with the reason on the audit entry; other
-      profiles in the same configuration remain valid.
 - [ ] `[observable]` Priming a cache entry, then making the registry unable to
       resolve that profile's app, then repeating the request: returns 500,
       and the previously cached token is not served.
 - [ ] `[observable]` Two requests resolving the same profile/digest through two
       different app identities do not share a cache entry.
-- [ ] `[observable]` A profile naming an enabled app remains valid across a
-      background profile refresh.
+- [ ] `[observable]` The token cache outcome metric is attributed with the
+      resolved app's name.
 - [ ] `[structural]` Resolution occurs in the profile resolver, not inside
       `Vending` (verified by the cache-bypass test above).
 
 ### Verification
 
-`just test` on `internal/profile` and `internal/vendor`; `just integration`
-for the end-to-end cases (request via second app, disabled-app 404,
-cache-bypass 500); an integration test issuing parallel requests across two
-apps under `go test -race`, guarding against future lazily-populated registry
-state.
+`just test` on `internal/vendor`; `just integration` for the end-to-end cases
+(request via second app, cache-bypass 500); an integration test issuing
+parallel requests across two apps under `go test -race`, guarding against
+future lazily-populated registry state.
 
 ### Regression watchpoints
 
 Single-app deployments (no `GITHUB_APPS`, no `app` properties) must behave
 exactly as before — same cache behavior modulo the one-time cold cache, same
 response shape, same audit shape (app name now always present, naming
-"default"). Existing profile-compilation and vendor-chain tests must keep
-passing.
+"default"). Existing vendor-chain tests must keep passing.
 
 ### Replan triggers
 
-If threading the registry's usable-names set through both the synchronous
-load path and `PeriodicRefresh`'s background path needs a broader interface
-change than expected, pause before Req 30's guarantee ends up only
-half-implemented.
+None beyond the cache-bypass test already called out as this phase's gate.
 
 ---
 
-## Phase 7: Span attributes for valid/invalid profile counts
+## Phase 8: Span attributes for valid/invalid profile counts
 
 **EARS requirements**: R47
 
@@ -704,7 +768,7 @@ exist.
 
 ---
 
-## Phase 8: Documentation
+## Phase 9: Documentation
 
 **EARS requirements**: R51 (only requirement in scope for this repository)
 
@@ -764,14 +828,14 @@ None.
 | R20–R27 | Phase 6 | Profile schema and compilation |
 | R28 | Phase 1 | Edge-triggered invalid-profile logging |
 | R29–R30 | Phase 6 | Invalid-profile request handling; refresh-path validity |
-| R31–R36 | Phase 6 | Token vending, resolution and the cache-bypass guard |
-| R37–R39 | Phase 6 | Caching |
+| R31–R36 | Phase 7 | Token vending, resolution and the cache-bypass guard |
+| R37–R39 | Phase 7 | Caching |
 | R40–R41 | Phase 3 | Startup gate |
 | R42 | Phase 2 | Shutdown hooks on every exit path |
-| R43 | Phase 6 | Audit entry records resolved app name |
-| R44 | Phase 1, Phase 6 | Cause captured in Phase 1; wired into audit entry in Phase 6 |
-| R45–R46 | Phase 6 | Response and cache-metric attribution |
-| R47 | Phase 7 | Span attributes for profile counts |
+| R43 | Phase 7 | Audit entry records resolved app name |
+| R44 | Phase 1 | Cause captured and wired into the audit entry — no app/registry dependency |
+| R45–R46 | Phase 7 | Response and cache-metric attribution |
+| R47 | Phase 8 | Span attributes for profile counts |
 | R48–R50 | Phase 5 | Registry logging and redaction |
-| R51 | Phase 8 | `.envrc` documentation (this repository) |
+| R51 | Phase 9 | `.envrc` documentation (this repository) |
 | R52–R57 | *(out of scope)* | Published from the separate documentation repository |

--- a/plans/github-app-association.md
+++ b/plans/github-app-association.md
@@ -1,0 +1,777 @@
+# Plan: Multiple GitHub App Association
+
+> Source PRD: `docs/prd-github-app-association.md`, implementation direction in
+> `docs/github-app-association.design-notes.md`
+
+## Architectural decisions
+
+Durable decisions that apply across all phases:
+
+- **Config**: `GITHUB_APPS` is the only new environment variable — a JSON array of
+  named app entries (`name`, `appId`, `installationId`, exactly one of
+  `privateKey`/`privateKeyArn`). Existing `GITHUB_APP_*` variables remain the
+  default app, unchanged.
+- **Registry**: lives in `internal/github`, built once at startup, immutable
+  thereafter (value receivers over an unexported map). Lookup by name returns
+  not-found for a disabled app — enabled state is exposed only for logging, so
+  no caller can accidentally resolve a disabled app by forgetting to check a
+  flag.
+- **Two entry types**: a configuration entry (name, application ID,
+  installation ID, key source — implements `slog.LogValuer`, never logs key
+  material) and a resolved entry (verification results, no key material).
+- **Same-organization verification**: the default app's installation account ID
+  is the reference; every registry app's account ID is queried concurrently and
+  compared by account ID (not login — logins are renameable and claimable).
+- **Disabled is terminal until restart** — no background re-verification, no hot
+  registry reload.
+- **Resolution point**: an app name resolves to an identity (name, application
+  ID, installation ID) once, in the profile resolver at the handler boundary —
+  never inside the `Vending` stage of the chain, because `Cached` short-circuits
+  on a hit before `Vending` runs. This is the single guard that prevents a
+  cache hit from serving a token through an app that has since been disabled.
+- **Cache key**: `digest:applicationID:installationID:profileURN`. Deploying
+  this changes the key format for the default app too — every existing cache
+  entry is orphaned once, accepted as a one-time cold cache.
+- **No sensitive data in any observable surface, in any phase.** No private key,
+  no private key ARN, and no other secret ever appears in a log line, error
+  message, audit entry, trace span, or HTTP response, in this feature or in any
+  phase that touches logging. This is a standing constraint on every phase
+  below, not just the registry phase.
+- **Service boundary**: the service records what it decided and when; it does
+  not snapshot or cross-check external state (GitHub App permissions,
+  installation repository selection) that it neither owns nor rechecks.
+
+## Normalization notes
+
+The PRD's requirements are already written in EARS syntax and numbered 1–57 in
+the source document. They are referenced directly here as `R1`–`R57` with no
+rewording; no separate traceability mapping is needed.
+
+## Suggested PR grouping
+
+Phases are the planning/acceptance-criteria unit; PRs may combine phases where
+they are not independently shippable:
+
+- **PR 1** — Phase 1 (edge-triggered invalid-profile logging)
+- **PR 2** — Phase 2 (shutdown hooks on every startup exit path)
+- **PR 3** — Phase 3 (startup gate)
+- **PR 4** — Phase 4 (config-validation/route-construction split, transport
+  ordering)
+- **PR 5** — Phases 5–7 combined (registry; profile schema, resolution,
+  cache-safe vending, response/audit attribution; span attributes for profile
+  counts) — combined because Phase 6 cannot exist without Phase 5's registry,
+  and Phase 7 is a small addition once Phase 6's compilation changes land.
+- **PR 6** — Phase 8 (`.envrc` documentation only — R51). Reqs 52–57 are
+  out of scope for this repository; they are published from the separate
+  `chinmina.github.io` documentation repository.
+
+Phases 1–4 are independent of `GITHUB_APPS` entirely and can land in any order
+relative to each other, ahead of the feature itself.
+
+## P0 baseline and standard quality gate
+
+- [ ] `just agent` (format, lint, test, build) — run before Phase 1; must pass
+- [ ] If it fails, stabilize before starting Phase 1
+- [ ] Re-run `just agent` before marking each phase complete
+- [ ] `just test`, `just integration`, and (where a phase changes concurrent or
+      timing-sensitive code) `go test ./... -race` are part of "must pass" for
+      the phases that touch those areas
+
+---
+
+## Phase 1: Edge-triggered invalid-profile logging; `ProfileUnavailableError` carries its cause
+
+**EARS requirements**: R28, R44 (foundation — full audit-entry wiring lands in
+Phase 6)
+
+### Why this phase exists
+
+Compilation logs its batched invalid-profile warning on every compile, and
+compilation runs on every refresh — so today, one permanently-invalid profile
+(for any existing reason, e.g. a bad match rule) produces a warning every
+refresh interval for the life of the process. This is worth fixing on its own,
+and it becomes load-bearing once app-caused invalidity exists in Phase 6:
+`ProfileUnavailableError` currently discards its cause, and once logging is
+edge-triggered, the audit entry becomes the only timely record of *why* a
+profile is invalid.
+
+### Locked decisions (non-negotiable)
+
+- The comparison lives in the profile store (`ProfileStoreOf`) — the only
+  component holding both the old and new generation, already under a write
+  lock.
+- Diff the profile-name-to-reason mapping, not just the set of invalid names —
+  a profile whose reason changes must be logged again.
+- Diff on the mapping, not the digest — an unchanged YAML whose validity flips
+  must still be caught; the store update runs even when the digest is
+  unchanged.
+- `ProfileUnavailableError` gains its wrapped cause without changing the
+  caller-facing message or HTTP behavior it already produces.
+- No sensitive data enters the logged reason string.
+
+### Flex zone (implementation choice allowed)
+
+- Exact diffing data structure (map vs. sorted slice comparison).
+- Whether the cause is exposed via `Unwrap()` or a dedicated accessor.
+- Log level and field layout for the batched warning.
+
+### End-to-end behaviour to implement
+
+Two successive profile refreshes with the same invalid profile (same name,
+same reason) log the warning once, not twice. A refresh whose invalid set or
+reasons change logs again. `ProfileUnavailableError` retains its cause
+internally even though the HTTP response and caller-facing message are
+unchanged.
+
+### Acceptance criteria
+
+- [ ] `[observable]` A profile invalid for the same reason across two
+      consecutive refreshes produces exactly one warning log line.
+- [ ] `[observable]` A profile whose invalidity reason changes between
+      refreshes (same name, different cause) produces a new warning log line.
+- [ ] `[observable]` A profile that becomes valid, then invalid again, is
+      logged again (not permanently suppressed).
+- [ ] `[structural]` `ProfileUnavailableError` exposes its wrapped cause
+      without changing the string returned to callers.
+- [ ] `[structural]` Existing 404 behavior and caller-facing message for an
+      unavailable profile are unchanged.
+
+### Verification
+
+`just test` on `internal/profile`; a new table-driven test asserting log-call
+counts across synthetic refresh sequences (unchanged invalid set → one log;
+changed reason → second log).
+
+### Regression watchpoints
+
+Existing profile refresh tests (e.g.
+`TestIntegrationProfileRefresh_ServesNoMixedGeneration`) must keep passing;
+the *first* log of a newly-invalid profile must not be accidentally
+suppressed.
+
+### Replan triggers
+
+If diffing by reason string proves unstable (e.g. a wrapped error's message
+contains non-deterministic content), revisit the comparison key before
+proceeding.
+
+---
+
+## Phase 2: Shutdown hooks run on every startup exit path
+
+**EARS requirements**: R42
+
+**Carry-forward**: re-verify Phase 1's refresh-logging behavior still passes
+(`just test` on `internal/profile`).
+
+### Why this phase exists
+
+Shutdown hooks currently run only via `server.RegisterOnShutdown`, which fires
+only when `server.Shutdown(ctx)` runs from the HTTP serving path. Any exit
+before serving starts — a configuration failure today, or the startup gate
+(Phase 3) and default-app verification failure (Phase 5) added later — discards
+buffered telemetry describing the failure and leaks a distributed cache
+connection per restart. Fixing this now means every later phase that adds a
+new startup-exit path inherits correct behavior for free.
+
+### Locked decisions (non-negotiable)
+
+- Shutdown hooks execute exactly once, on whichever path exits — normal HTTP
+  shutdown or a startup-time failure/exit.
+- Execution is guarded so the two call sites (existing server-shutdown wiring,
+  new startup-exit wiring) cannot double-execute hooks.
+
+### Flex zone (implementation choice allowed)
+
+- Mechanism: deferred wrapping of `main`/`launchServer`, a `sync.Once` guard,
+  or explicit calls at each known exit point.
+
+### End-to-end behaviour to implement
+
+If the server exits during startup, before `serveHTTP` begins accepting
+connections, registered shutdown hooks (telemetry flush, cache connection
+close) still execute before the process exits.
+
+### Acceptance criteria
+
+- [ ] `[observable]` A simulated startup failure still runs shutdown hooks
+      (telemetry flush / cache close), verified via test hook counters.
+- [ ] `[observable]` A normal HTTP shutdown (SIGTERM after serving starts)
+      still runs hooks exactly once — no double execution.
+- [ ] `[structural]` Hook execution is guarded so no code path can run hooks
+      twice.
+
+### Verification
+
+Unit test around `launchServer`/`main` exit paths, asserting hook-execution
+counts under (a) a startup failure and (b) a normal shutdown.
+
+### Replan triggers
+
+If forcing a single shutdown-hook call site requires reshaping `main.go`'s
+control flow more invasively than expected, fall back to explicit calls at
+each known exit point instead of one wrapper.
+
+---
+
+## Phase 3: Startup gate — don't accept connections until first profile generation loads
+
+**EARS requirements**: R40, R41
+
+**Carry-forward**: re-verify Phases 1–2 (`just test` on `internal/profile`;
+the shutdown-hook test from Phase 2).
+
+### Why this phase exists
+
+Until a profile generation has loaded, the service has no configuration to
+serve. Today it accepts connections immediately and serves
+`NewDefaultProfiles()` (one hardcoded pipeline profile) in the meantime —
+during a rolling deployment this looks healthy while silently answering
+organization-profile requests with 404 and pipeline requests with an
+unconfigured permission set. This is independent of app association and is
+exactly what R40/R41 require.
+
+### Locked decisions (non-negotiable)
+
+- Not listening is the readiness signal; the healthcheck contract
+  (`GET /healthcheck`, no auth/telemetry) is unchanged.
+- The gate is a latch on the *first* load only — a service that has loaded a
+  generation and later loses access to its source keeps serving what it has.
+- `PeriodicRefresh` already performs its first load synchronously before its
+  first interval-based refresh; the gate consumes that signal rather than
+  issuing a second fetch.
+- No timeout governs the gate — a hung upstream blocks startup, and the
+  platform's own startup grace period is the backstop. R41's per-attempt log
+  is the diagnostic.
+- Applies only where an organization profile location is configured;
+  deployments without one are unaffected.
+
+### Flex zone (implementation choice allowed)
+
+- Mechanism: synchronous first load followed by a refresh loop with a delayed
+  start (preferred in the design notes) vs. a readiness channel — either is
+  acceptable provided it is testable with synthetic time, matching how the
+  refresh daemon is already tested.
+- Exact insertion point in `main.go`/`configureServerRoutes`/`launchServer`.
+
+### Open questions / risk burn-down
+
+This couples startup to profile-source availability for existing deployments
+using an organization profile location — a real behavior change. Confirmed
+intentional per the PRD; Phase 8's documentation should call it out so it
+isn't mistaken for a regression during rollout.
+
+### End-to-end behaviour to implement
+
+A service configured with an organization profile location does not accept
+connections until the first profile generation has loaded; each failed load
+attempt while waiting is logged. A service with no organization profile
+location is unaffected.
+
+### Acceptance criteria
+
+- [ ] `[observable]` With a reachable profile source, the service does not
+      open its listening port until the first generation loads (gate
+      extracted as a function, exercised with synthetic time).
+- [ ] `[observable]` While waiting, each failed load attempt is logged.
+- [ ] `[observable]` A service with no organization profile location starts
+      and serves immediately, with no gate-related delay or log lines.
+- [ ] `[structural]` The gate reads only the refresh daemon's first-load
+      signal; no duplicate fetch is issued at boot.
+- [ ] `[observable]` Once a generation has loaded, later loss of access to the
+      profile source does not stop the service serving the generation it has.
+
+### Verification
+
+`just test` on `internal/profile` (gate function tested with synthetic time);
+since the integration harness constructs routes directly rather than booting
+the server, the extracted-function unit test is the primary coverage for this
+phase — call this out explicitly rather than relying on integration coverage
+that doesn't reach it.
+
+### Regression watchpoints
+
+Healthcheck must remain reachable and unaffected by gate semantics; existing
+refresh tests must keep passing.
+
+### Replan triggers
+
+If the harness's route-construction-without-booting approach means the gate
+genuinely cannot be exercised even via the extracted function, flag this
+before considering the phase done — an untested gate is a defect, not a
+completed phase.
+
+---
+
+## Phase 4: Split configuration validation from route construction; fix transport ordering
+
+**EARS requirements**: none directly — structural prerequisite for Phase 5's
+registry construction.
+
+**Carry-forward**: re-verify Phases 1–3 (`just test`, `just integration`).
+
+### Why this phase exists
+
+Pure prerequisite plumbing with no user-visible behavior change today — with a
+single app, there is no observable difference yet. It exists as its own phase
+because the registry (Phase 5) needs it to be correct: the registry must be
+constructed *after* `http.DefaultTransport` is replaced with the instrumented,
+pool-tuned transport, or registry traffic (installation-verification queries)
+is silently untraced and untuned. All offline validation should complete
+before any GitHub network call, so a configuration error is reported
+immediately rather than behind a network phase that hasn't run yet.
+
+### Locked decisions (non-negotiable)
+
+- Offline configuration validation completes fully before any GitHub network
+  call is attempted.
+- `http.DefaultTransport` is replaced with the tuned/instrumented transport
+  before any GitHub client (including the future registry's clients) is
+  constructed.
+- Routes are built only after all upstream clients exist, so no handler
+  captures a client that is later mutated.
+
+### Flex zone (implementation choice allowed)
+
+- Exact function boundaries inside `main.go`/`configureServerRoutes`/
+  `launchServer` used to express the ordering.
+
+### End-to-end behaviour to implement
+
+No externally observable change for single-app deployments; this phase is
+verified structurally and by absence of regressions, and unblocks Phase 5.
+
+### Acceptance criteria
+
+- [ ] `[structural]` All offline configuration validation completes before any
+      function that could make a GitHub network call is invoked.
+- [ ] `[structural]` `http.DefaultTransport` is replaced before any GitHub
+      client is constructed (verified by reading call order).
+- [ ] `[observable]` Existing single-app startup and request-serving behavior
+      is unchanged — full existing test suite passes unmodified.
+
+### Verification
+
+`just test`, `just integration`, `just docker` — full existing suite passes
+with zero behavior change.
+
+### Regression watchpoints
+
+Any configuration currently validated lazily (on first use) must keep the
+same error semantics if moved earlier — same error, just sooner, never a new
+failure mode.
+
+### Replan triggers
+
+If current validation is more deeply interleaved with route construction than
+expected, scope the split down rather than forcing an artificial separation
+that risks destabilizing unrelated startup code.
+
+---
+
+## Phase 5: Registry — config parsing, fail-fast validation, concurrent org verification, redacted startup logging
+
+**EARS requirements**: R1–R19, R48–R50
+
+**Carry-forward**: re-verify Phase 4 (`just test`, `just integration`) — this
+phase builds directly on its ordering guarantees.
+
+### Why this phase exists
+
+This is where `GITHUB_APPS` first exists. An operator declares named GitHub
+Apps in deployment configuration; the service builds a client per entry,
+verifies each shares the default app's organization, and disables (rather than
+crashes on) an app whose installation can't be reached — while a failure to
+verify the default app itself is fatal, since the service can't authenticate
+as itself.
+
+### Locked decisions (non-negotiable)
+
+- `GITHUB_APPS` is the only new env var (R1); default app config is unchanged.
+- Registry entries: name, application ID, installation ID, exactly one of
+  private key or private key ARN (R4, R6, R7).
+- Fail-fast (deploy-blocking, deterministic) on: malformed JSON or an
+  unrecognised field (R5); missing or duplicate key source (R6, R7); duplicate
+  name (R8); name `default` (R9); name failing
+  `^[a-z0-9]([a-z0-9._-]*[a-z0-9])?$` or exceeding 64 characters (R10);
+  non-positive application/installation ID (R11); unparseable private key or
+  unconstructable GitHub client (R15).
+- Verification: default app's installation account ID is the reference; every
+  registry app's account ID is queried concurrently alongside it (R12, R13),
+  compared by account ID, not login.
+- An app on a different account is disabled, not fatal (R14). An app whose
+  installation query fails is disabled; the service continues starting (R16).
+  The default app's installation query failing is fatal — non-zero exit (R17).
+- Disabled is terminal until process restart (R18).
+- No registry configured → zero installation queries at startup (R19).
+- Registry is built once, immutable thereafter (value receivers over an
+  unexported map). Lookup by name returns not-found for a disabled app.
+- Two entry types: a configuration entry (`slog.LogValuer` exposing only name,
+  application ID, installation ID, key source — no key material) and a
+  resolved entry (verification results, no key material) — this is how R48/R49
+  hold by construction, not by vigilance.
+- Configuration/verification error messages identify the faulty entry by name
+  or index and never contain a substring of its private key or ARN (R50). This
+  requires a deliberate, documented exception to the project's `%w`-wrapping
+  convention on the key-parsing path, since a third-party library's error
+  message is outside our control and may change on any dependency bump.
+- The signing key must not capture a short-lived context: registry
+  construction takes the long-lived server context; `createKMSSigningKey`
+  takes a shared `aws.Config` (one credential resolution for all apps), and
+  the signing call carries its own per-call context. Otherwise every mint
+  using `privateKeyArn` fails with `context canceled` once the
+  construction/verification-scoped context expires — a failure mode that only
+  reproduces with ARN-based keys, never PEM, so it needs its own test.
+- KMS key handling contacts nothing at construction; the first network call is
+  the signing operation. So R15's scope is offline, deterministic failures
+  only — every network-shaped failure (bad ARN, IAM denial, KMS outage) arrives
+  on the verification path and is disabled under R16.
+- No sensitive data in any log, error, or span this phase touches.
+
+### Flex zone (implementation choice allowed)
+
+- Internal registry data structure; exact function signatures for entry
+  construction and verification.
+- Worker-pool vs. unbounded-goroutine-with-`WaitGroup` for concurrent
+  verification (realistic app counts make this a minor choice).
+
+### Open questions / risk burn-down
+
+The GitHub mock server (`testhelpers.MockGitHubServer`) currently exposes one
+route that ignores the installation-ID path segment and returns one shared
+status/token/counter. It must be extended to per-installation responses and
+per-installation counters before any verification scenario (matching org,
+different org, query failure) can be tested. This is infrastructure work
+internal to this phase and blocks every acceptance criterion below — budget
+for it explicitly rather than discovering it mid-phase.
+
+### End-to-end behaviour to implement
+
+An operator sets `GITHUB_APPS` with one or more named entries. On startup, the
+service builds a client per entry, queries each installation's account
+concurrently alongside the default app's, disables any entry on a different
+account or with an unreachable installation, exits non-zero only if the
+default app itself can't be verified, and logs each entry's name, application
+ID, installation ID, verified organization, and enabled state — with no key
+material. Malformed configuration fails startup before any network call.
+
+### Acceptance criteria
+
+- [ ] `[observable]` A well-formed `GITHUB_APPS` with all apps on the default
+      app's account: service starts, all apps logged enabled.
+- [ ] `[observable]` A registry app whose mocked installation resolves to a
+      different account: service starts, that app logged disabled, others
+      unaffected.
+- [ ] `[observable]` A registry app whose mocked installation query fails:
+      service starts, that app disabled, others unaffected.
+- [ ] `[observable]` The default app's installation query failing: service
+      exits non-zero.
+- [ ] `[observable]` Each fail-fast configuration case (malformed JSON, unknown
+      field, duplicate name, name `default`, name failing the pattern,
+      both/neither key source, non-positive ID, unparseable key)
+      independently prevents startup.
+- [ ] `[structural]` No log line or error message emitted in this phase
+      contains private key material or a private key ARN — asserted against
+      the exact field set logged.
+- [ ] `[observable]` With `GITHUB_APPS` unset, zero installation-endpoint calls
+      are made at startup (assert on the mock's call counter).
+- [ ] `[observable]` A registry constructed under a context that is later
+      cancelled still mints tokens successfully afterward (ARN-based keys
+      only — the signing-key-outlives-verification regression test).
+
+### Verification
+
+`just test` on `internal/github` — table-driven construction/validation
+tests, then verification-outcome tests against the extended mock; the
+context-cancellation mint test; `just integration` once the harness supports
+multi-app config injection.
+
+### Regression watchpoints
+
+Existing single-app `internal/github` tests and the mock server's existing
+single-route behavior must keep working unchanged for the no-`GITHUB_APPS`
+path.
+
+### Replan triggers
+
+If extending the mock server for per-installation behavior needs a
+significantly larger harness rework than expected, treat that as an explicit
+sub-step with its own estimate before continuing into verification tests.
+
+---
+
+## Phase 6: Profile schema (`app`), resolution, cache-safe vending, response/audit attribution
+
+**EARS requirements**: R20–R27, R29–R39, R43, R45, R46
+
+**Carry-forward**: re-verify Phase 5 in full (`just test` on `internal/github`,
+`just integration`) — this phase is the registry's first consumer.
+
+### Why this phase exists
+
+This is where the registry becomes usable: profiles can name an app, requests
+resolve that name to an identity at the handler boundary, tokens mint through
+the resolved installation, and every downstream surface — cache, response,
+audit — reflects which app served the request. Resolution and the cache key
+are inseparable: a resolved identity that isn't part of the cache key means a
+cache hit can serve a token minted through an app that has since been
+disabled, which is exactly what R36 forbids. Splitting this into two phases
+would let one land in a state where that guarantee doesn't hold.
+
+### Locked decisions (non-negotiable)
+
+- Profile attributes stay pure data: `OrganizationProfileAttr`/
+  `PipelineProfileAttr` gain the app *name* (string), never a live client
+  (R20, R21).
+- Normalize in compilation, not at the request boundary: an omitted `app` and
+  an explicit `app: default` compile to the same attribute value, so they are
+  indistinguishable downstream and produce identical audit attribution (R22,
+  R23).
+- The default pipeline profile always mints through the default app and has no
+  `app` property (R24).
+- Empty `app` string is invalid; a name absent from the registry is invalid; a
+  name naming a disabled app is invalid (R25, R26, R27). Compilation asks the
+  registry for its set of usable names — the same function the request path
+  uses to resolve — so both share one enforcement point.
+- The name resolves to an app identity (name, application ID, installation ID)
+  at the handler boundary, in the profile resolver — never inside the
+  `Vending` stage. The chain is Audit → Authorized → Cached → Vending, and
+  `Cached` short-circuits on a hit before `Vending` runs, so a check inside
+  `Vending` would never run on a cache hit. Resolving in the resolver makes
+  that lookup the guard that runs on every request (R31; satisfies R36's
+  final clause).
+- A profile resolved but whose app cannot be resolved in the registry is a
+  500, not a 403/404: reaching that state means compilation should already
+  have invalidated the profile — the service's defect, not GitHub's denial,
+  matching the shape of existing unresolved-scope guards (R36).
+- The resolved identity is data (name, application ID, installation ID), not a
+  closure — no credential is captured in a value that flows into a cache
+  payload (R32).
+- Compilation threads the registry's usable-names set through
+  `FetchOrganizationProfile` → `load` → `compile`, *and* through
+  `PeriodicRefresh` for the background refresh path — missing the background
+  path is the specific failure Req 30 exists to prevent (profiles valid for
+  one refresh interval, invalid after, unchanged digest, generation swap
+  logging only at debug level).
+- The organization profile configuration file is always retrieved through the
+  default app, never a per-profile app (R34).
+- The service does not check a requested repository's owner against the
+  resolved app's organization — GitHub's installation boundary is the
+  enforcement point (R35).
+- Cache key becomes `digest:applicationID:installationID:profileURN` (R37).
+  Two requests resolving the same profile/digest through different app
+  identities must not share a cache entry (R38). The app an entry was minted
+  through is recorded in the entry itself, so a cache hit and a cache miss
+  return the same response shape (R39).
+- No consistency check between the app recorded in a cache entry and the app
+  implied by its key — a deliberate scope exclusion, covered by the cache-key
+  test rather than a runtime check.
+- Token response includes the minting app's name (R45); the audit entry
+  records the resolved app's name at resolution time, so every downstream
+  outcome — including failures — carries it (R43); the token cache outcome
+  metric is attributed with the app name (R46).
+- A profile invalid because its named app is disabled fails *before* an app is
+  resolved, so its audit entry carries the invalidity reason from Phase 1
+  (R44) rather than an app name — now load-bearing, since Phase 1's
+  edge-triggered logging means the audit entry is the only timely record.
+- Deploying this orphans every existing cache entry once (key format changes
+  for the default app too) — accepted as a one-time cold cache.
+- No sensitive data in any surface this phase touches.
+
+### Flex zone (implementation choice allowed)
+
+- Exact plumbing of the registry's usable-names set through the compilation
+  call chain.
+- Internal shape of the resolved identity value and where in the resolver it
+  attaches to the resolved request value.
+
+### Open questions / risk burn-down
+
+Highest blast radius in this plan: it changes the cache key for every existing
+deployment, touches the request-serving hot path, and a subtle placement
+mistake (resolving inside `Vending` instead of the resolver) would silently
+reintroduce the cache-bypass hazard. The single most important test in the
+whole plan is: prime a cache entry, disable the app, repeat the request,
+assert 500 and that the cached token was not served. This is the test that
+fails if resolution is ever moved into the vendor chain — treat it as a gate
+on this phase, not just one acceptance criterion among many.
+
+### End-to-end behaviour to implement
+
+An organization or named pipeline profile may declare `app: <name>`. A
+request against such a profile resolves the name to an app identity, mints
+its token through that app's installation, includes the app's name in the
+response and audit entry, and caches the result under a key that includes the
+app's identity. A profile naming a disabled or unknown app is invalid and
+returns 404 with the reason on the audit entry. A previously cached token is
+never served once its app becomes unresolvable.
+
+### Acceptance criteria
+
+- [ ] `[observable]` A request against a profile bound to a non-default
+      registered app returns a token minted via that app's installation, with
+      the app's name in the response body and the audit entry.
+- [ ] `[observable]` A request against the default pipeline profile, and one
+      against a profile with no `app` property, both mint through the default
+      app.
+- [ ] `[observable]` Two configurations differing only in the presence of
+      `app: default` compile to equal profile attributes.
+- [ ] `[observable]` A profile naming an unknown or disabled app is invalid;
+      the request returns 404 with the reason on the audit entry; other
+      profiles in the same configuration remain valid.
+- [ ] `[observable]` Priming a cache entry, then making the registry unable to
+      resolve that profile's app, then repeating the request: returns 500,
+      and the previously cached token is not served.
+- [ ] `[observable]` Two requests resolving the same profile/digest through two
+      different app identities do not share a cache entry.
+- [ ] `[observable]` A profile naming an enabled app remains valid across a
+      background profile refresh.
+- [ ] `[structural]` Resolution occurs in the profile resolver, not inside
+      `Vending` (verified by the cache-bypass test above).
+
+### Verification
+
+`just test` on `internal/profile` and `internal/vendor`; `just integration`
+for the end-to-end cases (request via second app, disabled-app 404,
+cache-bypass 500); an integration test issuing parallel requests across two
+apps under `go test -race`, guarding against future lazily-populated registry
+state.
+
+### Regression watchpoints
+
+Single-app deployments (no `GITHUB_APPS`, no `app` properties) must behave
+exactly as before — same cache behavior modulo the one-time cold cache, same
+response shape, same audit shape (app name now always present, naming
+"default"). Existing profile-compilation and vendor-chain tests must keep
+passing.
+
+### Replan triggers
+
+If threading the registry's usable-names set through both the synchronous
+load path and `PeriodicRefresh`'s background path needs a broader interface
+change than expected, pause before Req 30's guarantee ends up only
+half-implemented.
+
+---
+
+## Phase 7: Span attributes for valid/invalid profile counts
+
+**EARS requirements**: R47
+
+**Carry-forward**: re-verify Phase 6 (`just test` on `internal/profile`).
+
+### Why this phase exists
+
+Profile generation changes are already traced. Rather than a new metric that
+would duplicate the trace, this adds valid/invalid counts (by profile type) to
+the existing update span — the counts are the only part of profile state not
+already observable, and they're what makes a partly-invalid generation
+visible without scraping logs.
+
+### Locked decisions (non-negotiable)
+
+- Counts land on the existing profile-generation-update span, not a new metric
+  or new span.
+- Counts are broken down by profile type (organization vs. pipeline).
+
+### Flex zone (implementation choice allowed)
+
+- Attribute naming; exact point in the update path where counts are computed.
+
+### End-to-end behaviour to implement
+
+When the service updates the profile generation, the trace span for that
+update carries the count of valid and invalid profiles, by type.
+
+### Acceptance criteria
+
+- [ ] `[observable]` A refresh producing a mix of valid/invalid organization
+      and pipeline profiles produces a span with attributes reflecting the
+      correct counts, by type.
+- [ ] `[observable]` A refresh with everything valid shows zero on the invalid
+      counts, not an absent attribute.
+- [ ] `[structural]` No new metric series or new span is introduced.
+
+### Verification
+
+`just test` on `internal/profile`, asserting span attributes via the existing
+tracing test utilities.
+
+### Replan triggers
+
+None expected — small, low-risk addition once Phase 6's compilation changes
+exist.
+
+---
+
+## Phase 8: Documentation
+
+**EARS requirements**: R51 (only requirement in scope for this repository)
+
+**Carry-forward**: none — documentation-only phase.
+
+### Why this phase exists
+
+Reqs 52–57 describe operator-facing documentation published from the separate
+`chinmina.github.io` documentation repository and are out of scope for a PR
+here. Only R51 — the `.envrc` reference block — lives in this repository.
+
+### Locked decisions (non-negotiable)
+
+- `.envrc` (and `.development/.envrc`) document `GITHUB_APPS` with a commented
+  example alongside the existing `GITHUB_APP_*` variables, following the
+  existing `# required (one of)` / `# required` comment convention.
+- R52–R57 are explicitly out of scope for this repository's PRs — tracked as
+  follow-up work in the documentation site repository, not silently dropped.
+
+### Flex zone (implementation choice allowed)
+
+- Wording of the `.envrc` comment/example.
+
+### End-to-end behaviour to implement
+
+An operator reading `.envrc` sees a commented `GITHUB_APPS` example next to
+the existing app variables.
+
+### Acceptance criteria
+
+- [ ] `[observable]` `.envrc` contains a commented `GITHUB_APPS` example
+      matching the PRD's configuration shape.
+- [ ] `[structural]` The example is valid JSON matching the registry entry
+      schema from Phase 5 (name, appId, installationId, exactly one of
+      privateKey/privateKeyArn).
+- [ ] `[structural]` No change in this repository purports to satisfy
+      R52–R57 — those are called out as external follow-ups.
+
+### Verification
+
+Manual review of `.envrc`; optionally, a small test parsing the commented
+example (with the leading `#` stripped) against the registry's JSON schema so
+it can't silently drift from Phase 5's actual accepted shape.
+
+### Replan triggers
+
+None.
+
+---
+
+## Requirements coverage matrix
+
+| Requirement ID | Phase(s) | Notes |
+|---|---|---|
+| R1–R11 | Phase 5 | App registry configuration |
+| R12–R19 | Phase 5 | Organization verification |
+| R20–R27 | Phase 6 | Profile schema and compilation |
+| R28 | Phase 1 | Edge-triggered invalid-profile logging |
+| R29–R30 | Phase 6 | Invalid-profile request handling; refresh-path validity |
+| R31–R36 | Phase 6 | Token vending, resolution and the cache-bypass guard |
+| R37–R39 | Phase 6 | Caching |
+| R40–R41 | Phase 3 | Startup gate |
+| R42 | Phase 2 | Shutdown hooks on every exit path |
+| R43 | Phase 6 | Audit entry records resolved app name |
+| R44 | Phase 1, Phase 6 | Cause captured in Phase 1; wired into audit entry in Phase 6 |
+| R45–R46 | Phase 6 | Response and cache-metric attribution |
+| R47 | Phase 7 | Span attributes for profile counts |
+| R48–R50 | Phase 5 | Registry logging and redaction |
+| R51 | Phase 8 | `.envrc` documentation (this repository) |
+| R52–R57 | *(out of scope)* | Published from the separate documentation repository |


### PR DESCRIPTION
## Summary

This adds support for associating profiles with different GitHub Apps, allowing operators to vend tokens through multiple app installations rather than a single fixed app. Profiles can now declare which app to use for token minting, while deployment configuration controls which apps are available.

## Changes

- **Configuration**: Adds `GITHUB_APPS` environment variable to declare additional named GitHub Apps alongside the existing default app (app ID, installation ID, and private key/ARN)
- **Profile schema**: Organization and named pipeline profiles gain an optional `app` property to select which app mints their tokens
- **App registry**: New registry in `internal/github` that:
  - Validates app configuration at startup (names, key sources, IDs)
  - Verifies all apps are installed on the same GitHub organization as the default app
  - Disables apps that fail verification without blocking service startup
  - Provides immutable lookup by app name
- **Profile compilation**: Validates that profile `app` properties reference known, enabled apps; invalidates profiles that reference missing or disabled apps
- **Token vending**: Resolves the app at the handler boundary and carries it through the vendor chain; tokens are minted through the resolved app's installation
- **Cache key**: Includes app identity (application ID and installation ID) to prevent stale tokens when apps are remapped
- **Observability**: Audit entries and metrics now include the app name; startup logs show each configured app's status

## Implementation Details

- Profiles without an `app` property continue using the default app (backward compatible)
- The default app is defined by existing `GITHUB_APP_ID`, `GITHUB_APP_INSTALLATION_ID`, and private key variables
- No additional GitHub API calls are made at startup if `GITHUB_APPS` is not configured
- Disabled apps remain disabled until service restart; no background re-verification
- Profile YAML containing `app` properties is rejected entirely by older binaries due to `KnownFields(true)` validation, requiring binary rollout before YAML publication
- Cache entries are orphaned once due to key format change, resulting in a one-time cold cache

## Documentation

Comprehensive PRD included documenting problem statement, solution, all 48 requirements, implementation decisions, testing strategy, and out-of-scope items.

https://claude.ai/code/session_01QDdbbxvdQfJg4h9DVG2WFQ