### PR TITLE
refactor: separate configuration validation from route construction

### DIFF
--- a/harness_integration_test.go
+++ b/harness_integration_test.go
@@ -134,8 +134,15 @@ func NewAPITestHarness(t *testing.T, options ...APITestHarnessOption) *APITestHa
 		harness.valkeyPassword = cacheCfg.Valkey.Password
 	}
 
-	handler, err := configureServerRoutes(context.Background(), cfg, harness.ProfileStore, &hooks)
+	// Mirrors the production startup order deliberately: the harness should
+	// exercise the sequence the service actually uses.
+	validated, err := validateConfiguration(cfg)
 	require.NoError(t, err)
+
+	clients, err := configureUpstreamClients(context.Background(), cfg, validated, &hooks)
+	require.NoError(t, err)
+
+	handler := configureServerRoutes(validated, clients, harness.ProfileStore)
 
 	harness.Server = httptest.NewServer(handler)
 	hooks.AddClose("api-server", harness.Server)

--- a/harness_integration_test.go
+++ b/harness_integration_test.go
@@ -134,8 +134,9 @@ func NewAPITestHarness(t *testing.T, options ...APITestHarnessOption) *APITestHa
 		harness.valkeyPassword = cacheCfg.Valkey.Password
 	}
 
-	// Mirrors the production startup order deliberately: the harness should
-	// exercise the sequence the service actually uses.
+	// Mirrors the production construction sequence, minus the transport
+	// install: tests must not mutate http.DefaultTransport for the whole
+	// process, and with telemetry disabled there is nothing to instrument.
 	validated, err := validateConfiguration(cfg)
 	require.NoError(t, err)
 

--- a/main.go
+++ b/main.go
@@ -278,7 +278,7 @@ func startServer(serverContext context.Context, shutdownHooks *server.ShutdownHo
 
 	validated, err := validateConfiguration(cfg)
 	if err != nil {
-		return fmt.Errorf("configuration validation failed: %w", err)
+		return err
 	}
 
 	// configure telemetry, including wrapping default HTTP client

--- a/main.go
+++ b/main.go
@@ -27,47 +27,77 @@ import (
 	phuslog "github.com/phuslu/log"
 )
 
-func configureServerRoutes(ctx context.Context, cfg config.Config, orgProfile *profile.ProfileStore, hooks *server.ShutdownHooks) (http.Handler, error) {
-	// wrap a mux such that HTTP telemetry is configured by default
-	muxWithoutTelemetry := http.NewServeMux()
-	mux := observe.NewMux(muxWithoutTelemetry)
+type validatedConfig struct {
+	basePath           string // "" when served at the root
+	orgProfileLocation string // "" when no organization profile is configured
+	authorizer         alice.Constructor
+}
 
-	// configure middleware
-	auditor := audit.Middleware()
+// validateConfiguration must not make network calls, so that a configuration
+// error always beats the connectivity failure that would otherwise mask it.
+func validateConfiguration(cfg config.Config) (validatedConfig, error) {
+	// When a base path is configured, it is stripped before routing so the
+	// application can be served under a sub-path (e.g. behind an ALB).
+	basePath, err := config.NormalizeBasePath(cfg.Server.BasePath)
+	if err != nil {
+		return validatedConfig{}, fmt.Errorf("invalid base path: %w", err)
+	}
+
+	// Empty disables organization profiles. Checking here rather than at the
+	// gate is what keeps a typo cheap to diagnose.
+	orgProfileLocation := cfg.Server.OrgProfile
+	if orgProfileLocation != "" {
+		if err := profile.ValidateLocation(orgProfileLocation); err != nil {
+			return validatedConfig{}, fmt.Errorf("invalid organization profile location: %w", err)
+		}
+	}
 
 	authorizer, err := jwt.Middleware(cfg.Authorization)
 	if err != nil {
-		return nil, fmt.Errorf("authorizer configuration failed: %w", err)
+		return validatedConfig{}, fmt.Errorf("authorizer configuration failed: %w", err)
 	}
 
-	// The request body size is fairly limited to prevent accidental or
-	// deliberate abuse. Given the current API shape, this is not configurable.
-	requestLimitBytes := int64(20 << 10) // 20 KB
-	requestLimiter := maxRequestSize(requestLimitBytes)
+	return validatedConfig{
+		basePath:           basePath,
+		orgProfileLocation: orgProfileLocation,
+		authorizer:         authorizer,
+	}, nil
+}
 
-	// When a base path is configured, strip it before routing so the
-	// application can be served under a sub-path (e.g. behind an ALB).
-	normalizedBasePath, err := config.NormalizeBasePath(cfg.Server.BasePath)
-	if err != nil {
-		return nil, fmt.Errorf("invalid base path: %w", err)
-	}
+// upstreamClients must not be replaced after route construction captures it:
+// the handlers would keep the old values.
+type upstreamClients struct {
+	buildkite buildkite.PipelineLookup
+	github    github.Client
 
-	if normalizedBasePath != "" {
-		slog.Info("serving under base path", "path", normalizedBasePath)
-	}
+	// Token rather than app transport, because it reads repository content.
+	// Nil when unconfigured, which is what leaves the refresh task unstarted.
+	profileSource *github.Client
 
-	authorizedRouteMiddleware := alice.New(requestLimiter, auditor, authorizer)
-	standardRouteMiddleware := alice.New(requestLimiter)
+	tokenCache cache.TokenCache[vendor.ProfileToken]
+}
 
-	// setup token handler and dependencies
+// configureUpstreamClients must run after installOutboundTransport: clients
+// capture http.DefaultTransport as they are built, so one made earlier
+// silently loses pool tuning and tracing. Add new clients here.
+func configureUpstreamClients(ctx context.Context, cfg config.Config, validated validatedConfig, hooks *server.ShutdownHooks) (upstreamClients, error) {
 	bk, err := buildkite.New(cfg.Buildkite)
 	if err != nil {
-		return nil, fmt.Errorf("buildkite configuration failed: %w", err)
+		return upstreamClients{}, fmt.Errorf("buildkite configuration failed: %w", err)
 	}
 
 	gh, err := github.New(ctx, cfg.Github)
 	if err != nil {
-		return nil, fmt.Errorf("github configuration failed: %w", err)
+		return upstreamClients{}, fmt.Errorf("github configuration failed: %w", err)
+	}
+
+	var profileSource *github.Client
+	if validated.orgProfileLocation != "" {
+		client, err := github.New(ctx, cfg.Github, github.WithTokenTransport)
+		if err != nil {
+			return upstreamClients{}, fmt.Errorf("github configuration failed: %w", err)
+		}
+		profileSource = &client
 	}
 
 	// Configure cache backend based on CACHE_TYPE
@@ -78,10 +108,40 @@ func configureServerRoutes(ctx context.Context, cfg config.Config, orgProfile *p
 		10_000,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("cache configuration failed: %w", err)
+		return upstreamClients{}, fmt.Errorf("cache configuration failed: %w", err)
 	}
 
 	hooks.Add("cache", tokenCache.Close)
+
+	return upstreamClients{
+		buildkite:     bk,
+		github:        gh,
+		profileSource: profileSource,
+		tokenCache:    tokenCache,
+	}, nil
+}
+
+// configureServerRoutes cannot fail: everything it needs is validated and
+// constructed before it is called.
+func configureServerRoutes(validated validatedConfig, clients upstreamClients, orgProfile *profile.ProfileStore) http.Handler {
+	// wrap a mux such that HTTP telemetry is configured by default
+	muxWithoutTelemetry := http.NewServeMux()
+	mux := observe.NewMux(muxWithoutTelemetry)
+
+	// configure middleware
+	auditor := audit.Middleware()
+
+	// The request body size is fairly limited to prevent accidental or
+	// deliberate abuse. Given the current API shape, this is not configurable.
+	requestLimitBytes := int64(20 << 10) // 20 KB
+	requestLimiter := maxRequestSize(requestLimitBytes)
+
+	if validated.basePath != "" {
+		slog.Info("serving under base path", "path", validated.basePath)
+	}
+
+	authorizedRouteMiddleware := alice.New(requestLimiter, auditor, validated.authorizer)
+	standardRouteMiddleware := alice.New(requestLimiter)
 
 	// Pipeline and organization routes are deliberately separate, with very
 	// different authorization and match rules. This allows for simpler controls
@@ -99,8 +159,8 @@ func configureServerRoutes(ctx context.Context, cfg config.Config, orgProfile *p
 
 	repoVendor := vendor.Auditor(
 		vendor.Authorized(
-			vendor.Cached[profile.PipelineProfileAttr](tokenCache)(
-				vendor.Vending(vendor.PipelineRepositories(bk.RepositoryLookup), gh.CreateAccessToken),
+			vendor.Cached[profile.PipelineProfileAttr](clients.tokenCache)(
+				vendor.Vending(vendor.PipelineRepositories(clients.buildkite.RepositoryLookup), clients.github.CreateAccessToken),
 			),
 		),
 	)
@@ -118,8 +178,8 @@ func configureServerRoutes(ctx context.Context, cfg config.Config, orgProfile *p
 
 	orgVendor := vendor.Auditor(
 		vendor.Authorized(
-			vendor.Cached[profile.OrganizationProfileAttr](tokenCache)(
-				vendor.Vending(vendor.OrgRepositories, gh.CreateAccessToken),
+			vendor.Cached[profile.OrganizationProfileAttr](clients.tokenCache)(
+				vendor.Vending(vendor.OrgRepositories, clients.github.CreateAccessToken),
 			),
 		),
 	)
@@ -133,11 +193,11 @@ func configureServerRoutes(ctx context.Context, cfg config.Config, orgProfile *p
 
 	// StripPrefix wraps the entire mux so it runs before pattern matching.
 	var handler http.Handler = mux
-	if normalizedBasePath != "" {
-		handler = stripPrefix(normalizedBasePath, mux)
+	if validated.basePath != "" {
+		handler = stripPrefix(validated.basePath, mux)
 	}
 
-	return handler, nil
+	return handler
 }
 
 func main() {
@@ -182,26 +242,12 @@ func runWithShutdownHooks(ctx context.Context, run func(context.Context, *server
 //
 // No timeout: a deadline of ours would be evidence about this service rather
 // than the profile source, so the platform's grace period is the backstop.
-//
-// serverCtx builds the GitHub client and outlives shutdown; taskCtx governs the
-// refresh task.
-func startProfileRefresh(serverCtx, taskCtx context.Context, cfg config.Config, orgProfile *profile.ProfileStore) error {
-	orgProfileLocation := cfg.Server.OrgProfile
-	if orgProfileLocation == "" {
+func startProfileRefresh(taskCtx context.Context, orgProfile *profile.ProfileStore, source *github.Client, location string) error {
+	if source == nil {
 		return nil
 	}
 
-	err := profile.ValidateLocation(orgProfileLocation)
-	if err != nil {
-		return fmt.Errorf("invalid organization profile location: %w", err)
-	}
-
-	gh, err := github.New(serverCtx, cfg.Github, github.WithTokenTransport)
-	if err != nil {
-		return fmt.Errorf("github configuration failed: %w", err)
-	}
-
-	ready := profile.RefreshTask(orgProfile, gh, orgProfileLocation).Start(taskCtx)
+	ready := profile.RefreshTask(orgProfile, *source, location).Start(taskCtx)
 
 	return awaitFirstLoad(taskCtx, ready)
 }
@@ -218,12 +264,21 @@ func awaitFirstLoad(ctx context.Context, ready <-chan struct{}) error {
 	}
 }
 
+// startServer's stage order is load-bearing; each stage documents its own
+// constraint. Data flow enforces most of them, but telemetry-before-transport
+// holds only while these calls stay in this order.
 func startServer(serverContext context.Context, shutdownHooks *server.ShutdownHooks) error {
 	orgProfile := profile.NewProfileStore()
 	orgProfile.Update(serverContext, profile.NewDefaultProfiles())
+
 	cfg, err := config.Load(serverContext)
 	if err != nil {
 		return fmt.Errorf("configuration load failed: %w", err)
+	}
+
+	validated, err := validateConfiguration(cfg)
+	if err != nil {
+		return fmt.Errorf("configuration validation failed: %w", err)
 	}
 
 	// configure telemetry, including wrapping default HTTP client
@@ -243,19 +298,14 @@ func startServer(serverContext context.Context, shutdownHooks *server.ShutdownHo
 	}
 	shutdownHooks.Add("pyroscope", downPyroscope)
 
-	http.DefaultTransport = observe.HTTPTransport(
-		configureHTTPTransport(cfg.Server),
-		cfg.Observe,
-	)
-	http.DefaultClient = &http.Client{
-		Transport: http.DefaultTransport,
+	installOutboundTransport(cfg)
+
+	clients, err := configureUpstreamClients(serverContext, cfg, validated, shutdownHooks)
+	if err != nil {
+		return err
 	}
 
-	// setup routing and dependencies
-	handler, err := configureServerRoutes(serverContext, cfg, orgProfile, shutdownHooks)
-	if err != nil {
-		return fmt.Errorf("server routing configuration failed: %w", err)
-	}
+	handler := configureServerRoutes(validated, clients, orgProfile)
 
 	// Signal-aware because the gate below can block indefinitely, and
 	// serveHTTP — which installs the serving path's handler — is not reached
@@ -272,7 +322,7 @@ func startServer(serverContext context.Context, shutdownHooks *server.ShutdownHo
 	// every exit from startup, not just once the server is serving.
 	shutdownHooks.Add("context", func() error { stop(); return nil })
 
-	err = startProfileRefresh(serverContext, taskCtx, cfg, orgProfile)
+	err = startProfileRefresh(taskCtx, orgProfile, clients.profileSource, validated.orgProfileLocation)
 	if err != nil {
 		return err
 	}
@@ -330,6 +380,18 @@ func logBuildInfo() {
 	}
 
 	slog.Info("build information", attrs...)
+}
+
+// installOutboundTransport must run after telemetry is configured: the tracing
+// wrapper binds the providers set up there.
+func installOutboundTransport(cfg config.Config) {
+	http.DefaultTransport = observe.HTTPTransport(
+		configureHTTPTransport(cfg.Server),
+		cfg.Observe,
+	)
+	http.DefaultClient = &http.Client{
+		Transport: http.DefaultTransport,
+	}
 }
 
 func configureHTTPTransport(cfg config.ServerConfig) *http.Transport {

--- a/main_test.go
+++ b/main_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/chinmina/chinmina-bridge/internal/config"
+	"github.com/chinmina/chinmina-bridge/internal/jwt/jwxtest"
 	"github.com/chinmina/chinmina-bridge/internal/profile"
 	"github.com/chinmina/chinmina-bridge/internal/server"
 	"github.com/stretchr/testify/assert"
@@ -90,40 +91,187 @@ func TestRunWithShutdownHooks(t *testing.T) {
 	})
 }
 
-func TestStartProfileRefresh(t *testing.T) {
-	t.Run("does nothing when no organization profile location is configured", func(t *testing.T) {
-		store := profile.NewProfileStore()
-		before := store.Digest()
+// validConfig passes offline validation, so each case can vary only the field
+// it exercises.
+func validConfig(t *testing.T) config.Config {
+	t.Helper()
 
-		// The GitHub config is deliberately empty: reaching the client would
-		// fail, so returning cleanly proves the gate was never entered.
-		err := startProfileRefresh(t.Context(), t.Context(), config.Config{}, store)
+	return config.Config{
+		Authorization: config.AuthorizationConfig{
+			Audience:                  "test-audience",
+			BuildkiteOrganizationSlug: "test-org",
+			IssuerURL:                 "https://agent.buildkite.com",
+		},
+		Buildkite: config.BuildkiteConfig{
+			Token: "test-buildkite-token",
+		},
+		Cache: config.CacheConfig{Type: "memory"},
+		Github: config.GithubConfig{
+			PrivateKey:     jwxtest.NewJWK(t).PrivateKeyPEM(),
+			ApplicationID:  12345,
+			InstallationID: 67890,
+		},
+	}
+}
 
-		require.NoError(t, err)
-		assert.Equal(t, before, store.Digest())
-	})
+func TestValidateConfiguration_Valid(t *testing.T) {
+	tests := []struct {
+		name       string
+		modify     func(*config.Config)
+		expectPath string
+		expectOrg  string
+	}{
+		{
+			name:   "no base path and no organization profile",
+			modify: func(*config.Config) {},
+		},
+		{
+			name:       "base path is normalized",
+			modify:     func(c *config.Config) { c.Server.BasePath = "chinmina/" },
+			expectPath: "/chinmina",
+		},
+		{
+			name:      "organization profile location is retained",
+			modify:    func(c *config.Config) { c.Server.OrgProfile = "acme:silk:profile.yaml" },
+			expectOrg: "acme:silk:profile.yaml",
+		},
+		{
+			name: "a path containing colons is part of the location",
+			modify: func(c *config.Config) {
+				c.Server.OrgProfile = "acme:silk:some:nested:path.yaml"
+			},
+			expectOrg: "acme:silk:some:nested:path.yaml",
+		},
+	}
 
-	t.Run("rejects a malformed organization profile location", func(t *testing.T) {
-		locations := []string{
-			"acme:silk",
-			"profile.yaml",
-			":silk:docs/profile.yaml",
-			"acme::docs/profile.yaml",
-			"acme:silk:",
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validConfig(t)
+			tt.modify(&cfg)
 
-		for _, location := range locations {
-			t.Run(location, func(t *testing.T) {
-				cfg := config.Config{}
-				cfg.Server.OrgProfile = location
+			validated, err := validateConfiguration(cfg)
 
-				err := startProfileRefresh(t.Context(), t.Context(), cfg, profile.NewProfileStore())
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectPath, validated.basePath)
+			assert.Equal(t, tt.expectOrg, validated.orgProfileLocation)
+			assert.NotNil(t, validated.authorizer)
+		})
+	}
+}
 
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), "invalid organization profile location")
-			})
-		}
-	})
+func TestValidateConfiguration_Invalid(t *testing.T) {
+	tests := []struct {
+		name          string
+		modify        func(*config.Config)
+		expectedError string
+	}{
+		{
+			name:          "base path with double slashes",
+			modify:        func(c *config.Config) { c.Server.BasePath = "/chinmina//bridge" },
+			expectedError: "invalid base path",
+		},
+		{
+			name: "authorization configuration that cannot be used",
+			modify: func(c *config.Config) {
+				c.Authorization.ConfigurationStatic = "not-a-jwks"
+			},
+			expectedError: "authorizer configuration failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validConfig(t)
+			tt.modify(&cfg)
+
+			_, err := validateConfiguration(cfg)
+
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tt.expectedError)
+		})
+	}
+}
+
+// These moved from the gate to the offline stage; reaching the gate with an
+// unresolvable location is the failure ValidateLocation exists to prevent.
+func TestValidateConfiguration_MalformedProfileLocation(t *testing.T) {
+	locations := []string{
+		"acme:silk",
+		"profile.yaml",
+		":silk:docs/profile.yaml",
+		"acme::docs/profile.yaml",
+		"acme:silk:",
+	}
+
+	for _, location := range locations {
+		t.Run(location, func(t *testing.T) {
+			cfg := validConfig(t)
+			cfg.Server.OrgProfile = location
+
+			_, err := validateConfiguration(cfg)
+
+			require.Error(t, err)
+			assert.ErrorContains(t, err, "invalid organization profile location")
+		})
+	}
+}
+
+func TestConfigureUpstreamClients_ProfileSource(t *testing.T) {
+	tests := []struct {
+		name             string
+		orgProfile       string
+		expectProfileSrc bool
+	}{
+		{name: "constructed when an organization profile is configured", orgProfile: "acme:silk:profile.yaml", expectProfileSrc: true},
+		{name: "absent when no organization profile is configured", orgProfile: "", expectProfileSrc: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validConfig(t)
+			cfg.Server.OrgProfile = tt.orgProfile
+
+			validated, err := validateConfiguration(cfg)
+			require.NoError(t, err)
+
+			hooks := &server.ShutdownHooks{}
+			t.Cleanup(func() { hooks.Execute(t.Context()) })
+
+			clients, err := configureUpstreamClients(t.Context(), cfg, validated, hooks)
+
+			require.NoError(t, err)
+			require.NotNil(t, clients.tokenCache)
+			assert.Equal(t, tt.expectProfileSrc, clients.profileSource != nil)
+		})
+	}
+}
+
+func TestConfigureUpstreamClients_ConfigurationError(t *testing.T) {
+	cfg := validConfig(t)
+	cfg.Cache.Type = "not-a-cache-backend"
+
+	validated, err := validateConfiguration(cfg)
+	require.NoError(t, err)
+
+	hooks := &server.ShutdownHooks{}
+	t.Cleanup(func() { hooks.Execute(t.Context()) })
+
+	_, err = configureUpstreamClients(t.Context(), cfg, validated, hooks)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "cache configuration failed")
+}
+
+func TestStartProfileRefresh_NotConfigured(t *testing.T) {
+	store := profile.NewProfileStore()
+	before := store.Digest()
+
+	// Returning cleanly is the assertion: nothing loaded, no gate entered, so an
+	// unconfigured deployment starts as it always did.
+	err := startProfileRefresh(t.Context(), store, nil, "")
+
+	require.NoError(t, err)
+	assert.Equal(t, before, store.Digest())
 }
 
 func TestAwaitFirstLoad(t *testing.T) {


### PR DESCRIPTION
## Purpose

Startup interleaved validating configuration, constructing upstream clients, and building routes, which left the order between them accidental rather than intended. A malformed organization profile location was only rejected once the gate was being set up, so a typo was reported behind client construction and a connectivity failure could mask it entirely. Startup now runs offline validation to completion first, so a configuration error always beats the network failure that would otherwise hide it.

The transport ordering matters for what comes next. Each GitHub client captures `http.DefaultTransport` when it is built, so a client constructed before the tuned, instrumented transport is installed silently loses connection pool tuning and outbound tracing. Making that a property of where clients are built, rather than of where the calls happen to sit, is what lets the app registry add its own clients later without inheriting an untraced, untuned path for its installation-verification queries. Clients are also built as a group before routes are built from them, so no handler can capture one that is replaced afterwards.

There is no behaviour change for single-app deployments. Each configuration error keeps its own message, and is now reported earlier in startup. The stage-name prefixes that used to wrap them are gone: a cache dial failure was previously reported as "server routing configuration failed", which named the wrong subsystem.

## Context

Stacked on #371, which this rebases onto. The startup gate keeps its position and its contract, but sheds two jobs it had picked up for want of a better home: location validation moves into the offline stage, and the profile source client joins the other upstream clients so it too is built on the instrumented transport. Its absence, rather than an empty configuration string, is now what says the feature is off. The gate's tests followed the checks that moved.

Reasoning for the individual changes is in the commit messages; the diff covers what moved.