### PR TITLE
fix: run shutdown hooks on every exit path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,14 @@ tokenVendor := vendor.Auditor(vendorCache(vendor.New(bk.RepositoryLookup, gh.Cre
 - Handlers return appropriate HTTP status codes via `requestError(w, statusCode)`
 - panic() may not be added by CI agents without explicit direction to do so. The plan must state explicitly that a panic can be used in a given situation. Otherwise, errors must be used.
 
+### Concurrency
+
+- Put a critical section in its own function and unlock with `defer`: the body is
+  the guarded region, and no branch added later can skip the unlock.
+- Return the guarded state to the caller. Slow work, I/O and callbacks belong
+  outside the lock; never hold a lock across a callback.
+- Example: `ShutdownHooks.beginExecution` in `internal/server/shutdown.go`.
+
 ### Testing
 
 **Assertion Style:**

--- a/internal/server/shutdown.go
+++ b/internal/server/shutdown.go
@@ -17,10 +17,12 @@ type hookDefinition struct {
 //
 // A ShutdownHooks value must not be copied after first use.
 type ShutdownHooks struct {
+	// hooks is deliberately unsynchronized: every hook is registered during
+	// startup, before any exit path can call Execute.
 	hooks []hookDefinition
 
-	// mu guards completed, and only completed. beginExecution is the sole
-	// reader and writer of both.
+	// mu guards completed and nothing else, and beginExecution is its only
+	// reader and writer.
 	mu sync.Mutex
 	// completed is created when execution begins and closed when it finishes.
 	// A nil value means shutdown has not started. Waiting on a channel rather

--- a/internal/server/shutdown.go
+++ b/internal/server/shutdown.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"sync"
 
 	"log/slog"
 )
@@ -13,8 +14,20 @@ type hookDefinition struct {
 
 // ShutdownHooks manages a collection of hooks to be executed during application shutdown.
 // Hooks are executed in the order they were added, and execution continues even if a hook fails.
+//
+// A ShutdownHooks value must not be copied after first use.
 type ShutdownHooks struct {
 	hooks []hookDefinition
+
+	// mu guards completed, and only completed. beginExecution is the sole
+	// reader and writer of both.
+	mu sync.Mutex
+	// completed is created when execution begins and closed when it finishes.
+	// A nil value means shutdown has not started. Waiting on a channel rather
+	// than contending on a mutex (as sync.Once would) keeps the wait
+	// observable: a blocked receive is a durably blocking operation, so the
+	// behaviour can be tested under testing/synctest without real delays.
+	completed chan struct{}
 }
 
 // AddContext registers a shutdown hook that receives a context parameter.
@@ -62,7 +75,25 @@ func (s *ShutdownHooks) AddClose(name string, closer interface{ Close() }) {
 // Execute runs all registered shutdown hooks in the order they were added.
 // Each hook is executed with the provided context, and execution continues even if a hook fails.
 // Success and failure of each hook is logged appropriately.
+//
+// Hooks run at most once for the lifetime of the value: the process has
+// several exit paths (a startup failure, and the HTTP server's own shutdown
+// wiring) and each of them calls Execute, so without this guard a normal
+// shutdown would flush telemetry and close the cache twice. A caller arriving
+// while another is mid-execution blocks until that execution finishes, so
+// Execute returning always means shutdown is complete — the deferred
+// startup-path call cannot let the process exit while the server-shutdown
+// call is still flushing.
 func (s *ShutdownHooks) Execute(ctx context.Context) {
+	completed, owner := s.beginExecution()
+	if !owner {
+		<-completed
+		return
+	}
+
+	// Closing on the way out releases any waiter even if a hook panics.
+	defer close(completed)
+
 	for _, hook := range s.hooks {
 		hookLog := slog.With("hook", hook.name)
 
@@ -73,4 +104,25 @@ func (s *ShutdownHooks) Execute(ctx context.Context) {
 			hookLog.Info("shutdown complete")
 		}
 	}
+}
+
+// beginExecution claims the right to run the hooks. It returns the channel
+// tracking completion of this shutdown, and whether the caller owns it: an
+// owner runs the hooks and closes the channel when they are done, and any
+// other caller waits on it.
+//
+// The lock is deliberately confined to this function: it must not be held
+// while the hooks run, both because a waiter needs it to reach the channel and
+// because holding a lock across caller-supplied callbacks invites deadlock.
+func (s *ShutdownHooks) beginExecution() (completed chan struct{}, owner bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.completed != nil {
+		return s.completed, false
+	}
+
+	s.completed = make(chan struct{})
+
+	return s.completed, true
 }

--- a/internal/server/shutdown_test.go
+++ b/internal/server/shutdown_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"testing/synctest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -214,6 +215,82 @@ func TestShutdownHooks_Execute(t *testing.T) {
 		hooks := &ShutdownHooks{hooks: nil}
 		// Should not panic
 		hooks.Execute(context.Background())
+	})
+
+	t.Run("runs hooks only once across repeated calls", func(t *testing.T) {
+		hooks := &ShutdownHooks{}
+		calls := 0
+
+		hooks.AddContext("counted", func(ctx context.Context) error {
+			calls++
+			return nil
+		})
+
+		hooks.Execute(context.Background())
+		hooks.Execute(context.Background())
+		hooks.Execute(context.Background())
+
+		assert.Equal(t, 1, calls, "hooks should execute exactly once regardless of how many exit paths call Execute")
+	})
+
+	t.Run("hooks added after execution do not run", func(t *testing.T) {
+		hooks := &ShutdownHooks{}
+		called := false
+
+		hooks.Execute(context.Background())
+		hooks.AddContext("late", func(ctx context.Context) error {
+			called = true
+			return nil
+		})
+		hooks.Execute(context.Background())
+
+		assert.False(t, called, "shutdown is terminal: a hook registered afterwards must not resurrect execution")
+	})
+
+	t.Run("concurrent caller blocks until execution completes", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			hooks := &ShutdownHooks{}
+			release := make(chan struct{})
+			started := make(chan struct{})
+			finished := false
+
+			hooks.AddContext("slow", func(ctx context.Context) error {
+				close(started)
+				<-release
+				finished = true
+				return nil
+			})
+
+			go hooks.Execute(context.Background())
+			<-started
+
+			// The second caller must not observe an incomplete shutdown: this
+			// is what stops the process exiting while telemetry is still
+			// flushing.
+			returned := make(chan struct{})
+			go func() {
+				hooks.Execute(context.Background())
+				close(returned)
+			}()
+
+			// Returns only once the second caller is parked waiting on the
+			// in-flight execution, rather than merely not yet scheduled. A
+			// real-time delay here would prove nothing on a loaded machine.
+			synctest.Wait()
+
+			select {
+			case <-returned:
+				t.Fatal("Execute returned while hooks were still running")
+			default:
+			}
+
+			close(release)
+
+			// No timeout guard needed: an execution that never released the
+			// waiter would leave the bubble deadlocked, which fails the test.
+			<-returned
+			assert.True(t, finished, "the blocked caller should only return once hooks have completed")
+		})
 	})
 }
 

--- a/main.go
+++ b/main.go
@@ -151,10 +151,27 @@ func main() {
 }
 
 func launchServer() error {
-	shutdownHooks := server.ShutdownHooks{}
+	return runWithShutdownHooks(context.Background(), startServer)
+}
 
-	serverContext := context.Background()
+// runWithShutdownHooks guarantees that hooks registered by run are executed
+// before the process exits, on whichever path it takes. Registration happens
+// progressively during startup, so an exit before the HTTP server begins
+// serving (a configuration failure, or any later startup gate) would otherwise
+// discard buffered telemetry describing that very failure and leak the cache
+// connection.
+//
+// The deferred call and the server's own shutdown wiring both call Execute;
+// Execute runs the hooks at most once, so the two call sites cannot
+// double-execute them.
+func runWithShutdownHooks(ctx context.Context, run func(context.Context, *server.ShutdownHooks) error) error {
+	shutdownHooks := &server.ShutdownHooks{}
+	defer shutdownHooks.Execute(ctx)
 
+	return run(ctx, shutdownHooks)
+}
+
+func startServer(serverContext context.Context, shutdownHooks *server.ShutdownHooks) error {
 	orgProfile := profile.NewProfileStore()
 	orgProfile.Update(serverContext, profile.NewDefaultProfiles())
 	cfg, err := config.Load(serverContext)
@@ -188,7 +205,7 @@ func launchServer() error {
 	}
 
 	// setup routing and dependencies
-	handler, err := configureServerRoutes(serverContext, cfg, orgProfile, &shutdownHooks)
+	handler, err := configureServerRoutes(serverContext, cfg, orgProfile, shutdownHooks)
 	if err != nil {
 		return fmt.Errorf("server routing configuration failed: %w", err)
 	}
@@ -196,7 +213,12 @@ func launchServer() error {
 	orgProfileLocation := cfg.Server.OrgProfile
 
 	taskCtx, cancel := context.WithCancel(serverContext)
-	defer cancel()
+
+	// Cancelling the task context has to be the last action so it doesn't
+	// interfere with other shutdown tasks, so it is registered here rather than
+	// deferred: the hooks are the only cancellation path, and they now run on
+	// every exit from startup, not just once the server is serving.
+	shutdownHooks.Add("context", func() error { cancel(); return nil })
 
 	// Start Goroutine to refresh the organization profile every 5 minutes
 	if orgProfileLocation != "" {
@@ -222,10 +244,6 @@ func launchServer() error {
 		ReadHeaderTimeout: 20 * time.Second, // Prevent Slowloris attacks
 	}
 
-	// cancelling the task context has to be the last action so it doesn't
-	// interfere with other shutdown tasks. Cancel is done here explicitly to
-	// include it with the rest of the shutdown hooks, even though it is deferred.
-	shutdownHooks.Add("context", func() error { cancel(); return nil })
 	server.RegisterOnShutdown(func() {
 		shutdownHooks.Execute(serverContext)
 	})

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/chinmina/chinmina-bridge/internal/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunWithShutdownHooks(t *testing.T) {
+	t.Run("runs hooks when startup fails before serving", func(t *testing.T) {
+		expectedErr := errors.New("startup failed")
+		var executed []string
+
+		err := runWithShutdownHooks(context.Background(), func(ctx context.Context, hooks *server.ShutdownHooks) error {
+			hooks.Add("telemetry", func() error {
+				executed = append(executed, "telemetry")
+				return nil
+			})
+			hooks.Add("cache", func() error {
+				executed = append(executed, "cache")
+				return nil
+			})
+
+			return expectedErr
+		})
+
+		require.Error(t, err)
+		assert.Equal(t, expectedErr, err, "the startup error is returned unchanged")
+		assert.Equal(t, []string{"telemetry", "cache"}, executed,
+			"hooks registered before the failure must still run, so telemetry describing the failure is flushed")
+	})
+
+	t.Run("runs hooks exactly once when the serving path has already run them", func(t *testing.T) {
+		calls := 0
+
+		err := runWithShutdownHooks(context.Background(), func(ctx context.Context, hooks *server.ShutdownHooks) error {
+			hooks.Add("telemetry", func() error {
+				calls++
+				return nil
+			})
+
+			// The HTTP server's RegisterOnShutdown wiring executes the hooks on
+			// a normal shutdown, before startup returns.
+			hooks.Execute(ctx)
+
+			return nil
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, 1, calls, "the server shutdown path and the deferred startup path must not double-execute hooks")
+	})
+
+	t.Run("runs hooks when startup returns without serving", func(t *testing.T) {
+		calls := 0
+
+		err := runWithShutdownHooks(context.Background(), func(ctx context.Context, hooks *server.ShutdownHooks) error {
+			hooks.Add("cache", func() error {
+				calls++
+				return nil
+			})
+
+			return nil
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, 1, calls)
+	})
+
+	t.Run("runs hooks when startup panics", func(t *testing.T) {
+		calls := 0
+
+		assert.Panics(t, func() {
+			_ = runWithShutdownHooks(context.Background(), func(ctx context.Context, hooks *server.ShutdownHooks) error {
+				hooks.Add("cache", func() error {
+					calls++
+					return nil
+				})
+
+				panic("startup exploded")
+			})
+		})
+
+		assert.Equal(t, 1, calls, "an unwinding panic is still an exit path")
+	})
+}


### PR DESCRIPTION
## Purpose

Shutdown hooks only ran when the HTTP server shut down cleanly. Two operational consequences:

**A failed startup lost its own diagnostics.** If the process exited before it began serving — a bad configuration, a telemetry bootstrap failure — the buffered telemetry describing that failure was discarded and the cache connection was left open. A crash-looping deployment leaked a connection per restart while telling you nothing about why it was failing.

**A normal shutdown could truncate its flush.** `http.Server.Shutdown` starts its registered functions and returns without waiting for them, so the process could exit mid-flush on an ordinary SIGTERM.

Startup now runs the hooks on whichever path exits, and a caller arriving while shutdown is already in progress waits for it to finish. Any exit path added to startup later inherits this behaviour rather than having to remember it.

## Context

- The guard is a channel latch rather than `sync.Once`. Blocking on a mutex is not a durably blocking operation, so a caller parked inside `once.Do` is invisible to `testing/synctest` and the test bubble deadlocks. Waiting on a channel makes the behaviour assertable with `synctest.Wait()` rather than a real-time sleep, so the test is both deterministic and instant.
- Cancellation of the profile-refresh context moves into the hook list. It still runs last, but now also runs on early exits.
- Adds an `AGENTS.md` convention for keeping critical sections in their own function with a deferred unlock.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PsVDXxqwKU3y6NNPAKvoMn)_