### PR TITLE
feat: record why a profile is unavailable on the audit entry

### DIFF
--- a/handlers_test.go
+++ b/handlers_test.go
@@ -1261,6 +1261,60 @@ func TestHandlers_UnresolvedProfileIsNotAuditedAsCanonicalURN(t *testing.T) {
 	assert.NotContains(t, entry.RequestedProfile, "profile://")
 }
 
+// invalidProfileYAML compiles to one valid profile and one that fails
+// validation, so a request against the invalid profile carries a reason
+// produced by the real compilation path rather than a synthesised error.
+const invalidProfileYAML = `organization:
+  profiles:
+    - name: valid-profile
+      repositories:
+        - repo1
+      permissions:
+        - contents:read
+    - name: broken-profile
+      repositories:
+        - repo1
+      permissions:
+        - contents:read
+      match:
+        - claim: not_a_real_claim
+          value: anything
+
+pipeline:
+  defaults:
+    permissions:
+      - contents:read
+`
+
+// TestHandlePostToken_RecordsInvalidProfileReason: the caller of an
+// unavailable profile is told only that it is unavailable, so the audit
+// entry's error is the sole durable record of why. Without the reason, an
+// operator seeing a 404 has no way to tell a misconfigured profile from a
+// mistyped name.
+func TestHandlePostToken_RecordsInvalidProfileReason(t *testing.T) {
+	store := profiletest.CreateTestProfileStore(t, invalidProfileYAML)
+	resolve := NewOrgProfileResolver(store.GetOrganizationProfile)
+
+	ctx, entry := audit.Context(claimsContext())
+	req, err := http.NewRequestWithContext(ctx, "POST", "/organization/token/broken-profile", nil)
+	require.NoError(t, err)
+	req.SetPathValue("profile", "broken-profile")
+
+	rr := httptest.NewRecorder()
+	handlePostToken(tv[orgAttr]("unused"), resolve).ServeHTTP(rr, req)
+
+	// caller-facing behaviour is unchanged: 404, and a message that says
+	// nothing about the cause
+	require.Equal(t, http.StatusNotFound, rr.Code)
+	var respBody ErrorResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &respBody))
+	assert.Equal(t, ErrorResponse{Error: "profile unavailable: validation failed"}, respBody)
+
+	assert.Equal(t,
+		`profile resolution failed: profile "broken-profile" unavailable: invalid match rule for claim "not_a_real_claim": claim "not_a_real_claim" is not allowed for matching`,
+		entry.Error)
+}
+
 // TestHandlePostToken_RecordsScopedRepositoryInAuditedProfile:
 // the caller-supplied repository scope must be visible in the audited profile
 // URN, so an audit reader can tell which repository a caller-scoped profile

--- a/internal/profile/config.go
+++ b/internal/profile/config.go
@@ -73,8 +73,15 @@ type ProfileUnavailableError struct {
 	Cause error
 }
 
+// Error names the reason the profile failed validation, so the audit entry
+// this string lands on records why the request was refused. The caller-facing
+// message comes from Status and stays deliberately generic.
 func (e ProfileUnavailableError) Error() string {
-	return fmt.Sprintf("profile %q unavailable: validation failed", e.Name)
+	if e.Cause == nil {
+		return fmt.Sprintf("profile %q unavailable: validation failed", e.Name)
+	}
+
+	return fmt.Sprintf("profile %q unavailable: %v", e.Name, e.Cause)
 }
 
 func (e ProfileUnavailableError) Unwrap() error {

--- a/internal/profile/config_test.go
+++ b/internal/profile/config_test.go
@@ -119,6 +119,14 @@ func TestProfileUnavailableError_Format(t *testing.T) {
 		Cause: assert.AnError,
 	}
 
+	assert.Equal(t, `profile "test-profile" unavailable: `+assert.AnError.Error(), err.Error())
+}
+
+// A cause is always set in practice, but the message must stay readable if a
+// caller constructs the error without one.
+func TestProfileUnavailableError_FormatWithoutCause(t *testing.T) {
+	err := ProfileUnavailableError{Name: "test-profile"}
+
 	assert.Equal(t, `profile "test-profile" unavailable: validation failed`, err.Error())
 }
 


### PR DESCRIPTION
## Purpose

An operator investigating a 404 for an unavailable profile cannot tell a misconfigured profile from a mistyped name. The response is deliberately generic, and the error behind it repeated that same generic wording, so the reason existed only in the batched warning logged by whichever refresh last compiled the configuration — possibly hours earlier, on another instance.

Naming the cause in the error puts it on the audit entry for the request that was actually refused. The response body is unchanged: it is built from a separate message and still discloses nothing about the configuration.

## Context

Groundwork for associating profiles with multiple GitHub Apps: an unknown or disabled app becomes another reason a profile is invalid, and it will surface through this path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017jMWmycT6r9vLYygTDNbr4