### PR TITLE
feat: create tokens through multiple GitHub Apps

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -153,6 +153,10 @@ source_env_if_exists .envrc.private
 # export GITHUB_APPS='[
 #   {"name": "packages", "appId": 333, "installationId": 444, "privateKeyArn": "<AWS KMS alias arn>"}
 # ]'
+# or, read the JSON from a file instead (mutually exclusive with GITHUB_APPS).
+# Preferred when entries carry an inline privateKey, since it keeps the key out
+# of the process environment:
+# export GITHUB_APPS_FILE="<path to apps json>"
 
 # optionally, if you intend to use organisation profiles
 # export GITHUB_ORG_PROFILE="<ORG PROFILE LOCATION>

--- a/.envrc
+++ b/.envrc
@@ -146,6 +146,14 @@ source_env_if_exists .envrc.private
 # required
 # export GITHUB_APP_INSTALLATION_ID="<id of installation of app for user/organization>"
 
+# optional: additional apps that profiles may mint through by name, as a JSON
+# array. Each entry needs a name, appId and installationId, and exactly one of
+# privateKey or privateKeyArn. Every app must be installed on the same
+# organization as the app above.
+# export GITHUB_APPS='[
+#   {"name": "packages", "appId": 333, "installationId": 444, "privateKeyArn": "<AWS KMS alias arn>"}
+# ]'
+
 # optionally, if you intend to use organisation profiles
 # export GITHUB_ORG_PROFILE="<ORG PROFILE LOCATION>
 

--- a/.envrc
+++ b/.envrc
@@ -163,6 +163,18 @@ source_env_if_exists .envrc.private
 
 
 #
+# development-only switches
+#
+
+# Never set these in production; each defaults to the production behaviour.
+
+# Adds the minting GitHub App's identity to both response formats, for
+# confirming locally which installation a profile mints through. The audit log
+# records the identifiers either way.
+# export DEV_DISCLOSE_APP_IDENTIFIERS=true
+
+
+#
 # local OIDC utility
 #
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,25 @@ tokenVendor := vendor.Auditor(vendorCache(vendor.New(bk.RepositoryLookup, gh.Cre
 - Handlers return appropriate HTTP status codes via `requestError(w, statusCode)`
 - panic() may not be added by CI agents without explicit direction to do so. The plan must state explicitly that a panic can be used in a given situation. Otherwise, errors must be used.
 
+### JSON
+
+- **JSON v2 is mandatory for all new code**: import `encoding/json/v2` (and
+  `encoding/json/jsontext` for raw values). `encoding/json` (v1) must not be used
+  in new or modified code, including tests. `GOEXPERIMENT=jsonv2` is set by
+  `.envrc` and the `justfile`; any new build or CI entry point must set it too.
+- v2 is required because its defaults are safe by construction: `json.Unmarshal`
+  rejects trailing data after the top-level value, duplicate object members are
+  an error, and field matching is case-sensitive. The v1 streaming decoder
+  silently accepts a truncated or concatenated document.
+- Reject unknown fields explicitly with `json.RejectUnknownMembers(true)` when
+  decoding configuration or requests: a silently ignored typo is configuration
+  that behaves differently from how it reads.
+- JSON `null` unmarshals to a nil slice/map/pointer without error. Where null
+  and "absent" must be distinguished (configuration especially), check for it
+  explicitly and fail. See `parseAppEntries` in `internal/github/registry.go`.
+- Existing `encoding/json` usages are migrated opportunistically; do not leave a
+  file you are already changing on v1.
+
 ### Concurrency
 
 - Put a critical section in its own function and unlock with `defer`: the body is

--- a/api_integration_test.go
+++ b/api_integration_test.go
@@ -998,3 +998,33 @@ func TestIntegrationProfileRefresh_ServesNoMixedGeneration(t *testing.T) {
 	require.Positive(t, vended, "some caller must have been admitted")
 	require.Positive(t, denied, "some caller must have been denied by the other generation")
 }
+
+// Decoded as a map, not a struct: a struct would hide an absent key.
+func TestIntegrationPipelineToken_WithholdsAppIdentifiersByDefault(t *testing.T) {
+	harness := NewAPITestHarness(t)
+	harness.BuildkiteMock.RepositoryURL = "https://github.com/test-org/test-repo"
+
+	response, status, err := harness.Client().RequestJSON("POST", "/token", harness.PipelineToken(), nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, status)
+
+	assert.Equal(t, "default", response["app"])
+	assert.NotContains(t, response, "appId")
+	assert.NotContains(t, response, "installationId")
+}
+
+func TestIntegrationPipelineGitCredentials_WithholdsAppIdentifiersByDefault(t *testing.T) {
+	harness := NewAPITestHarness(t)
+	harness.BuildkiteMock.RepositoryURL = "https://github.com/test-org/test-repo"
+
+	props, err := harness.Client().GitCredentials(harness.PipelineToken(), "",
+		GitCredentialRequest{Protocol: "https", Host: "github.com", Path: "test-org/test-repo"})
+	require.NoError(t, err)
+
+	var keys []string
+	for i := props.Iter(); i.HasNext(); {
+		k, _ := i.Next()
+		keys = append(keys, k)
+	}
+	assert.Equal(t, []string{"protocol", "host", "path", "username", "password", "password_expiry_utc"}, keys)
+}

--- a/handlers.go
+++ b/handlers.go
@@ -227,8 +227,12 @@ func recordResolvedRequest[T any](ctx context.Context, resolved vendor.Resolved[
 	entry.RequestedRepository = requestedRepo
 
 	// Recorded at resolution rather than at vend, so a failed mint still names
-	// the app it was attempted through.
+	// the app it was attempted through. The identifiers come from the resolved
+	// identity rather than the vended token, which also keeps them correct on a
+	// cache hit predating their addition to the payload.
 	entry.App = resolved.App.Name
+	entry.ApplicationID = resolved.App.ApplicationID
+	entry.InstallationID = resolved.App.InstallationID
 }
 
 // recordRequestedName stamps the raw profile path parameter before anything can

--- a/handlers.go
+++ b/handlers.go
@@ -107,17 +107,12 @@ type ProfileResolver[T any] struct {
 	Resolve func(ctx context.Context, pv PathValuer, explicitScope, implicitScope string) (vendor.Resolved[T], error)
 }
 
-// AppResolver maps a profile's declared app name to the identity its tokens
-// are minted through. It is the app registry's own resolution function, and a
-// disabled app resolves to nothing.
+// AppResolver maps a profile's declared app name to the identity its tokens are
+// minted through; a disabled app resolves to nothing.
 //
-// It is consulted in the profile resolver, and nowhere else on the request
-// path. The vendor chain is Audit -> Authorized -> Cached -> Vending, and
-// Cached short-circuits on a hit before Vending runs, so a registry check
-// inside the chain would be absent on exactly the requests that need it: those
-// whose profile was valid long enough to warm a cache entry and has since had
-// its app disabled. Resolving at the boundary makes this lookup the guard that
-// runs on every request, warm cache or cold.
+// It is consulted in the profile resolver, not inside the vendor chain: Cached
+// short-circuits before Vending, so a check in the chain would be skipped on
+// exactly the warm-cache requests whose app has since been disabled.
 type AppResolver func(name string) (github.AppIdentity, bool)
 
 // NewOrgProfileResolver returns the resolver for the /organization/* routes,
@@ -189,9 +184,8 @@ func NewPipelineProfileResolver(lookup ProfileLookup[profile.PipelineProfileAttr
 // audit entry, and nothing downstream of a failed resolution may read a
 // half-populated value.
 //
-// T is constrained to AppNamed because this is the one stage that reads a
-// family-specific attribute. Every stage downstream reads the resolved
-// identity from the request value and stays generic.
+// T is constrained to AppNamed because this is the only stage that reads a
+// family-specific attribute; downstream stages read the resolved app instead.
 func resolveProfile[T profile.AppNamed](ctx context.Context, pv PathValuer, lookup ProfileLookup[T], resolveApp AppResolver, expectedType profile.ProfileType) (vendor.Resolved[T], error) {
 	claims := jwt.RequireBuildkiteClaimsFromContext(ctx)
 
@@ -209,10 +203,8 @@ func resolveProfile[T profile.AppNamed](ctx context.Context, pv PathValuer, look
 
 	app, resolvable := resolveApp(appName)
 	if !resolvable {
-		// Reaching this means a profile was served that compilation should
-		// already have invalidated, so it is our defect rather than GitHub's
-		// denial: a 500, not a 403 or a 404. The existing guards for an
-		// unresolved scope and an uncompiled matcher have the same shape.
+		// A served profile naming an unresolvable app is our defect rather
+		// than GitHub's denial: a 500, not a 403 or a 404.
 		return vendor.Resolved[T]{}, profile.AppUnresolvedError{ProfileName: ref.Name, AppName: appName}
 	}
 
@@ -234,9 +226,8 @@ func recordResolvedRequest[T any](ctx context.Context, resolved vendor.Resolved[
 	entry.RequestedProfile = resolved.Ref.String()
 	entry.RequestedRepository = requestedRepo
 
-	// Recorded at resolution rather than at vend, so every outcome reached
-	// after this point — including a failed mint — names the app it was
-	// attempted through.
+	// Recorded at resolution rather than at vend, so a failed mint still names
+	// the app it was attempted through.
 	entry.App = resolved.App.Name
 }
 

--- a/handlers.go
+++ b/handlers.go
@@ -227,9 +227,7 @@ func recordResolvedRequest[T any](ctx context.Context, resolved vendor.Resolved[
 	entry.RequestedRepository = requestedRepo
 
 	// Recorded at resolution rather than at vend, so a failed mint still names
-	// the app it was attempted through. The identifiers come from the resolved
-	// identity rather than the vended token, which also keeps them correct on a
-	// cache hit predating their addition to the payload.
+	// the app, and a cache hit predating the identifiers still reports them.
 	entry.App = resolved.App.Name
 	entry.ApplicationID = resolved.App.ApplicationID
 	entry.InstallationID = resolved.App.InstallationID
@@ -305,7 +303,7 @@ func extractRepositoryScope(r *http.Request) (string, error) {
 	return scope, nil
 }
 
-func handlePostToken[T any](tokenVendor vendor.ProfileTokenVendor[T], resolve ProfileResolver[T]) http.Handler {
+func handlePostToken[T any](tokenVendor vendor.ProfileTokenVendor[T], resolve ProfileResolver[T], marshaler TokenResponseMarshaler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer drainRequestBody(r)
 		recordRequestedName(r.Context(), r)
@@ -344,8 +342,7 @@ func handlePostToken[T any](tokenVendor vendor.ProfileTokenVendor[T], resolve Pr
 
 		// VendStatusSuccess: write the response to the client as JSON, supplying
 		// the token and URL of the repository it's vended for.
-		tokenResponse := result.Token()
-		marshalledResponse, err := json.Marshal(tokenResponse)
+		marshalledResponse, err := marshaler.MarshalToken(result.Token())
 		if err != nil {
 			requestError(r.Context(), w, http.StatusInternalServerError, fmt.Errorf("failed to marshal token response: %w", err))
 			return
@@ -362,7 +359,7 @@ func handlePostToken[T any](tokenVendor vendor.ProfileTokenVendor[T], resolve Pr
 	})
 }
 
-func handlePostGitCredentials[T any](tokenVendor vendor.ProfileTokenVendor[T], resolve ProfileResolver[T]) http.Handler {
+func handlePostGitCredentials[T any](tokenVendor vendor.ProfileTokenVendor[T], resolve ProfileResolver[T], marshaler TokenResponseMarshaler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer drainRequestBody(r)
 		recordRequestedName(r.Context(), r)
@@ -427,15 +424,7 @@ func handlePostGitCredentials[T any](tokenVendor vendor.ProfileTokenVendor[T], r
 			return
 		}
 
-		props := credentialhandler.NewMap(6)
-		props.Set("protocol", tokenURL.Scheme)
-		props.Set("host", tokenURL.Host)
-		props.Set("path", strings.TrimPrefix(tokenURL.Path, "/"))
-		props.Set("username", "x-access-token")
-		props.Set("password", tokenResponse.Token)
-		props.Set("password_expiry_utc", tokenResponse.ExpiryUnix())
-
-		err = credentialhandler.WriteProperties(props, w)
+		err = credentialhandler.WriteProperties(marshaler.CredentialProperties(tokenResponse, tokenURL), w)
 		if err != nil {
 			requestError(r.Context(), w, http.StatusInternalServerError, fmt.Errorf("failed to write response: %w", err))
 			return

--- a/handlers.go
+++ b/handlers.go
@@ -107,6 +107,19 @@ type ProfileResolver[T any] struct {
 	Resolve func(ctx context.Context, pv PathValuer, explicitScope, implicitScope string) (vendor.Resolved[T], error)
 }
 
+// AppResolver maps a profile's declared app name to the identity its tokens
+// are minted through. It is the app registry's own resolution function, and a
+// disabled app resolves to nothing.
+//
+// It is consulted in the profile resolver, and nowhere else on the request
+// path. The vendor chain is Audit -> Authorized -> Cached -> Vending, and
+// Cached short-circuits on a hit before Vending runs, so a registry check
+// inside the chain would be absent on exactly the requests that need it: those
+// whose profile was valid long enough to warm a cache entry and has since had
+// its app disabled. Resolving at the boundary makes this lookup the guard that
+// runs on every request, warm cache or cold.
+type AppResolver func(name string) (github.AppIdentity, bool)
+
 // NewOrgProfileResolver returns the resolver for the /organization/* routes,
 // enforcing the bidirectional scope rules below; they require the profile's
 // declared scope, so they can only run once the profile is resolved.
@@ -124,11 +137,11 @@ type ProfileResolver[T any] struct {
 // allow-list by design; the only controls are the match rules, the granted
 // permissions, and the App's installation scope. Pair caller-scoped
 // profiles with narrow permissions and tight match rules.
-func NewOrgProfileResolver(lookup ProfileLookup[profile.OrganizationProfileAttr]) ProfileResolver[profile.OrganizationProfileAttr] {
+func NewOrgProfileResolver(lookup ProfileLookup[profile.OrganizationProfileAttr], resolveApp AppResolver) ProfileResolver[profile.OrganizationProfileAttr] {
 	return ProfileResolver[profile.OrganizationProfileAttr]{
 		AcceptsRepositoryScope: true,
 		Resolve: func(ctx context.Context, pv PathValuer, explicitScope, implicitScope string) (vendor.Resolved[profile.OrganizationProfileAttr], error) {
-			resolved, err := resolveProfile(ctx, pv, lookup, profile.ProfileTypeOrg)
+			resolved, err := resolveProfile(ctx, pv, lookup, resolveApp, profile.ProfileTypeOrg)
 			if err != nil {
 				return resolved, err
 			}
@@ -162,19 +175,24 @@ func NewOrgProfileResolver(lookup ProfileLookup[profile.OrganizationProfileAttr]
 // NewPipelineProfileResolver returns the resolver for the /token and
 // /git-credentials routes. Pipeline profiles are never scoped, so both scope
 // signals are ignored.
-func NewPipelineProfileResolver(lookup ProfileLookup[profile.PipelineProfileAttr]) ProfileResolver[profile.PipelineProfileAttr] {
+func NewPipelineProfileResolver(lookup ProfileLookup[profile.PipelineProfileAttr], resolveApp AppResolver) ProfileResolver[profile.PipelineProfileAttr] {
 	return ProfileResolver[profile.PipelineProfileAttr]{
 		Resolve: func(ctx context.Context, pv PathValuer, _, _ string) (vendor.Resolved[profile.PipelineProfileAttr], error) {
-			return resolveProfile(ctx, pv, lookup, profile.ProfileTypeRepo)
+			return resolveProfile(ctx, pv, lookup, resolveApp, profile.ProfileTypeRepo)
 		},
 	}
 }
 
-// resolveProfile parses the profile path parameter and reads the named profile
-// from configuration exactly once. Failure returns an empty Resolved: the raw
-// requested name is already on the audit entry, and nothing downstream of a
-// failed resolution may read a half-populated value.
-func resolveProfile[T any](ctx context.Context, pv PathValuer, lookup ProfileLookup[T], expectedType profile.ProfileType) (vendor.Resolved[T], error) {
+// resolveProfile parses the profile path parameter, reads the named profile
+// from configuration exactly once, and resolves the app it mints through.
+// Failure returns an empty Resolved: the raw requested name is already on the
+// audit entry, and nothing downstream of a failed resolution may read a
+// half-populated value.
+//
+// T is constrained to AppNamed because this is the one stage that reads a
+// family-specific attribute. Every stage downstream reads the resolved
+// identity from the request value and stays generic.
+func resolveProfile[T profile.AppNamed](ctx context.Context, pv PathValuer, lookup ProfileLookup[T], resolveApp AppResolver, expectedType profile.ProfileType) (vendor.Resolved[T], error) {
 	claims := jwt.RequireBuildkiteClaimsFromContext(ctx)
 
 	ref, err := profile.NewProfileRef(claims, expectedType, pv.PathValue("profile"))
@@ -187,7 +205,18 @@ func resolveProfile[T any](ctx context.Context, pv PathValuer, lookup ProfileLoo
 		return vendor.Resolved[T]{}, err
 	}
 
-	return vendor.Resolved[T]{Ref: ref, Profile: authProfile, Digest: digest}, nil
+	appName := authProfile.Attrs.AppName()
+
+	app, resolvable := resolveApp(appName)
+	if !resolvable {
+		// Reaching this means a profile was served that compilation should
+		// already have invalidated, so it is our defect rather than GitHub's
+		// denial: a 500, not a 403 or a 404. The existing guards for an
+		// unresolved scope and an uncompiled matcher have the same shape.
+		return vendor.Resolved[T]{}, profile.AppUnresolvedError{ProfileName: ref.Name, AppName: appName}
+	}
+
+	return vendor.Resolved[T]{Ref: ref, Profile: authProfile, Digest: digest, App: app}, nil
 }
 
 // recordResolvedRequest stamps the request's intent on the audit entry once
@@ -200,10 +229,15 @@ func resolveProfile[T any](ctx context.Context, pv PathValuer, lookup ProfileLoo
 // name can itself be URN-shaped. Distinguish a served request from a
 // rejected one via the entry's error field, never the shape of
 // requestedProfile.
-func recordResolvedRequest(ctx context.Context, ref profile.ProfileRef, requestedRepo string) {
+func recordResolvedRequest[T any](ctx context.Context, resolved vendor.Resolved[T], requestedRepo string) {
 	entry := audit.Log(ctx)
-	entry.RequestedProfile = ref.String()
+	entry.RequestedProfile = resolved.Ref.String()
 	entry.RequestedRepository = requestedRepo
+
+	// Recorded at resolution rather than at vend, so every outcome reached
+	// after this point — including a failed mint — names the app it was
+	// attempted through.
+	entry.App = resolved.App.Name
 }
 
 // recordRequestedName stamps the raw profile path parameter before anything can
@@ -299,7 +333,7 @@ func handlePostToken[T any](tokenVendor vendor.ProfileTokenVendor[T], resolve Pr
 			writeJSONError(r.Context(), w, resolveError{err: err})
 			return
 		}
-		recordResolvedRequest(r.Context(), resolved.Ref, "")
+		recordResolvedRequest(r.Context(), resolved, "")
 
 		result := tokenVendor(r.Context(), resolved, "")
 
@@ -369,7 +403,7 @@ func handlePostGitCredentials[T any](tokenVendor vendor.ProfileTokenVendor[T], r
 			writeTextError(r.Context(), w, resolveError{err: err})
 			return
 		}
-		recordResolvedRequest(r.Context(), resolved.Ref, requestedRepoURL)
+		recordResolvedRequest(r.Context(), resolved, requestedRepoURL)
 
 		result := tokenVendor(r.Context(), resolved, requestedRepoURL)
 

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -79,12 +79,12 @@ func TestHandlers_RequireClaims(t *testing.T) {
 	}{
 		{
 			name:    "postToken",
-			handler: handlePostToken(nil, testPipelineResolver()),
+			handler: handlePostToken(nil, testPipelineResolver(), withheld),
 			body:    nil,
 		},
 		{
 			name:    "postGitCredentials",
-			handler: handlePostGitCredentials(nil, testPipelineResolver()),
+			handler: handlePostGitCredentials(nil, testPipelineResolver(), withheld),
 			body:    validGitCredsBody(),
 		},
 	}
@@ -113,7 +113,7 @@ func TestHandlePostToken_ReturnsTokenOnSuccess(t *testing.T) {
 	rr := httptest.NewRecorder()
 
 	// act
-	handler := handlePostToken(tokenVendor, testPipelineResolver())
+	handler := handlePostToken(tokenVendor, testPipelineResolver(), withheld)
 	handler.ServeHTTP(rr, req)
 
 	// assert
@@ -141,7 +141,7 @@ func TestHandlePostToken_ReturnsFailureOnVendorFailure(t *testing.T) {
 	rr := httptest.NewRecorder()
 
 	// act
-	handler := handlePostToken(tokenVendor, testPipelineResolver())
+	handler := handlePostToken(tokenVendor, testPipelineResolver(), withheld)
 	handler.ServeHTTP(rr, req)
 
 	// assert
@@ -185,7 +185,7 @@ func TestHandlePostTokenWithProfile_ReturnsTokenOnSuccess(t *testing.T) {
 			rr := httptest.NewRecorder()
 
 			// act
-			handler := handlePostToken(tokenVendor, testPipelineResolver())
+			handler := handlePostToken(tokenVendor, testPipelineResolver(), withheld)
 			handler.ServeHTTP(rr, req)
 
 			// assert
@@ -222,7 +222,7 @@ func TestHandlePostGitCredentials_ReturnsTokenOnSuccess(t *testing.T) {
 	rr := httptest.NewRecorder()
 
 	// act
-	handler := handlePostGitCredentials(tokenVendor, testPipelineResolver())
+	handler := handlePostGitCredentials(tokenVendor, testPipelineResolver(), withheld)
 	handler.ServeHTTP(rr, req)
 
 	// assert
@@ -252,7 +252,7 @@ func TestHandlePostGitCredentials_ReturnsEmptySuccessWhenNoToken(t *testing.T) {
 	rr := httptest.NewRecorder()
 
 	// act
-	handler := handlePostGitCredentials(tokenVendor, testPipelineResolver())
+	handler := handlePostGitCredentials(tokenVendor, testPipelineResolver(), withheld)
 	handler.ServeHTTP(rr, req)
 
 	// assert
@@ -276,7 +276,7 @@ func TestHandlePostGitCredentials_ReturnsFailureOnInvalidRequest(t *testing.T) {
 	rr := httptest.NewRecorder()
 
 	// act
-	handler := handlePostGitCredentials(tokenVendor, testPipelineResolver())
+	handler := handlePostGitCredentials(tokenVendor, testPipelineResolver(), withheld)
 	handler.ServeHTTP(rr, req)
 
 	// assert
@@ -305,7 +305,7 @@ func TestHandlePostGitCredentials_ReturnsFailureOnReadFailure(t *testing.T) {
 	// act
 	handler := maxRequestSize(1)(
 		// use the request size limit to force an error in the credentials handler
-		handlePostGitCredentials(tokenVendor, testPipelineResolver()),
+		handlePostGitCredentials(tokenVendor, testPipelineResolver(), withheld),
 	)
 	handler.ServeHTTP(rr, req)
 
@@ -332,7 +332,7 @@ func TestHandlePostGitCredentials_ReturnsFailureOnVendorFailure(t *testing.T) {
 	rr := httptest.NewRecorder()
 
 	// act
-	handler := handlePostGitCredentials(tokenVendor, testPipelineResolver())
+	handler := handlePostGitCredentials(tokenVendor, testPipelineResolver(), withheld)
 	handler.ServeHTTP(rr, req)
 
 	// assert
@@ -380,7 +380,7 @@ func TestHandlePostGitCredentialsWithRepoProfile_ReturnsTokenOnSuccess(t *testin
 			rr := httptest.NewRecorder()
 
 			// act
-			handler := handlePostGitCredentials(tokenVendor, testPipelineResolver())
+			handler := handlePostGitCredentials(tokenVendor, testPipelineResolver(), withheld)
 			handler.ServeHTTP(rr, req)
 
 			// assert
@@ -447,7 +447,7 @@ func TestHandlePostGitCredentialsWithProfile_ReturnsTokenOnSuccess(t *testing.T)
 	rr := httptest.NewRecorder()
 
 	// act
-	handler := handlePostGitCredentials(tokenVendor, resolve)
+	handler := handlePostGitCredentials(tokenVendor, resolve, withheld)
 	handler.ServeHTTP(rr, req)
 
 	// assert
@@ -558,7 +558,7 @@ func TestHandlePostToken_ProfileErrors(t *testing.T) {
 			rr := httptest.NewRecorder()
 
 			// act
-			handler := handlePostToken(tokenVendor, testPipelineResolver())
+			handler := handlePostToken(tokenVendor, testPipelineResolver(), withheld)
 			handler.ServeHTTP(rr, req)
 
 			// assert
@@ -587,7 +587,7 @@ func TestHandlePostToken_ClaimValidationError(t *testing.T) {
 	rr := httptest.NewRecorder()
 
 	// act
-	handler := handlePostToken(tokenVendor, testPipelineResolver())
+	handler := handlePostToken(tokenVendor, testPipelineResolver(), withheld)
 	handler.ServeHTTP(rr, req)
 
 	// assert
@@ -617,7 +617,7 @@ func TestHandlePostGitCredentials_ClaimValidationError(t *testing.T) {
 	rr := httptest.NewRecorder()
 
 	// act
-	handler := handlePostGitCredentials(tokenVendor, testPipelineResolver())
+	handler := handlePostGitCredentials(tokenVendor, testPipelineResolver(), withheld)
 	handler.ServeHTTP(rr, req)
 
 	// assert
@@ -935,7 +935,7 @@ func TestHandlePostToken_PipelineProfileNotFoundAnswers404(t *testing.T) {
 	require.NoError(t, err)
 
 	rr := httptest.NewRecorder()
-	handlePostToken(tokenVendor, resolve).ServeHTTP(rr, req)
+	handlePostToken(tokenVendor, resolve, withheld).ServeHTTP(rr, req)
 
 	assert.Equal(t, http.StatusNotFound, rr.Code)
 	assert.False(t, vended, "no token may be vended for a profile that does not exist")
@@ -977,7 +977,7 @@ func TestHandlePostToken_OrgStaticList_RejectsScopeWithSpecificMessage(t *testin
 	req.SetPathValue("profile", "static-profile")
 	rr := httptest.NewRecorder()
 
-	handler := handlePostToken(tv[orgAttr]("unused"), resolve)
+	handler := handlePostToken(tv[orgAttr]("unused"), resolve, withheld)
 	handler.ServeHTTP(rr, req)
 
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
@@ -997,7 +997,7 @@ func TestHandlePostToken_OrgCallerScoped_MissingScopeReturnsSpecificMessage(t *t
 	req.SetPathValue("profile", "caller-scoped-profile")
 	rr := httptest.NewRecorder()
 
-	handler := handlePostToken(tv[orgAttr]("unused"), resolve)
+	handler := handlePostToken(tv[orgAttr]("unused"), resolve, withheld)
 	handler.ServeHTTP(rr, req)
 
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
@@ -1075,7 +1075,7 @@ func TestHandlePostToken_PipelineRouteIgnoresRepositoryScope(t *testing.T) {
 	req.SetPathValue("profile", "default")
 
 	rr := httptest.NewRecorder()
-	handlePostToken(tokenVendor, testPipelineResolver()).ServeHTTP(rr, req)
+	handlePostToken(tokenVendor, testPipelineResolver(), withheld).ServeHTTP(rr, req)
 
 	require.Equal(t, http.StatusOK, rr.Code, "a scope parameter the route ignores must not fail the request")
 }
@@ -1223,13 +1223,13 @@ func TestHandlers_RecordRequestedProfileWhenResolutionFails(t *testing.T) {
 		{
 			name: "postToken",
 			handler: func(r ProfileResolver[orgAttr]) http.Handler {
-				return handlePostToken(tv[orgAttr]("unused"), r)
+				return handlePostToken(tv[orgAttr]("unused"), r, withheld)
 			},
 		},
 		{
 			name: "postGitCredentials",
 			handler: func(r ProfileResolver[orgAttr]) http.Handler {
-				return handlePostGitCredentials(tv[orgAttr]("unused"), r)
+				return handlePostGitCredentials(tv[orgAttr]("unused"), r, withheld)
 			},
 			body: gitCredentialsBody(t, "org", "repo1"),
 		},
@@ -1267,7 +1267,7 @@ func TestHandlers_UnresolvedProfileIsNotAuditedAsCanonicalURN(t *testing.T) {
 	req.SetPathValue("profile", forged)
 
 	rr := httptest.NewRecorder()
-	handlePostToken(tv[orgAttr]("unused"), NewOrgProfileResolver(store.GetOrganizationProfile, testAppResolver)).ServeHTTP(rr, req)
+	handlePostToken(tv[orgAttr]("unused"), NewOrgProfileResolver(store.GetOrganizationProfile, testAppResolver), withheld).ServeHTTP(rr, req)
 
 	require.Equal(t, http.StatusNotFound, rr.Code)
 	assert.Equal(t, forged, entry.RequestedProfile, "an unresolved name must be recorded verbatim, never as a URN")
@@ -1314,7 +1314,7 @@ func TestHandlePostToken_RecordsInvalidProfileReason(t *testing.T) {
 	req.SetPathValue("profile", "broken-profile")
 
 	rr := httptest.NewRecorder()
-	handlePostToken(tv[orgAttr]("unused"), resolve).ServeHTTP(rr, req)
+	handlePostToken(tv[orgAttr]("unused"), resolve, withheld).ServeHTTP(rr, req)
 
 	// caller-facing behaviour is unchanged: 404, and a message that says
 	// nothing about the cause
@@ -1342,7 +1342,7 @@ func TestHandlePostToken_RecordsScopedRepositoryInAuditedProfile(t *testing.T) {
 	req.SetPathValue("profile", "caller-scoped-profile")
 
 	rr := httptest.NewRecorder()
-	handlePostToken(tv[orgAttr]("token-value"), resolve).ServeHTTP(rr, req)
+	handlePostToken(tv[orgAttr]("token-value"), resolve, withheld).ServeHTTP(rr, req)
 
 	require.Equal(t, http.StatusOK, rr.Code)
 	assert.Equal(t, "profile://organization/organization-slug/profile/caller-scoped-profile/repository/target-repo", entry.RequestedProfile)
@@ -1362,7 +1362,7 @@ func TestHandlePostToken_RecordsRequestedProfileWhenScopeRejected(t *testing.T) 
 	req.SetPathValue("profile", "static-profile")
 
 	rr := httptest.NewRecorder()
-	handlePostToken(tv[orgAttr]("unused"), resolve).ServeHTTP(rr, req)
+	handlePostToken(tv[orgAttr]("unused"), resolve, withheld).ServeHTTP(rr, req)
 
 	require.Equal(t, http.StatusBadRequest, rr.Code)
 	assert.Equal(t, "static-profile", entry.RequestedProfile)
@@ -1403,7 +1403,7 @@ pipeline:
 		{
 			name: "organization token",
 			handler: func(store *profile.ProfileStore, reads *int, tokenVendor vendor.TokenVendor) http.Handler {
-				return handlePostToken(orgChain(t, tokenVendor), countingOrgResolver(store, reads))
+				return handlePostToken(orgChain(t, tokenVendor), countingOrgResolver(store, reads), withheld)
 			},
 			target:  "/organization/token/static-profile",
 			profile: "static-profile",
@@ -1411,7 +1411,7 @@ pipeline:
 		{
 			name: "organization git-credentials",
 			handler: func(store *profile.ProfileStore, reads *int, tokenVendor vendor.TokenVendor) http.Handler {
-				return handlePostGitCredentials(orgChain(t, tokenVendor), countingOrgResolver(store, reads))
+				return handlePostGitCredentials(orgChain(t, tokenVendor), countingOrgResolver(store, reads), withheld)
 			},
 			target:  "/organization/git-credentials/static-profile",
 			profile: "static-profile",
@@ -1420,14 +1420,14 @@ pipeline:
 		{
 			name: "pipeline token",
 			handler: func(store *profile.ProfileStore, reads *int, tokenVendor vendor.TokenVendor) http.Handler {
-				return handlePostToken(pipelineChain(t, repoLookup, tokenVendor), countingPipelineResolver(store, reads))
+				return handlePostToken(pipelineChain(t, repoLookup, tokenVendor), countingPipelineResolver(store, reads), withheld)
 			},
 			target: "/token",
 		},
 		{
 			name: "pipeline git-credentials",
 			handler: func(store *profile.ProfileStore, reads *int, tokenVendor vendor.TokenVendor) http.Handler {
-				return handlePostGitCredentials(pipelineChain(t, repoLookup, tokenVendor), countingPipelineResolver(store, reads))
+				return handlePostGitCredentials(pipelineChain(t, repoLookup, tokenVendor), countingPipelineResolver(store, reads), withheld)
 			},
 			target: "/git-credentials",
 			body:   func() io.Reader { return gitCredentialsBody(t, "organization-slug", "repo1") },

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -35,13 +35,11 @@ type (
 	orgAttr      = profile.OrganizationProfileAttr
 )
 
-// testApp is the identity every test profile resolves to. Production passes
-// the app registry's own resolver; these tests care about handler plumbing,
-// not about which app was chosen.
+// testApp is the identity every test profile resolves to.
 var testApp = github.AppIdentity{Name: "default", ApplicationID: 111, InstallationID: 222}
 
-// testAppResolver resolves the default app and nothing else, matching a
-// deployment with no app registry configured.
+// testAppResolver matches a deployment with no app registry: the default app
+// resolves and nothing else does.
 func testAppResolver(name string) (github.AppIdentity, bool) {
 	if name != testApp.Name {
 		return github.AppIdentity{}, false
@@ -1532,8 +1530,8 @@ func gitCredentialsBody(t *testing.T, org, repo string) io.Reader {
 	return b
 }
 
-// mintingThrough adapts a plain token vendor to the app-aware signature for
-// tests that do not care which app was resolved.
+// mintingThrough adapts a plain token vendor to the app-aware signature,
+// discarding the app.
 func mintingThrough(mint vendor.TokenVendor) vendor.AppTokenVendor {
 	return func(ctx context.Context, _ github.AppIdentity, repoNames []string, scopes []string) (string, time.Time, error) {
 		return mint(ctx, repoNames, scopes)

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/chinmina/chinmina-bridge/internal/audit"
 	"github.com/chinmina/chinmina-bridge/internal/cache"
 	"github.com/chinmina/chinmina-bridge/internal/credentialhandler"
+	"github.com/chinmina/chinmina-bridge/internal/github"
 	"github.com/chinmina/chinmina-bridge/internal/jwt"
 	"github.com/chinmina/chinmina-bridge/internal/profile"
 	"github.com/chinmina/chinmina-bridge/internal/profile/profiletest"
@@ -34,14 +35,28 @@ type (
 	orgAttr      = profile.OrganizationProfileAttr
 )
 
+// testApp is the identity every test profile resolves to. Production passes
+// the app registry's own resolver; these tests care about handler plumbing,
+// not about which app was chosen.
+var testApp = github.AppIdentity{Name: "default", ApplicationID: 111, InstallationID: 222}
+
+// testAppResolver resolves the default app and nothing else, matching a
+// deployment with no app registry configured.
+func testAppResolver(name string) (github.AppIdentity, bool) {
+	if name != testApp.Name {
+		return github.AppIdentity{}, false
+	}
+	return testApp, true
+}
+
 // testPipelineResolver returns a pipeline ProfileResolver whose lookup always
 // yields an unconditionally-matching profile. It is sufficient for tests that
 // exercise handler plumbing rather than configuration; profile lookup failure
 // and scope validation are covered by the resolver unit tests below.
 func testPipelineResolver() ProfileResolver[pipelineAttr] {
 	return NewPipelineProfileResolver(func(string) (profile.AuthorizedProfile[pipelineAttr], string, error) {
-		return profile.NewAuthorizedProfile(profile.CompositeMatcher(), pipelineAttr{}), "test-digest", nil
-	})
+		return profile.NewAuthorizedProfile(profile.CompositeMatcher(), pipelineAttr{App: testApp.Name}), "test-digest", nil
+	}, testAppResolver)
 }
 
 func TestHandlers_RequireClaims(t *testing.T) {
@@ -416,7 +431,7 @@ func tv[T any](token string) vendor.ProfileTokenVendor[T] {
 func TestHandlePostGitCredentialsWithProfile_ReturnsTokenOnSuccess(t *testing.T) {
 	tokenVendor := tv[orgAttr]("expected-token-value")
 	store := profiletest.CreateTestProfileStore(t, scopedProfilesYAML)
-	resolve := NewOrgProfileResolver(store.GetOrganizationProfile)
+	resolve := NewOrgProfileResolver(store.GetOrganizationProfile, testAppResolver)
 
 	ctx := claimsContext()
 
@@ -743,7 +758,7 @@ func TestProfileResolver_OrgProfile(t *testing.T) {
 	// Non-caller-scoped org profile with no caller-supplied scope produces
 	// an unscoped ref — status quo for static-list profiles.
 	store := profiletest.CreateTestProfileStore(t, scopedProfilesYAML)
-	resolve := NewOrgProfileResolver(store.GetOrganizationProfile)
+	resolve := NewOrgProfileResolver(store.GetOrganizationProfile, testAppResolver)
 
 	ctx := claimsContext()
 	pv := mapPathValuer{"profile": "static-profile"}
@@ -809,7 +824,7 @@ func TestProfileResolver_OrgCallerScoped_MissingScopeReturnsRequiredError(t *tes
 	// RepositoryScopeRequiredError so the handler can respond with 400 and
 	// a specific message identifying the required scope.
 	store := profiletest.CreateTestProfileStore(t, scopedProfilesYAML)
-	resolve := NewOrgProfileResolver(store.GetOrganizationProfile)
+	resolve := NewOrgProfileResolver(store.GetOrganizationProfile, testAppResolver)
 
 	ctx := claimsContext()
 	pv := mapPathValuer{"profile": "caller-scoped-profile"}
@@ -826,7 +841,7 @@ func TestProfileResolver_OrgStaticList_RejectsScope(t *testing.T) {
 	// RepositoryScopeUnexpectedError carries a 400 status, allowing the
 	// handler to surface a specific message via writeJSONError/writeTextError.
 	store := profiletest.CreateTestProfileStore(t, scopedProfilesYAML)
-	resolve := NewOrgProfileResolver(store.GetOrganizationProfile)
+	resolve := NewOrgProfileResolver(store.GetOrganizationProfile, testAppResolver)
 
 	ctx := claimsContext()
 	pv := mapPathValuer{"profile": "static-profile"}
@@ -843,7 +858,7 @@ func TestProfileResolver_OrgCallerScoped_PopulatesScopedRepository(t *testing.T)
 	// the resolver populates ref.ScopedRepository so downstream consumers
 	// (URN, cache key, audit log) observe a single source of truth.
 	store := profiletest.CreateTestProfileStore(t, scopedProfilesYAML)
-	resolve := NewOrgProfileResolver(store.GetOrganizationProfile)
+	resolve := NewOrgProfileResolver(store.GetOrganizationProfile, testAppResolver)
 
 	ctx := claimsContext()
 	pv := mapPathValuer{"profile": "caller-scoped-profile"}
@@ -865,7 +880,7 @@ func TestProfileResolver_OrgCallerScoped_UsesImplicitScopeWhenExplicitEmpty(t *t
 	// profiles this fills ref.ScopedRepository when no explicit scope is
 	// supplied.
 	store := profiletest.CreateTestProfileStore(t, scopedProfilesYAML)
-	resolve := NewOrgProfileResolver(store.GetOrganizationProfile)
+	resolve := NewOrgProfileResolver(store.GetOrganizationProfile, testAppResolver)
 
 	ctx := claimsContext()
 	pv := mapPathValuer{"profile": "caller-scoped-profile"}
@@ -894,7 +909,7 @@ func TestProfileResolver_OrgProfileNotFound_SurfacesLookupError(t *testing.T) {
 	// The handler will route this through writeJSONError / writeTextError,
 	// preserving the 404 status the error carries.
 	store := profiletest.CreateTestProfileStore(t, scopedProfilesYAML)
-	resolve := NewOrgProfileResolver(store.GetOrganizationProfile)
+	resolve := NewOrgProfileResolver(store.GetOrganizationProfile, testAppResolver)
 
 	ctx := claimsContext()
 	pv := mapPathValuer{"profile": "no-such-profile"}
@@ -916,7 +931,7 @@ func TestHandlePostToken_PipelineProfileNotFoundAnswers404(t *testing.T) {
 	})
 
 	// An unloaded store answers ProfileNotFoundError for every name.
-	resolve := NewPipelineProfileResolver(profile.NewProfileStore().GetPipelineProfile)
+	resolve := NewPipelineProfileResolver(profile.NewProfileStore().GetPipelineProfile, testAppResolver)
 
 	req, err := http.NewRequestWithContext(claimsContext(), "POST", "/token", nil)
 	require.NoError(t, err)
@@ -937,7 +952,7 @@ func TestProfileResolver_OrgNonCallerScoped_IgnoresImplicitScope(t *testing.T) {
 	for _, profileName := range cases {
 		t.Run(profileName, func(t *testing.T) {
 			store := profiletest.CreateTestProfileStore(t, scopedProfilesYAML)
-			resolve := NewOrgProfileResolver(store.GetOrganizationProfile)
+			resolve := NewOrgProfileResolver(store.GetOrganizationProfile, testAppResolver)
 
 			ctx := claimsContext()
 			pv := mapPathValuer{"profile": profileName}
@@ -956,7 +971,7 @@ func TestHandlePostToken_OrgStaticList_RejectsScopeWithSpecificMessage(t *testin
 	// errors through writeJSONError so HTTPStatuser types carry their
 	// declared message.
 	store := profiletest.CreateTestProfileStore(t, scopedProfilesYAML)
-	resolve := NewOrgProfileResolver(store.GetOrganizationProfile)
+	resolve := NewOrgProfileResolver(store.GetOrganizationProfile, testAppResolver)
 
 	ctx := claimsContext()
 	req, err := http.NewRequestWithContext(ctx, "POST", "/organization/token/static-profile?repository-scope=anything", nil)
@@ -976,7 +991,7 @@ func TestHandlePostToken_OrgStaticList_RejectsScopeWithSpecificMessage(t *testin
 func TestHandlePostToken_OrgCallerScoped_MissingScopeReturnsSpecificMessage(t *testing.T) {
 	// The caller must learn that the profile requires a scope.
 	store := profiletest.CreateTestProfileStore(t, scopedProfilesYAML)
-	resolve := NewOrgProfileResolver(store.GetOrganizationProfile)
+	resolve := NewOrgProfileResolver(store.GetOrganizationProfile, testAppResolver)
 
 	ctx := claimsContext()
 	req, err := http.NewRequestWithContext(ctx, "POST", "/organization/token/caller-scoped-profile", nil)
@@ -1230,7 +1245,7 @@ func TestHandlers_RecordRequestedProfileWhenResolutionFails(t *testing.T) {
 			req.SetPathValue("profile", "no-such-profile")
 
 			rr := httptest.NewRecorder()
-			tc.handler(NewOrgProfileResolver(store.GetOrganizationProfile)).ServeHTTP(rr, req)
+			tc.handler(NewOrgProfileResolver(store.GetOrganizationProfile, testAppResolver)).ServeHTTP(rr, req)
 
 			assert.Equal(t, http.StatusNotFound, rr.Code)
 			assert.Equal(t, "no-such-profile", entry.RequestedProfile)
@@ -1254,7 +1269,7 @@ func TestHandlers_UnresolvedProfileIsNotAuditedAsCanonicalURN(t *testing.T) {
 	req.SetPathValue("profile", forged)
 
 	rr := httptest.NewRecorder()
-	handlePostToken(tv[orgAttr]("unused"), NewOrgProfileResolver(store.GetOrganizationProfile)).ServeHTTP(rr, req)
+	handlePostToken(tv[orgAttr]("unused"), NewOrgProfileResolver(store.GetOrganizationProfile, testAppResolver)).ServeHTTP(rr, req)
 
 	require.Equal(t, http.StatusNotFound, rr.Code)
 	assert.Equal(t, forged, entry.RequestedProfile, "an unresolved name must be recorded verbatim, never as a URN")
@@ -1293,7 +1308,7 @@ pipeline:
 // mistyped name.
 func TestHandlePostToken_RecordsInvalidProfileReason(t *testing.T) {
 	store := profiletest.CreateTestProfileStore(t, invalidProfileYAML)
-	resolve := NewOrgProfileResolver(store.GetOrganizationProfile)
+	resolve := NewOrgProfileResolver(store.GetOrganizationProfile, testAppResolver)
 
 	ctx, entry := audit.Context(claimsContext())
 	req, err := http.NewRequestWithContext(ctx, "POST", "/organization/token/broken-profile", nil)
@@ -1321,7 +1336,7 @@ func TestHandlePostToken_RecordsInvalidProfileReason(t *testing.T) {
 // was actually exercised against.
 func TestHandlePostToken_RecordsScopedRepositoryInAuditedProfile(t *testing.T) {
 	store := profiletest.CreateTestProfileStore(t, scopedProfilesYAML)
-	resolve := NewOrgProfileResolver(store.GetOrganizationProfile)
+	resolve := NewOrgProfileResolver(store.GetOrganizationProfile, testAppResolver)
 
 	ctx, entry := audit.Context(claimsContext())
 	req, err := http.NewRequestWithContext(ctx, "POST", "/organization/token/caller-scoped-profile?repository-scope=target-repo", nil)
@@ -1341,7 +1356,7 @@ func TestHandlePostToken_RecordsScopedRepositoryInAuditedProfile(t *testing.T) {
 // know which profile the caller was aiming at.
 func TestHandlePostToken_RecordsRequestedProfileWhenScopeRejected(t *testing.T) {
 	store := profiletest.CreateTestProfileStore(t, scopedProfilesYAML)
-	resolve := NewOrgProfileResolver(store.GetOrganizationProfile)
+	resolve := NewOrgProfileResolver(store.GetOrganizationProfile, testAppResolver)
 
 	ctx, entry := audit.Context(claimsContext())
 	req, err := http.NewRequestWithContext(ctx, "POST", "/organization/token/static-profile?repository-scope=bad/scope", nil)
@@ -1463,7 +1478,7 @@ func orgChain(t *testing.T, tokenVendor vendor.TokenVendor) vendor.ProfileTokenV
 	t.Helper()
 
 	return vendor.Auditor(vendor.Authorized(vendor.Cached[orgAttr](testTokenCache(t))(
-		vendor.Vending(vendor.OrgRepositories, tokenVendor),
+		vendor.Vending(vendor.OrgRepositories, mintingThrough(tokenVendor)),
 	)))
 }
 
@@ -1472,7 +1487,7 @@ func pipelineChain(t *testing.T, repoLookup vendor.RepositoryLookup, tokenVendor
 	t.Helper()
 
 	return vendor.Auditor(vendor.Authorized(vendor.Cached[pipelineAttr](testTokenCache(t))(
-		vendor.Vending(vendor.PipelineRepositories(repoLookup), tokenVendor),
+		vendor.Vending(vendor.PipelineRepositories(repoLookup), mintingThrough(tokenVendor)),
 	)))
 }
 
@@ -1491,7 +1506,7 @@ func countingOrgResolver(store *profile.ProfileStore, reads *int) ProfileResolve
 	return NewOrgProfileResolver(func(name string) (profile.AuthorizedProfile[orgAttr], string, error) {
 		*reads++
 		return store.GetOrganizationProfile(name)
-	})
+	}, testAppResolver)
 }
 
 // countingPipelineResolver counts the store reads a request performs.
@@ -1499,7 +1514,7 @@ func countingPipelineResolver(store *profile.ProfileStore, reads *int) ProfileRe
 	return NewPipelineProfileResolver(func(name string) (profile.AuthorizedProfile[pipelineAttr], string, error) {
 		*reads++
 		return store.GetPipelineProfile(name)
-	})
+	}, testAppResolver)
 }
 
 // gitCredentialsBody renders a minimal git-credentials request body for the
@@ -1515,4 +1530,12 @@ func gitCredentialsBody(t *testing.T, org, repo string) io.Reader {
 	b := &bytes.Buffer{}
 	require.NoError(t, credentialhandler.WriteProperties(m, b))
 	return b
+}
+
+// mintingThrough adapts a plain token vendor to the app-aware signature for
+// tests that do not care which app was resolved.
+func mintingThrough(mint vendor.TokenVendor) vendor.AppTokenVendor {
+	return func(ctx context.Context, _ github.AppIdentity, repoNames []string, scopes []string) (string, time.Time, error) {
+		return mint(ctx, repoNames, scopes)
+	}
 }

--- a/handlersapp_test.go
+++ b/handlersapp_test.go
@@ -1,0 +1,244 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/chinmina/chinmina-bridge/internal/audit"
+	"github.com/chinmina/chinmina-bridge/internal/github"
+	"github.com/chinmina/chinmina-bridge/internal/profile"
+	"github.com/chinmina/chinmina-bridge/internal/profile/profiletest"
+	"github.com/chinmina/chinmina-bridge/internal/vendor"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const appProfilesYAML = `organization:
+  profiles:
+    - name: publish-packages
+      app: packages
+      repositories:
+        - repo1
+      permissions:
+        - contents:read
+    - name: default-app-profile
+      repositories:
+        - repo1
+      permissions:
+        - contents:read
+
+pipeline:
+  defaults:
+    permissions:
+      - contents:read
+`
+
+var (
+	defaultAppIdentity  = github.AppIdentity{Name: "default", ApplicationID: 111, InstallationID: 222}
+	packagesAppIdentity = github.AppIdentity{Name: "packages", ApplicationID: 333, InstallationID: 444}
+)
+
+// registryResolver stands in for the app registry: a set of resolvable
+// identities, mutable between requests so a test can withdraw one the way
+// a restart with different configuration would.
+type registryResolver struct {
+	apps map[string]github.AppIdentity
+}
+
+func (r *registryResolver) Resolve(name string) (github.AppIdentity, bool) {
+	app, found := r.apps[name]
+	return app, found
+}
+
+func (r *registryResolver) withdraw(name string) {
+	delete(r.apps, name)
+}
+
+func newRegistryResolver(apps ...github.AppIdentity) *registryResolver {
+	byName := make(map[string]github.AppIdentity, len(apps))
+	for _, app := range apps {
+		byName[app.Name] = app
+	}
+	return &registryResolver{apps: byName}
+}
+
+// TestRoutes_WarmCacheEntryDoesNotBypassAppResolution is the acceptance
+// observable for resolving the app at the handler boundary rather than inside
+// the vendor chain.
+//
+// The chain is Audit -> Authorized -> Cached -> Vending, and Cached
+// short-circuits on a hit before Vending runs. A registry check placed inside
+// the chain would therefore be absent on exactly the requests that need it:
+// those whose profile was valid long enough to warm an entry and has since had
+// its app disabled. This test fails if resolution is ever moved into the
+// vendor chain, which is the reason it exists.
+func TestRoutes_WarmCacheEntryDoesNotBypassAppResolution(t *testing.T) {
+	store := profiletest.CreateTestProfileStore(t, appProfilesYAML, usableApps("packages"))
+	registry := newRegistryResolver(defaultAppIdentity, packagesAppIdentity)
+
+	vends := 0
+	chain := orgChain(t, func(context.Context, []string, []string) (string, time.Time, error) {
+		vends++
+		return "minted-token", defaultExpiry, nil
+	})
+
+	handler := handlePostToken(chain, NewOrgProfileResolver(store.GetOrganizationProfile, registry.Resolve))
+
+	serve := func() *httptest.ResponseRecorder {
+		ctx, _ := audit.Context(claimsContext())
+		req, err := http.NewRequestWithContext(ctx, "POST", "/organization/token/publish-packages", nil)
+		require.NoError(t, err)
+		req.SetPathValue("profile", "publish-packages")
+
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		return rr
+	}
+
+	warm := serve()
+	require.Equal(t, http.StatusOK, warm.Code, "the entry must be warm before the app is withdrawn")
+	require.Equal(t, 1, vends)
+
+	// The app becomes unresolvable — an operator removed it, or this instance
+	// restarted and disabled it at verification.
+	registry.withdraw("packages")
+
+	after := serve()
+
+	assert.Equal(t, http.StatusInternalServerError, after.Code,
+		"an unresolvable app is our defect, not GitHub's denial")
+	assert.NotContains(t, after.Body.String(), "minted-token",
+		"the cached token must not be served once its app cannot be resolved")
+	assert.Equal(t, 1, vends, "no new token may be minted either")
+}
+
+// A request against a profile bound to a non-default app mints through that
+// app and is attributed to it in both the response and the audit entry.
+func TestRoutes_MintThroughTheResolvedApp(t *testing.T) {
+	tests := []struct {
+		name        string
+		profileName string
+		expectedApp github.AppIdentity
+	}{
+		{
+			name:        "a profile naming a registry app",
+			profileName: "publish-packages",
+			expectedApp: packagesAppIdentity,
+		},
+		{
+			// An omitted app property compiles to the default app, so this is
+			// indistinguishable from an explicit `app: default`.
+			name:        "a profile with no app property",
+			profileName: "default-app-profile",
+			expectedApp: defaultAppIdentity,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := profiletest.CreateTestProfileStore(t, appProfilesYAML, usableApps("packages"))
+			registry := newRegistryResolver(defaultAppIdentity, packagesAppIdentity)
+
+			var mintedThrough github.AppIdentity
+			chain := vendor.Auditor(vendor.Authorized(vendor.Cached[orgAttr](testTokenCache(t))(
+				vendor.Vending(vendor.OrgRepositories,
+					func(_ context.Context, app github.AppIdentity, _ []string, _ []string) (string, time.Time, error) {
+						mintedThrough = app
+						return "minted-token", defaultExpiry, nil
+					}),
+			)))
+
+			handler := handlePostToken(chain, NewOrgProfileResolver(store.GetOrganizationProfile, registry.Resolve))
+
+			ctx, entry := audit.Context(claimsContext())
+			req, err := http.NewRequestWithContext(ctx, "POST", "/organization/token/"+tt.profileName, nil)
+			require.NoError(t, err)
+			req.SetPathValue("profile", tt.profileName)
+
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			require.Equal(t, http.StatusOK, rr.Code)
+
+			assert.Equal(t, tt.expectedApp, mintedThrough,
+				"the token must be minted through the installation the profile named")
+
+			var response vendor.ProfileToken
+			require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
+			assert.Equal(t, tt.expectedApp.Name, response.App)
+
+			assert.Equal(t, tt.expectedApp.Name, entry.App)
+		})
+	}
+}
+
+// The app is stamped at resolution rather than at vend, so an outcome reached
+// after resolution still names the app it was attempted through. Without this
+// a failed mint would be the one case with no attribution — exactly the case
+// an operator is looking at.
+func TestRoutes_AuditEntryNamesTheAppWhenMintingFails(t *testing.T) {
+	store := profiletest.CreateTestProfileStore(t, appProfilesYAML, usableApps("packages"))
+	registry := newRegistryResolver(defaultAppIdentity, packagesAppIdentity)
+
+	chain := orgChain(t, func(context.Context, []string, []string) (string, time.Time, error) {
+		return "", time.Time{}, assert.AnError
+	})
+
+	handler := handlePostToken(chain, NewOrgProfileResolver(store.GetOrganizationProfile, registry.Resolve))
+
+	ctx, entry := audit.Context(claimsContext())
+	req, err := http.NewRequestWithContext(ctx, "POST", "/organization/token/publish-packages", nil)
+	require.NoError(t, err)
+	req.SetPathValue("profile", "publish-packages")
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Equal(t, "packages", entry.App)
+	assert.NotEmpty(t, entry.Error)
+}
+
+// A profile invalid because its app is disabled fails before an app is
+// resolved, so the audit entry carries the reason rather than an app name.
+func TestRoutes_DisabledAppMakesTheProfileUnavailable(t *testing.T) {
+	// Compiled with no registry: `app: packages` names nothing usable.
+	store := profiletest.CreateTestProfileStore(t, appProfilesYAML)
+	registry := newRegistryResolver(defaultAppIdentity)
+
+	chain := orgChain(t, func(context.Context, []string, []string) (string, time.Time, error) {
+		t.Fatal("an unavailable profile must not reach the vendor")
+		return "", time.Time{}, nil
+	})
+
+	handler := handlePostToken(chain, NewOrgProfileResolver(store.GetOrganizationProfile, registry.Resolve))
+
+	ctx, entry := audit.Context(claimsContext())
+	req, err := http.NewRequestWithContext(ctx, "POST", "/organization/token/publish-packages", nil)
+	require.NoError(t, err)
+	req.SetPathValue("profile", "publish-packages")
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+	assert.Empty(t, entry.App, "no app was resolved, so none may be attributed")
+	assert.Contains(t, entry.Error, "packages", "the audit entry must record why the profile is unavailable")
+}
+
+// usableApps builds the compilation-time lookup over a set of enabled names.
+func usableApps(names ...string) profile.AppLookup {
+	usable := map[string]struct{}{"default": {}}
+	for _, name := range names {
+		usable[name] = struct{}{}
+	}
+
+	return func(name string) bool {
+		_, found := usable[name]
+		return found
+	}
+}

--- a/handlersapp_test.go
+++ b/handlersapp_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"github.com/chinmina/chinmina-bridge/internal/audit"
+	"github.com/chinmina/chinmina-bridge/internal/credentialhandler"
 	"github.com/chinmina/chinmina-bridge/internal/github"
 	"github.com/chinmina/chinmina-bridge/internal/profile"
 	"github.com/chinmina/chinmina-bridge/internal/profile/profiletest"
@@ -79,7 +81,7 @@ func TestRoutes_WarmCacheEntryDoesNotBypassAppResolution(t *testing.T) {
 		return "minted-token", defaultExpiry, nil
 	})
 
-	handler := handlePostToken(chain, NewOrgProfileResolver(store.GetOrganizationProfile, registry.Resolve))
+	handler := handlePostToken(chain, NewOrgProfileResolver(store.GetOrganizationProfile, registry.Resolve), withheld)
 
 	serve := func() *httptest.ResponseRecorder {
 		ctx, _ := audit.Context(claimsContext())
@@ -140,7 +142,7 @@ func TestRoutes_MintThroughTheResolvedApp(t *testing.T) {
 					}),
 			)))
 
-			handler := handlePostToken(chain, NewOrgProfileResolver(store.GetOrganizationProfile, registry.Resolve))
+			handler := handlePostToken(chain, NewOrgProfileResolver(store.GetOrganizationProfile, registry.Resolve), disclosed)
 
 			ctx, entry := audit.Context(claimsContext())
 			req, err := http.NewRequestWithContext(ctx, "POST", "/organization/token/"+tt.profileName, nil)
@@ -157,7 +159,11 @@ func TestRoutes_MintThroughTheResolvedApp(t *testing.T) {
 
 			var response vendor.ProfileToken
 			require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
-			assert.Equal(t, tt.expectedApp.Name, response.App)
+			assert.Equal(t, tt.expectedApp, github.AppIdentity{
+				Name:           response.App,
+				ApplicationID:  response.ApplicationID,
+				InstallationID: response.InstallationID,
+			}, "the disclosed response must name the installation the mint went through")
 
 			assert.Equal(t, tt.expectedApp, auditedApp(entry),
 				"the audit entry must identify the installation, not just its repointable name")
@@ -175,7 +181,7 @@ func TestRoutes_AuditEntryNamesTheAppWhenMintingFails(t *testing.T) {
 		return "", time.Time{}, assert.AnError
 	})
 
-	handler := handlePostToken(chain, NewOrgProfileResolver(store.GetOrganizationProfile, registry.Resolve))
+	handler := handlePostToken(chain, NewOrgProfileResolver(store.GetOrganizationProfile, registry.Resolve), withheld)
 
 	ctx, entry := audit.Context(claimsContext())
 	req, err := http.NewRequestWithContext(ctx, "POST", "/organization/token/publish-packages", nil)
@@ -202,7 +208,7 @@ func TestRoutes_DisabledAppMakesTheProfileUnavailable(t *testing.T) {
 		return "", time.Time{}, nil
 	})
 
-	handler := handlePostToken(chain, NewOrgProfileResolver(store.GetOrganizationProfile, registry.Resolve))
+	handler := handlePostToken(chain, NewOrgProfileResolver(store.GetOrganizationProfile, registry.Resolve), withheld)
 
 	ctx, entry := audit.Context(claimsContext())
 	req, err := http.NewRequestWithContext(ctx, "POST", "/organization/token/publish-packages", nil)
@@ -218,8 +224,6 @@ func TestRoutes_DisabledAppMakesTheProfileUnavailable(t *testing.T) {
 	assert.Contains(t, entry.Error, "packages", "the audit entry must record why the profile is unavailable")
 }
 
-// auditedApp reassembles the identity an audit entry attributes a request to,
-// so a test can assert on it whole rather than field by field.
 func auditedApp(entry *audit.Entry) github.AppIdentity {
 	return github.AppIdentity{
 		Name:           entry.App,
@@ -238,5 +242,141 @@ func usableApps(names ...string) profile.AppLookup {
 	return func(name string) bool {
 		_, found := usable[name]
 		return found
+	}
+}
+
+var (
+	withheld  = newTokenResponseMarshaler(false)
+	disclosed = newTokenResponseMarshaler(true)
+)
+
+func packagesOrgChain(t *testing.T) (vendor.ProfileTokenVendor[orgAttr], ProfileResolver[orgAttr]) {
+	t.Helper()
+
+	store := profiletest.CreateTestProfileStore(t, appProfilesYAML, usableApps("packages"))
+	registry := newRegistryResolver(defaultAppIdentity, packagesAppIdentity)
+	chain := orgChain(t, func(context.Context, []string, []string) (string, time.Time, error) {
+		return "minted-token", defaultExpiry, nil
+	})
+
+	return chain, NewOrgProfileResolver(store.GetOrganizationProfile, registry.Resolve)
+}
+
+func serveOrgToken(t *testing.T, marshaler TokenResponseMarshaler, profileName string) (*httptest.ResponseRecorder, *audit.Entry) {
+	t.Helper()
+
+	chain, resolve := packagesOrgChain(t)
+	handler := handlePostToken(chain, resolve, marshaler)
+
+	ctx, entry := audit.Context(claimsContext())
+	req, err := http.NewRequestWithContext(ctx, "POST", "/organization/token/"+profileName, nil)
+	require.NoError(t, err)
+	req.SetPathValue("profile", profileName)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	return rr, entry
+}
+
+// Substring-matching the body would also hit the hashed token, so assertions
+// run on the decoded object.
+func TestRoutes_TokenResponseDisclosesIdentifiersOnlyWhenConfigured(t *testing.T) {
+	tests := []struct {
+		name      string
+		marshaler TokenResponseMarshaler
+		expected  map[string]any
+		absent    []string
+	}{
+		{
+			name:      "withholding is the production default",
+			marshaler: withheld,
+			expected:  map[string]any{"app": "packages"},
+			absent:    []string{"appId", "installationId"},
+		},
+		{
+			name:      "disclosing carries both identifiers",
+			marshaler: disclosed,
+			expected: map[string]any{
+				"app":            "packages",
+				"appId":          float64(packagesAppIdentity.ApplicationID),
+				"installationId": float64(packagesAppIdentity.InstallationID),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rr, _ := serveOrgToken(t, tt.marshaler, "publish-packages")
+
+			var response map[string]any
+			require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
+
+			for key, want := range tt.expected {
+				assert.Equal(t, want, response[key])
+			}
+			for _, key := range tt.absent {
+				assert.NotContains(t, response, key)
+			}
+		})
+	}
+}
+
+// Both halves read from the same request, so neither can be satisfied by a
+// fixture that only looks right in isolation.
+func TestRoutes_AuditRecordsIdentifiersTheResponseWithholds(t *testing.T) {
+	rr, entry := serveOrgToken(t, withheld, "publish-packages")
+
+	var response map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
+	assert.NotContains(t, response, "appId", "a CI pipeline has no use for the deployment's app topology")
+	assert.Equal(t, packagesAppIdentity, auditedApp(entry), "the operator-facing record must still attribute the vend")
+}
+
+func TestRoutes_GitCredentialsDiscloseIdentifiersOnlyWhenConfigured(t *testing.T) {
+	tests := []struct {
+		name      string
+		marshaler TokenResponseMarshaler
+		expected  string
+	}{
+		{
+			name:      "withholding leaves git's properties untouched",
+			marshaler: withheld,
+			expected: "protocol=https\nhost=github.com\npath=acme/repo1\n" +
+				"username=x-access-token\npassword=minted-token\npassword_expiry_utc=1715104776\n\n",
+		},
+		{
+			name:      "disclosing appends the chinmina properties",
+			marshaler: disclosed,
+			expected: "protocol=https\nhost=github.com\npath=acme/repo1\n" +
+				"username=x-access-token\npassword=minted-token\npassword_expiry_utc=1715104776\n" +
+				"chinmina_app_name=packages\nchinmina_app_id=333\nchinmina_installation_id=444\n\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chain, resolve := packagesOrgChain(t)
+			handler := handlePostGitCredentials(chain, resolve, tt.marshaler)
+
+			props := credentialhandler.NewMap(3)
+			props.Set("protocol", "https")
+			props.Set("host", "github.com")
+			props.Set("path", "acme/repo1")
+			body := &bytes.Buffer{}
+			require.NoError(t, credentialhandler.WriteProperties(props, body))
+
+			ctx, _ := audit.Context(claimsContext())
+			req, err := http.NewRequestWithContext(ctx, "POST", "/organization/git-credentials/publish-packages", body)
+			require.NoError(t, err)
+			req.SetPathValue("profile", "publish-packages")
+
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			require.Equal(t, http.StatusOK, rr.Code)
+			assert.Equal(t, tt.expected, rr.Body.String())
+		})
 	}
 }

--- a/handlersapp_test.go
+++ b/handlersapp_test.go
@@ -159,7 +159,8 @@ func TestRoutes_MintThroughTheResolvedApp(t *testing.T) {
 			require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
 			assert.Equal(t, tt.expectedApp.Name, response.App)
 
-			assert.Equal(t, tt.expectedApp.Name, entry.App)
+			assert.Equal(t, tt.expectedApp, auditedApp(entry),
+				"the audit entry must identify the installation, not just its repointable name")
 		})
 	}
 }
@@ -185,7 +186,7 @@ func TestRoutes_AuditEntryNamesTheAppWhenMintingFails(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 
 	require.Equal(t, http.StatusInternalServerError, rr.Code)
-	assert.Equal(t, "packages", entry.App)
+	assert.Equal(t, packagesAppIdentity, auditedApp(entry))
 	assert.NotEmpty(t, entry.Error)
 }
 
@@ -212,8 +213,19 @@ func TestRoutes_DisabledAppMakesTheProfileUnavailable(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 
 	assert.Equal(t, http.StatusNotFound, rr.Code)
-	assert.Empty(t, entry.App, "no app was resolved, so none may be attributed")
+	assert.Equal(t, github.AppIdentity{}, auditedApp(entry),
+		"no app was resolved, so none may be attributed")
 	assert.Contains(t, entry.Error, "packages", "the audit entry must record why the profile is unavailable")
+}
+
+// auditedApp reassembles the identity an audit entry attributes a request to,
+// so a test can assert on it whole rather than field by field.
+func auditedApp(entry *audit.Entry) github.AppIdentity {
+	return github.AppIdentity{
+		Name:           entry.App,
+		ApplicationID:  entry.ApplicationID,
+		InstallationID: entry.InstallationID,
+	}
 }
 
 // usableApps builds the compilation-time lookup over a set of enabled names.

--- a/handlersapp_test.go
+++ b/handlersapp_test.go
@@ -42,9 +42,8 @@ var (
 	packagesAppIdentity = github.AppIdentity{Name: "packages", ApplicationID: 333, InstallationID: 444}
 )
 
-// registryResolver stands in for the app registry: a set of resolvable
-// identities, mutable between requests so a test can withdraw one the way
-// a restart with different configuration would.
+// registryResolver stands in for the app registry. Its identities are mutable
+// between requests, so a test can withdraw one mid-test.
 type registryResolver struct {
 	apps map[string]github.AppIdentity
 }
@@ -66,16 +65,10 @@ func newRegistryResolver(apps ...github.AppIdentity) *registryResolver {
 	return &registryResolver{apps: byName}
 }
 
-// TestRoutes_WarmCacheEntryDoesNotBypassAppResolution is the acceptance
-// observable for resolving the app at the handler boundary rather than inside
-// the vendor chain.
-//
-// The chain is Audit -> Authorized -> Cached -> Vending, and Cached
-// short-circuits on a hit before Vending runs. A registry check placed inside
-// the chain would therefore be absent on exactly the requests that need it:
-// those whose profile was valid long enough to warm an entry and has since had
-// its app disabled. This test fails if resolution is ever moved into the
-// vendor chain, which is the reason it exists.
+// Cached short-circuits on a hit before Vending runs, so a registry check
+// placed inside the vendor chain would be skipped on exactly the requests that
+// need it: those warmed while the profile was valid, whose app has since been
+// disabled. Resolution therefore belongs at the handler boundary.
 func TestRoutes_WarmCacheEntryDoesNotBypassAppResolution(t *testing.T) {
 	store := profiletest.CreateTestProfileStore(t, appProfilesYAML, usableApps("packages"))
 	registry := newRegistryResolver(defaultAppIdentity, packagesAppIdentity)
@@ -103,8 +96,7 @@ func TestRoutes_WarmCacheEntryDoesNotBypassAppResolution(t *testing.T) {
 	require.Equal(t, http.StatusOK, warm.Code, "the entry must be warm before the app is withdrawn")
 	require.Equal(t, 1, vends)
 
-	// The app becomes unresolvable — an operator removed it, or this instance
-	// restarted and disabled it at verification.
+	// In production this is a restart that disables the app at verification.
 	registry.withdraw("packages")
 
 	after := serve()
@@ -116,8 +108,6 @@ func TestRoutes_WarmCacheEntryDoesNotBypassAppResolution(t *testing.T) {
 	assert.Equal(t, 1, vends, "no new token may be minted either")
 }
 
-// A request against a profile bound to a non-default app mints through that
-// app and is attributed to it in both the response and the audit entry.
 func TestRoutes_MintThroughTheResolvedApp(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -130,8 +120,6 @@ func TestRoutes_MintThroughTheResolvedApp(t *testing.T) {
 			expectedApp: packagesAppIdentity,
 		},
 		{
-			// An omitted app property compiles to the default app, so this is
-			// indistinguishable from an explicit `app: default`.
 			name:        "a profile with no app property",
 			profileName: "default-app-profile",
 			expectedApp: defaultAppIdentity,
@@ -176,10 +164,8 @@ func TestRoutes_MintThroughTheResolvedApp(t *testing.T) {
 	}
 }
 
-// The app is stamped at resolution rather than at vend, so an outcome reached
-// after resolution still names the app it was attempted through. Without this
-// a failed mint would be the one case with no attribution — exactly the case
-// an operator is looking at.
+// The app is stamped at resolution rather than at vend, so a failed mint is
+// still attributed to the app it was attempted through.
 func TestRoutes_AuditEntryNamesTheAppWhenMintingFails(t *testing.T) {
 	store := profiletest.CreateTestProfileStore(t, appProfilesYAML, usableApps("packages"))
 	registry := newRegistryResolver(defaultAppIdentity, packagesAppIdentity)
@@ -203,8 +189,8 @@ func TestRoutes_AuditEntryNamesTheAppWhenMintingFails(t *testing.T) {
 	assert.NotEmpty(t, entry.Error)
 }
 
-// A profile invalid because its app is disabled fails before an app is
-// resolved, so the audit entry carries the reason rather than an app name.
+// A profile invalid because its app is disabled fails before any app is
+// resolved: the audit entry carries the reason, not an app name.
 func TestRoutes_DisabledAppMakesTheProfileUnavailable(t *testing.T) {
 	// Compiled with no registry: `app: packages` names nothing usable.
 	store := profiletest.CreateTestProfileStore(t, appProfilesYAML)

--- a/harness_integration_test.go
+++ b/harness_integration_test.go
@@ -88,6 +88,14 @@ func WithValkeyCache() APITestHarnessOption {
 	}
 }
 
+// WithDisclosedAppIdentifiers turns on DEV_DISCLOSE_APP_IDENTIFIERS, so a test
+// exercises the disclosing shape through the real routing.
+func WithDisclosedAppIdentifiers() APITestHarnessOption {
+	return func(_ *APITestHarness, cfg *config.Config) {
+		cfg.Development.DiscloseAppIdentifiers = true
+	}
+}
+
 // WithBasePath configures the test harness with a base path prefix for
 // sub-path deployment testing.
 func WithBasePath(basePath string) APITestHarnessOption {

--- a/harness_integration_test.go
+++ b/harness_integration_test.go
@@ -15,9 +15,11 @@ import (
 
 	"github.com/chinmina/chinmina-bridge/internal/config"
 	"github.com/chinmina/chinmina-bridge/internal/credentialhandler"
+	"github.com/chinmina/chinmina-bridge/internal/github"
 	"github.com/chinmina/chinmina-bridge/internal/jwt"
 	"github.com/chinmina/chinmina-bridge/internal/jwt/jwxtest"
 	"github.com/chinmina/chinmina-bridge/internal/profile"
+	"github.com/chinmina/chinmina-bridge/internal/profile/profiletest"
 	"github.com/chinmina/chinmina-bridge/internal/server"
 	"github.com/chinmina/chinmina-bridge/internal/testhelpers"
 	"github.com/chinmina/chinmina-bridge/internal/vendor"
@@ -37,17 +39,56 @@ type APITestHarness struct {
 	GitHubMock          *testhelpers.MockGitHubServer
 	BuildkiteMock       *testhelpers.MockBuildkiteServer
 	ProfileStore        *profile.ProfileStore
-	jwk                 jwxtest.JWK
-	valkeyAddr          string
-	valkeyPassword      string
+
+	// Apps is the registry the routes were built with. Tests compile profiles
+	// against it so a profile naming an app agrees with what the running
+	// service considers usable.
+	Apps           github.Registry
+	jwk            jwxtest.JWK
+	valkeyAddr     string
+	valkeyPassword string
 }
 
-// APITestHarnessOption configures the API test harness.
-type APITestHarnessOption func(*config.Config)
+// APITestHarnessOption configures the API test harness. It receives the
+// harness as well as the configuration because some options need the mock
+// servers, which exist before the service is configured — an app registry is
+// verified against the GitHub mock during construction, so a test must be able
+// to set up that mock's responses first.
+type APITestHarnessOption func(*APITestHarness, *config.Config)
+
+// WithGitHubApps configures additional named GitHub Apps, as GITHUB_APPS does
+// in a deployment. Entries inherit the mock's API URL, so their installation
+// verification and minting both resolve against it.
+func WithGitHubApps(entries ...GitHubAppEntry) APITestHarnessOption {
+	return func(_ *APITestHarness, cfg *config.Config) {
+		encoded, err := json.Marshal(entries)
+		if err != nil {
+			panic(fmt.Sprintf("could not encode GITHUB_APPS: %v", err))
+		}
+		cfg.Github.Apps = string(encoded)
+	}
+}
+
+// WithInstallation configures the GitHub mock's response for one installation
+// before the registry verifies it, which is the only way to exercise an app
+// that verification disables.
+func WithInstallation(installationID int64, installation testhelpers.MockInstallation) APITestHarnessOption {
+	return func(h *APITestHarness, _ *config.Config) {
+		h.GitHubMock.SetInstallation(installationID, installation)
+	}
+}
+
+// GitHubAppEntry mirrors one GITHUB_APPS entry.
+type GitHubAppEntry struct {
+	Name           string `json:"name"`
+	ApplicationID  int64  `json:"appId"`
+	InstallationID int64  `json:"installationId"`
+	PrivateKey     string `json:"privateKey"`
+}
 
 // WithValkeyCache configures the test harness to use a Valkey cache container.
 func WithValkeyCache() APITestHarnessOption {
-	return func(cfg *config.Config) {
+	return func(_ *APITestHarness, cfg *config.Config) {
 		cfg.Cache.Type = "valkey"
 	}
 }
@@ -55,7 +96,7 @@ func WithValkeyCache() APITestHarnessOption {
 // WithBasePath configures the test harness with a base path prefix for
 // sub-path deployment testing.
 func WithBasePath(basePath string) APITestHarnessOption {
-	return func(cfg *config.Config) {
+	return func(_ *APITestHarness, cfg *config.Config) {
 		cfg.Server.BasePath = basePath
 	}
 }
@@ -124,7 +165,7 @@ func NewAPITestHarness(t *testing.T, options ...APITestHarnessOption) *APITestHa
 
 	// Apply options
 	for _, opt := range options {
-		opt(&cfg)
+		opt(harness, &cfg)
 	}
 
 	if cfg.Cache.Type == "valkey" {
@@ -143,12 +184,27 @@ func NewAPITestHarness(t *testing.T, options ...APITestHarnessOption) *APITestHa
 	clients, err := configureUpstreamClients(context.Background(), cfg, validated, &hooks)
 	require.NoError(t, err)
 
+	harness.Apps = clients.apps
+
 	handler := configureServerRoutes(validated, clients, harness.ProfileStore)
 
 	harness.Server = httptest.NewServer(handler)
 	hooks.AddClose("api-server", harness.Server)
 
 	return harness
+}
+
+// UpdateProfiles compiles profile YAML against this harness's app registry and
+// installs it as the current generation. Compiling against the registry is
+// what makes a profile naming an app valid in the same way it would be in a
+// deployment.
+func (h *APITestHarness) UpdateProfiles(t *testing.T, yamlContent string) {
+	t.Helper()
+
+	profiles, err := profiletest.CompileFromYAML(yamlContent, h.Apps.IsUsable)
+	require.NoError(t, err)
+
+	h.ProfileStore.Update(t.Context(), profiles)
 }
 
 // GenerateToken creates a valid JWT signed with the test JWK.

--- a/harness_integration_test.go
+++ b/harness_integration_test.go
@@ -40,9 +40,8 @@ type APITestHarness struct {
 	BuildkiteMock       *testhelpers.MockBuildkiteServer
 	ProfileStore        *profile.ProfileStore
 
-	// Apps is the registry the routes were built with. Tests compile profiles
-	// against it so a profile naming an app agrees with what the running
-	// service considers usable.
+	// Apps is the registry the routes were built with, so tests can compile
+	// profiles against what the running service considers usable.
 	Apps           github.Registry
 	jwk            jwxtest.JWK
 	valkeyAddr     string
@@ -50,15 +49,13 @@ type APITestHarness struct {
 }
 
 // APITestHarnessOption configures the API test harness. It receives the
-// harness as well as the configuration because some options need the mock
-// servers, which exist before the service is configured — an app registry is
-// verified against the GitHub mock during construction, so a test must be able
-// to set up that mock's responses first.
+// harness as well as the configuration because the app registry is verified
+// against the GitHub mock during construction, so an option may need to set up
+// that mock's responses first.
 type APITestHarnessOption func(*APITestHarness, *config.Config)
 
 // WithGitHubApps configures additional named GitHub Apps, as GITHUB_APPS does
-// in a deployment. Entries inherit the mock's API URL, so their installation
-// verification and minting both resolve against it.
+// in a deployment. Entries inherit the mock's API URL.
 func WithGitHubApps(entries ...GitHubAppEntry) APITestHarnessOption {
 	return func(_ *APITestHarness, cfg *config.Config) {
 		encoded, err := json.Marshal(entries)
@@ -69,9 +66,8 @@ func WithGitHubApps(entries ...GitHubAppEntry) APITestHarnessOption {
 	}
 }
 
-// WithInstallation configures the GitHub mock's response for one installation
-// before the registry verifies it, which is the only way to exercise an app
-// that verification disables.
+// WithInstallation sets the GitHub mock's response for one installation before
+// the registry verifies it.
 func WithInstallation(installationID int64, installation testhelpers.MockInstallation) APITestHarnessOption {
 	return func(h *APITestHarness, _ *config.Config) {
 		h.GitHubMock.SetInstallation(installationID, installation)
@@ -194,10 +190,8 @@ func NewAPITestHarness(t *testing.T, options ...APITestHarnessOption) *APITestHa
 	return harness
 }
 
-// UpdateProfiles compiles profile YAML against this harness's app registry and
-// installs it as the current generation. Compiling against the registry is
-// what makes a profile naming an app valid in the same way it would be in a
-// deployment.
+// UpdateProfiles compiles profile YAML against this harness's app registry, as
+// a deployment does, and installs it as the current generation.
 func (h *APITestHarness) UpdateProfiles(t *testing.T, yamlContent string) {
 	t.Helper()
 

--- a/harness_integration_test.go
+++ b/harness_integration_test.go
@@ -57,11 +57,10 @@ type APITestHarnessOption func(*APITestHarness, *config.Config)
 // WithGitHubApps configures additional named GitHub Apps, as GITHUB_APPS does
 // in a deployment. Entries inherit the mock's API URL.
 func WithGitHubApps(entries ...GitHubAppEntry) APITestHarnessOption {
-	return func(_ *APITestHarness, cfg *config.Config) {
+	return func(h *APITestHarness, cfg *config.Config) {
 		encoded, err := json.Marshal(entries)
-		if err != nil {
-			panic(fmt.Sprintf("could not encode GITHUB_APPS: %v", err))
-		}
+		require.NoError(h.t, err, "could not encode GITHUB_APPS")
+
 		cfg.Github.Apps = string(encoded)
 	}
 }

--- a/integration/docker-compose.yaml
+++ b/integration/docker-compose.yaml
@@ -164,6 +164,7 @@ services:
       GITHUB_APP_ID:
       GITHUB_APP_INSTALLATION_ID:
       GITHUB_ORG_PROFILE:
+      DEV_DISCLOSE_APP_IDENTIFIERS:
       CACHE_TYPE: ${CACHE_TYPE:-valkey} # valkey or memory
       VALKEY_ADDRESS: valkey:6379
       VALKEY_USE_IAM_AUTH: "false"

--- a/internal/audit/__snapshots__/slogattr_test.snap
+++ b/internal/audit/__snapshots__/slogattr_test.snap
@@ -284,6 +284,8 @@
   "userAgent": "test/1.0"
  },
  "token": {
+  "app": "publisher",
+  "applicationID": 12345,
   "attemptedPatterns": [
    {
     "claim": "build_branch",
@@ -294,6 +296,7 @@
   "expiry": "2030-01-01T00:00:00Z",
   "expiryRemaining": "<Any value>",
   "hashedToken": "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=",
+  "installationID": 67890,
   "matches": [
    {
     "claim": "pipeline_slug",
@@ -352,6 +355,52 @@
  },
  "token": {
   "requestedRepository": "https://github.com/org/repo"
+ },
+ "type": "audit"
+}
+---
+
+[TestSlogEntryAttrs/with_app_identity - 1]
+{
+ "authorization": {
+  "authorized": false
+ },
+ "level": "INFO",
+ "msg": "audit_event",
+ "request": {
+  "method": "",
+  "path": "",
+  "sourceIP": "",
+  "status": 0,
+  "userAgent": ""
+ },
+ "token": {
+  "app": "publisher",
+  "applicationID": 12345,
+  "installationID": 67890,
+  "requestedProfile": "org/repo"
+ },
+ "type": "audit"
+}
+---
+
+[TestSlogEntryAttrs/app_named_but_identifiers_unresolved - 1]
+{
+ "authorization": {
+  "authorized": false
+ },
+ "level": "INFO",
+ "msg": "audit_event",
+ "request": {
+  "method": "",
+  "path": "",
+  "sourceIP": "",
+  "status": 0,
+  "userAgent": ""
+ },
+ "token": {
+  "app": "publisher",
+  "requestedProfile": "org/repo"
  },
  "type": "audit"
 }

--- a/internal/audit/log.go
+++ b/internal/audit/log.go
@@ -39,23 +39,30 @@ type Entry struct {
 	RequestedProfile    string
 	RequestedRepository string
 	VendedRepository    string
-	Authorized          bool
-	AuthSubject         string
-	AuthIssuer          string
-	AuthAudience        []string
-	AuthExpirySecs      int64
-	OrganizationSlug    string
-	PipelineSlug        string
-	JobID               string
-	BuildNumber         int
-	BuildBranch         string
-	Error               string
-	Repositories        []string
-	Permissions         []string
-	ExpirySecs          int64
-	HashedToken         string
-	ClaimsMatched       []ClaimMatch
-	ClaimsFailed        []ClaimFailure
+
+	// App is the name of the GitHub App the request resolved to, recorded at
+	// resolution rather than at vend so that every outcome downstream of
+	// resolution carries it — including failures. A profile invalid because
+	// its app is disabled fails before an app is resolved, so it is the Error
+	// field that names the reason in that case.
+	App              string
+	Authorized       bool
+	AuthSubject      string
+	AuthIssuer       string
+	AuthAudience     []string
+	AuthExpirySecs   int64
+	OrganizationSlug string
+	PipelineSlug     string
+	JobID            string
+	BuildNumber      int
+	BuildBranch      string
+	Error            string
+	Repositories     []string
+	Permissions      []string
+	ExpirySecs       int64
+	HashedToken      string
+	ClaimsMatched    []ClaimMatch
+	ClaimsFailed     []ClaimFailure
 }
 
 // Begin sets up the audit log entry for the current request with details from the request.

--- a/internal/audit/log.go
+++ b/internal/audit/log.go
@@ -40,9 +40,16 @@ type Entry struct {
 	RequestedRepository string
 	VendedRepository    string
 
-	// App is the name of the GitHub App the request resolved to. Empty when the
-	// request failed before resolution; Error names the reason in that case.
+	// App, ApplicationID and InstallationID identify the GitHub App the request
+	// resolved to. All zero when the request failed before resolution; Error
+	// names the reason in that case.
+	//
+	// The name is a repointable label — an installation can be moved between
+	// names, and two names can alias one installation — so the identifiers are
+	// what make a vend attributable without consulting deployment config.
 	App              string
+	ApplicationID    int64
+	InstallationID   int64
 	Authorized       bool
 	AuthSubject      string
 	AuthIssuer       string

--- a/internal/audit/log.go
+++ b/internal/audit/log.go
@@ -40,11 +40,8 @@ type Entry struct {
 	RequestedRepository string
 	VendedRepository    string
 
-	// App is the name of the GitHub App the request resolved to, recorded at
-	// resolution rather than at vend so that every outcome downstream of
-	// resolution carries it — including failures. A profile invalid because
-	// its app is disabled fails before an app is resolved, so it is the Error
-	// field that names the reason in that case.
+	// App is the name of the GitHub App the request resolved to. Empty when the
+	// request failed before resolution; Error names the reason in that case.
 	App              string
 	Authorized       bool
 	AuthSubject      string

--- a/internal/audit/log.go
+++ b/internal/audit/log.go
@@ -40,13 +40,9 @@ type Entry struct {
 	RequestedRepository string
 	VendedRepository    string
 
-	// App, ApplicationID and InstallationID identify the GitHub App the request
-	// resolved to. All zero when the request failed before resolution; Error
-	// names the reason in that case.
-	//
-	// The name is a repointable label — an installation can be moved between
-	// names, and two names can alias one installation — so the identifiers are
-	// what make a vend attributable without consulting deployment config.
+	// All zero when the request failed before resolution; Error names the reason
+	// in that case. The name alone is not enough: it can be repointed, and two
+	// names can alias one installation.
 	App              string
 	ApplicationID    int64
 	InstallationID   int64

--- a/internal/audit/optionalgroup.go
+++ b/internal/audit/optionalgroup.go
@@ -35,6 +35,18 @@ func (og *OptionalGroup) Int(key string, val int) *OptionalGroup {
 	return og
 }
 
+// Int64 adds an int64 attribute, skipping zero values. Mirrors Int rather than
+// routing through Attr: Attr always marks the group modified, which would make
+// the token group appear on requests that fail before resolution.
+func (og *OptionalGroup) Int64(key string, val int64) *OptionalGroup {
+	if val == 0 {
+		return og
+	}
+	og.attrs = append(og.attrs, slog.Int64(key, val))
+	og.modified = true
+	return og
+}
+
 // Bool adds a bool attribute. Unlike Str/Int, zero (false) is not skipped,
 // since false is a meaningful authorization state.
 func (og *OptionalGroup) Bool(key string, val bool) *OptionalGroup {

--- a/internal/audit/optionalgroup.go
+++ b/internal/audit/optionalgroup.go
@@ -35,9 +35,8 @@ func (og *OptionalGroup) Int(key string, val int) *OptionalGroup {
 	return og
 }
 
-// Int64 adds an int64 attribute, skipping zero values. Mirrors Int rather than
-// routing through Attr: Attr always marks the group modified, which would make
-// the token group appear on requests that fail before resolution.
+// Int64 adds an int64 attribute, skipping zero values. Not routed through Attr,
+// which always marks the group modified.
 func (og *OptionalGroup) Int64(key string, val int64) *OptionalGroup {
 	if val == 0 {
 		return og

--- a/internal/audit/optionalgroup_test.go
+++ b/internal/audit/optionalgroup_test.go
@@ -104,3 +104,18 @@ func TestOptionalGroup_GroupKeyPreserved(t *testing.T) {
 	require.True(t, hasAttrs)
 	assert.Equal(t, slog.Attr{Key: "my-group", Value: slog.GroupValue(slog.String("field", "value"))}, a)
 }
+
+func TestOptionalGroup_Int64SkipsZero(t *testing.T) {
+	og := audit.NewOptionalGroup()
+	og.Int64("k", 0)
+	_, hasAttrs := og.Group("key")
+	assert.False(t, hasAttrs, "zero int64 should not mark modified")
+}
+
+func TestOptionalGroup_Int64AddsNonZero(t *testing.T) {
+	og := audit.NewOptionalGroup()
+	og.Int64("k", 1234567890123)
+	a, hasAttrs := og.Group("g")
+	require.True(t, hasAttrs)
+	assert.Equal(t, slog.Attr{Key: "g", Value: slog.GroupValue(slog.Int64("k", 1234567890123))}, a)
+}

--- a/internal/audit/slogattr.go
+++ b/internal/audit/slogattr.go
@@ -118,6 +118,7 @@ func (e *Entry) SlogAttrs() []slog.Attr {
 		Str("requestedProfile", e.RequestedProfile).
 		Str("requestedRepository", e.RequestedRepository).
 		Str("vendedRepository", e.VendedRepository).
+		Str("app", e.App).
 		Str("hashedToken", e.HashedToken).
 		Strs("repositories", e.Repositories).
 		Strs("permissions", e.Permissions)

--- a/internal/audit/slogattr.go
+++ b/internal/audit/slogattr.go
@@ -119,6 +119,8 @@ func (e *Entry) SlogAttrs() []slog.Attr {
 		Str("requestedRepository", e.RequestedRepository).
 		Str("vendedRepository", e.VendedRepository).
 		Str("app", e.App).
+		Int64("applicationID", e.ApplicationID).
+		Int64("installationID", e.InstallationID).
 		Str("hashedToken", e.HashedToken).
 		Strs("repositories", e.Repositories).
 		Strs("permissions", e.Permissions)

--- a/internal/audit/slogattr_test.go
+++ b/internal/audit/slogattr_test.go
@@ -293,9 +293,6 @@ func TestSlogEntryAttrsStructure(t *testing.T) {
 	assert.Contains(t, auth, "expiryRemaining", "expiryRemaining should be set when AuthExpirySecs > 0")
 }
 
-// TestSlogEntryAppIdentity pins the app identity keys in the token group: the
-// two identifiers are what make a vend attributable to an installation, and
-// they are skipped rather than emitted as zero when resolution never happened.
 func TestSlogEntryAppIdentity(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -345,9 +342,8 @@ func TestSlogEntryAppIdentity(t *testing.T) {
 	}
 }
 
-// TestSlogEntryTokenGroupElidedForZeroIdentity proves the identifiers use
-// skip-zero semantics rather than the Attr escape hatch: a request that failed
-// before resolution must not gain a token group.
+// Skip-zero rather than the Attr escape hatch: a request failing before
+// resolution must not gain a token group.
 func TestSlogEntryTokenGroupElidedForZeroIdentity(t *testing.T) {
 	var result map[string]any
 	require.NoError(t, json.Unmarshal(serializeSlogEntry(audit.Entry{Method: "POST", Path: "/token"}), &result))

--- a/internal/audit/slogattr_test.go
+++ b/internal/audit/slogattr_test.go
@@ -182,6 +182,22 @@ func TestSlogEntryAttrs(t *testing.T) {
 			},
 		},
 		{
+			name: "with app identity",
+			entry: audit.Entry{
+				RequestedProfile: "org/repo",
+				App:              "publisher",
+				ApplicationID:    12345,
+				InstallationID:   67890,
+			},
+		},
+		{
+			name: "app named but identifiers unresolved",
+			entry: audit.Entry{
+				RequestedProfile: "org/repo",
+				App:              "publisher",
+			},
+		},
+		{
 			name: "fully populated",
 			entry: audit.Entry{
 				Method:              "POST",
@@ -202,6 +218,9 @@ func TestSlogEntryAttrs(t *testing.T) {
 				RequestedProfile:    "org/repo",
 				RequestedRepository: "https://github.com/org/repo",
 				VendedRepository:    "https://github.com/org/vended-repo",
+				App:                 "publisher",
+				ApplicationID:       12345,
+				InstallationID:      67890,
 				HashedToken:         "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=",
 				Repositories:        []string{"org/repo"},
 				Permissions:         []string{"contents:read"},
@@ -272,4 +291,65 @@ func TestSlogEntryAttrsStructure(t *testing.T) {
 	auth := result2["authorization"].(map[string]any)
 	assert.Contains(t, auth, "expiry", "expiry should be set when AuthExpirySecs > 0")
 	assert.Contains(t, auth, "expiryRemaining", "expiryRemaining should be set when AuthExpirySecs > 0")
+}
+
+// TestSlogEntryAppIdentity pins the app identity keys in the token group: the
+// two identifiers are what make a vend attributable to an installation, and
+// they are skipped rather than emitted as zero when resolution never happened.
+func TestSlogEntryAppIdentity(t *testing.T) {
+	tests := []struct {
+		name     string
+		entry    audit.Entry
+		expected map[string]any
+		absent   []string
+	}{
+		{
+			name: "identifiers recorded alongside the name",
+			entry: audit.Entry{
+				App:            "publisher",
+				ApplicationID:  12345,
+				InstallationID: 67890,
+			},
+			expected: map[string]any{
+				"app":            "publisher",
+				"applicationID":  float64(12345),
+				"installationID": float64(67890),
+			},
+		},
+		{
+			name: "identifiers absent when the app was never resolved",
+			entry: audit.Entry{
+				RequestedProfile: "org/repo",
+				App:              "publisher",
+			},
+			expected: map[string]any{"app": "publisher"},
+			absent:   []string{"applicationID", "installationID"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result map[string]any
+			require.NoError(t, json.Unmarshal(serializeSlogEntry(tt.entry), &result))
+
+			token, ok := result["token"].(map[string]any)
+			require.True(t, ok, "token group should be present")
+
+			for k, v := range tt.expected {
+				assert.Equal(t, v, token[k])
+			}
+			for _, k := range tt.absent {
+				assert.NotContains(t, token, k)
+			}
+		})
+	}
+}
+
+// TestSlogEntryTokenGroupElidedForZeroIdentity proves the identifiers use
+// skip-zero semantics rather than the Attr escape hatch: a request that failed
+// before resolution must not gain a token group.
+func TestSlogEntryTokenGroupElidedForZeroIdentity(t *testing.T) {
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(serializeSlogEntry(audit.Entry{Method: "POST", Path: "/token"}), &result))
+	assert.NotContains(t, result, "token")
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -112,6 +112,14 @@ type GithubConfig struct {
 
 	ApplicationID  int64 `env:"GITHUB_APP_ID, required"`
 	InstallationID int64 `env:"GITHUB_APP_INSTALLATION_ID, required"`
+
+	// Apps is a JSON array of additional named GitHub App entries, each with a
+	// name, appId, installationId and exactly one of privateKey or
+	// privateKeyArn. It is held as raw JSON because its schema, validation and
+	// redaction rules belong with the app registry rather than with
+	// environment loading. Empty means no registry: the default app above vends
+	// every token and no installation is queried at startup.
+	Apps string `env:"GITHUB_APPS"`
 }
 
 type ObserveConfig struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -139,7 +139,13 @@ type ObserveConfig struct {
 }
 
 func Load(ctx context.Context) (Config, error) {
-	lookup := newFileContentLookuper(envconfig.OsLookuper(), "JWT_JWKS_STATIC", "GITHUB_APP_PRIVATE_KEY")
+	// GITHUB_APPS is allowlisted alongside the single-app private key: its
+	// entries can carry an inline PEM, and an environment variable is readable
+	// from process listings, container inspection and rendered task
+	// definitions.
+	lookup := newFileContentLookuper(envconfig.OsLookuper(),
+		"JWT_JWKS_STATIC", "GITHUB_APP_PRIVATE_KEY", "GITHUB_APPS",
+	)
 	return load(ctx, lookup)
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -113,12 +113,9 @@ type GithubConfig struct {
 	ApplicationID  int64 `env:"GITHUB_APP_ID, required"`
 	InstallationID int64 `env:"GITHUB_APP_INSTALLATION_ID, required"`
 
-	// Apps is a JSON array of additional named GitHub App entries, each with a
-	// name, appId, installationId and exactly one of privateKey or
-	// privateKeyArn. It is held as raw JSON because its schema, validation and
-	// redaction rules belong with the app registry rather than with
-	// environment loading. Empty means no registry: the default app above vends
-	// every token and no installation is queried at startup.
+	// Apps holds the named GitHub App registry as raw JSON: its schema,
+	// validation and redaction rules belong with the registry, not with
+	// environment loading. Empty means the default app above vends every token.
 	Apps string `env:"GITHUB_APPS"`
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,9 +14,20 @@ type Config struct {
 	Authorization AuthorizationConfig
 	Buildkite     BuildkiteConfig
 	Cache         CacheConfig
+	Development   DevelopmentConfig
 	Github        GithubConfig
 	Observe       ObserveConfig
 	Server        ServerConfig
+}
+
+// DevelopmentConfig holds switches for local development and testing. Every
+// field defaults to the production behaviour.
+type DevelopmentConfig struct {
+	// DiscloseAppIdentifiers adds appId and installationId to token responses,
+	// and chinmina_app_name, chinmina_app_id and chinmina_installation_id to
+	// git-credentials responses. A CI pipeline has no use for the deployment's
+	// app topology, so production discloses nothing.
+	DiscloseAppIdentifiers bool `env:"DEV_DISCLOSE_APP_IDENTIFIERS, default=false"`
 }
 
 type ServerConfig struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -631,18 +631,74 @@ func TestLoad_RealEnvironment(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "private-key.pem")
 	require.NoError(t, os.WriteFile(path, []byte("file-key\n"), 0o600))
 
+	clearFileVars(t)
 	for key, value := range requiredConfig {
 		if key == "GITHUB_APP_PRIVATE_KEY" {
 			continue // sourced from GITHUB_APP_PRIVATE_KEY_FILE below instead
 		}
 		t.Setenv(key, value)
 	}
-	unsetEnv(t, "GITHUB_APP_PRIVATE_KEY")
 	t.Setenv("GITHUB_APP_PRIVATE_KEY_FILE", path)
 
 	cfg, err := Load(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, "file-key", cfg.Github.PrivateKey)
+}
+
+// TestLoad_RealEnvironment_GithubAppsFile proves GITHUB_APPS is in the
+// allowlist Load builds, not just in a test-supplied one. Registry entries can
+// carry an inline PEM private key, so an operator needs the same escape hatch
+// from the process environment that the single-app private key has.
+func TestLoad_RealEnvironment_GithubAppsFile(t *testing.T) {
+	apps := `[{"name":"packages","appId":1,"installationId":2,"privateKey":"key"}]`
+
+	path := filepath.Join(t.TempDir(), "apps.json")
+	require.NoError(t, os.WriteFile(path, []byte(apps+"\n"), 0o600))
+
+	clearFileVars(t)
+	for key, value := range requiredConfig {
+		t.Setenv(key, value)
+	}
+	t.Setenv("GITHUB_APPS_FILE", path)
+
+	cfg, err := Load(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, apps, cfg.Github.Apps)
+}
+
+// TestLoad_RealEnvironment_GithubAppsConflict confirms GITHUB_APPS follows the
+// same mutual-exclusion rule as the other allowlisted keys: two sources for one
+// value leaves which app mints tokens ambiguous, so it fails rather than
+// silently preferring one.
+func TestLoad_RealEnvironment_GithubAppsConflict(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "apps.json")
+	require.NoError(t, os.WriteFile(path, []byte("[]\n"), 0o600))
+
+	clearFileVars(t)
+	for key, value := range requiredConfig {
+		t.Setenv(key, value)
+	}
+	t.Setenv("GITHUB_APPS", "[]")
+	t.Setenv("GITHUB_APPS_FILE", path)
+
+	_, err := Load(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid configuration")
+	assert.Contains(t, err.Error(), "GITHUB_APPS and GITHUB_APPS_FILE are mutually exclusive")
+}
+
+// clearFileVars removes every allowlisted key and its "_FILE" counterpart for
+// the duration of the test. Load reads the real process environment, so a
+// developer shell that already points one of these at a file (the repository's
+// direnv profile sets JWT_JWKS_STATIC_FILE, for one) would otherwise decide
+// the outcome of a test about a different variable.
+func clearFileVars(t *testing.T) {
+	t.Helper()
+
+	for _, key := range []string{"JWT_JWKS_STATIC", "GITHUB_APP_PRIVATE_KEY", "GITHUB_APPS"} {
+		unsetEnv(t, key)
+		unsetEnv(t, key+"_FILE")
+	}
 }
 
 // unsetEnv removes key from the environment for the duration of the test,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -714,3 +714,25 @@ func unsetEnv(t *testing.T, key string) {
 	}
 	require.NoError(t, os.Unsetenv(key))
 }
+
+// This is the only gate on the identifiers reaching a client, so its default
+// is the whole control.
+func TestDevelopmentConfig_DisclosureDefaultsOff(t *testing.T) {
+	cfg, err := load(context.Background(), envconfig.MapLookuper(requiredConfig))
+	require.NoError(t, err)
+
+	assert.Equal(t, DevelopmentConfig{}, cfg.Development)
+	assert.False(t, cfg.Development.DiscloseAppIdentifiers)
+}
+
+func TestDevelopmentConfig_DisclosureEnabledByEnvironment(t *testing.T) {
+	lookuper := envconfig.MultiLookuper(
+		envconfig.MapLookuper(requiredConfig),
+		envconfig.MapLookuper(map[string]string{"DEV_DISCLOSE_APP_IDENTIFIERS": "true"}),
+	)
+
+	cfg, err := load(context.Background(), lookuper)
+	require.NoError(t, err)
+
+	assert.True(t, cfg.Development.DiscloseAppIdentifiers)
+}

--- a/internal/github/apptokensource_test.go
+++ b/internal/github/apptokensource_test.go
@@ -70,7 +70,6 @@ func TestAppTokenSource_Token_KMS(t *testing.T) {
 	}
 
 	key := kmsSigningKey{
-		ctx:    context.Background(),
 		client: mockClient,
 		arn:    "arn:aws:kms:us-east-1:123456789:key/test-key",
 	}

--- a/internal/github/registry.go
+++ b/internal/github/registry.go
@@ -19,51 +19,36 @@ import (
 // property resolves to the same identity.
 const DefaultAppName = "default"
 
-// maxAppNameLength bounds a registry entry's name. Names appear in log lines,
-// audit entries and metric attributes, so an unbounded one is an unbounded
-// cardinality and an unbounded log record.
+// maxAppNameLength bounds a registry entry's name: names become metric
+// attributes, so unbounded length is unbounded cardinality.
 const maxAppNameLength = 64
 
-// appNamePattern constrains a registry entry's name to a lower-case,
-// URL- and label-safe form. Names travel into metric attributes and audit
-// entries, so the set of accepted characters is deliberately small.
+// appNamePattern constrains a registry entry's name to a lower-case, URL- and
+// label-safe form.
 var appNamePattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9._-]*[a-z0-9])?$`)
 
-// ErrPrivateKeyInvalid reports an unparseable private key.
-//
-// This is a deliberate, documented exception to the project's %w-wrapping
-// convention. The underlying error comes from a third-party parser whose
-// message content is outside our control and may change on any dependency
-// bump; a configuration error must never carry a substring of the key it
-// failed to parse. The entry is identified by name, and the operator has the
-// key — the library's message adds nothing they cannot reproduce.
+// ErrPrivateKeyInvalid reports an unparseable private key. A deliberate
+// exception to the %w convention: the parser's message may quote the key.
 var ErrPrivateKeyInvalid = errors.New("private key could not be parsed")
 
-// ErrAppUnknown reports a name that resolves to no usable app. A disabled app
-// is indistinguishable from an absent one here by design: enabled state is
-// exposed for logging only, so no caller can resolve a disabled app by
-// forgetting to check a flag.
+// ErrAppUnknown reports a name that resolves to no usable app. Disabled apps
+// are indistinguishable from absent ones: enabled state is for logging only.
 var ErrAppUnknown = errors.New("no such app")
 
-// AppIdentity is what a profile's app name resolves to: enough to mint through
-// an installation and to attribute the result, and nothing else. It is plain
-// data rather than a client or a closure, so it can travel on the resolved
-// request value and into a cache key without carrying a credential with it.
+// AppIdentity is what a profile's app name resolves to. It is plain data, not a
+// client, so it can travel on a request value or into a cache key.
 type AppIdentity struct {
 	Name           string
 	ApplicationID  int64
 	InstallationID int64
 }
 
-// IsZero reports whether the identity was never resolved. Callers that key on
-// an identity use this to refuse rather than silently key on zeroes.
+// IsZero reports whether the identity was never resolved.
 func (i AppIdentity) IsZero() bool {
 	return i == AppIdentity{}
 }
 
-// LogValue keeps the identity's log shape fixed at the three fields that
-// identify it. Key material never reaches this type, so there is nothing to
-// redact.
+// LogValue implements slog.LogValuer.
 func (i AppIdentity) LogValue() slog.Value {
 	return slog.GroupValue(
 		slog.String("name", i.Name),
@@ -72,10 +57,7 @@ func (i AppIdentity) LogValue() slog.Value {
 	)
 }
 
-// appEntryConfig is one GITHUB_APPS entry as configured. It is the only type
-// in the registry that holds key material, and its LogValue omits it: an
-// operator cannot leak a key by logging this value, whatever they add to the
-// struct later.
+// appEntryConfig is one GITHUB_APPS entry as configured.
 type appEntryConfig struct {
 	Name           string `json:"name"`
 	ApplicationID  int64  `json:"appId"`
@@ -84,8 +66,7 @@ type appEntryConfig struct {
 	PrivateKeyARN  string `json:"privateKeyArn"`
 }
 
-// keySource names where a key comes from without disclosing it. Exactly one
-// source is present by the time this is called.
+// keySource names where a key comes from without disclosing it.
 func keySource(privateKeyARN string) string {
 	if privateKeyARN != "" {
 		return "privateKeyArn"
@@ -93,9 +74,8 @@ func keySource(privateKeyARN string) string {
 	return "privateKey"
 }
 
-// LogValue deliberately omits PrivateKey and PrivateKeyARN. The ARN is
-// omitted as well as the key: it names the credential and its account, and an
-// operator reading a log has no use for it that justifies publishing it.
+// LogValue omits both the private key and its ARN: the ARN names the
+// credential and its account, and neither belongs in a log.
 func (e appEntryConfig) LogValue() slog.Value {
 	return slog.GroupValue(
 		slog.String("name", e.Name),
@@ -105,30 +85,25 @@ func (e appEntryConfig) LogValue() slog.Value {
 	)
 }
 
-// resolvedApp is a registry entry after verification. It holds no key
-// material: the client it wraps has already absorbed the key, so nothing that
-// survives construction can disclose one.
+// resolvedApp is a registry entry after verification.
 type resolvedApp struct {
 	identity  AppIdentity
 	client    Client
 	keySource string
 
-	// enabled is false for an app on a different account, or one whose
-	// installation could not be queried. Disabled is terminal until the
-	// process restarts: re-verification would make an instance's enabled set a
-	// function of when its timer fired rather than of its configuration.
+	// enabled is false for an app on another account, or one whose installation
+	// could not be queried. Disabled is terminal until restart: re-verification
+	// would make the enabled set depend on when a timer fired.
 	enabled bool
 
-	// accountLogin is the verified organization, for logging. Empty when
-	// verification failed.
+	// accountLogin is the verified organization. Empty when verification failed.
 	accountLogin string
 
 	// disabledReason explains a false enabled, for the startup log only.
 	disabledReason string
 }
 
-// LogValue is the R48 startup record: name, application ID, installation ID,
-// verified organization and enabled state.
+// LogValue is the startup record for one registry entry.
 func (a resolvedApp) LogValue() slog.Value {
 	attrs := []slog.Attr{
 		slog.String("name", a.identity.Name),
@@ -145,13 +120,9 @@ func (a resolvedApp) LogValue() slog.Value {
 }
 
 // Registry maps a profile's app name to the installation its tokens are minted
-// through. It is built once at startup and never written afterwards: methods
-// take value receivers over a map that the constructor is the only writer of,
-// so a handler that captured it cannot observe it change, and no request path
-// needs a lock.
-//
-// The default app is always present under DefaultAppName, whether or not
-// GITHUB_APPS is configured.
+// through. It is written only by the constructor and never afterwards, so the
+// request path needs no lock. The default app is always present under
+// DefaultAppName.
 type Registry struct {
 	apps map[string]resolvedApp
 }
@@ -159,19 +130,13 @@ type Registry struct {
 // NewRegistry builds the app registry from the default app's configuration and
 // the GITHUB_APPS entries alongside it.
 //
-// ctx must be the long-lived server context. It reaches KMS-backed signing key
-// construction, and a key built under a startup- or verification-scoped
-// context would boot cleanly and then fail every mint once that context
-// expired.
+// ctx must be the long-lived server context: it reaches KMS-backed signing key
+// construction, and a key built under a startup-scoped context would boot
+// cleanly and then fail every mint.
 //
-// defaultClient is the already-constructed client for the default app, reused
-// rather than rebuilt so the default app has exactly one minting identity.
-//
-// Errors here are deploy-blocking and deterministic: they describe
-// configuration with no single unambiguous meaning, or a default app that
-// cannot authenticate as itself. An individual registry app that cannot be
-// verified is disabled instead, so one unreachable credential does not take
-// down vending for every other profile.
+// Errors here are deploy-blocking: ambiguous configuration, or a default app
+// that cannot authenticate as itself. A registry app that cannot be verified is
+// disabled instead, so one unreachable credential does not stop the rest.
 func NewRegistry(ctx context.Context, cfg appconfig.GithubConfig, defaultClient Client) (Registry, error) {
 	defaultApp := resolvedApp{
 		identity: AppIdentity{
@@ -189,9 +154,8 @@ func NewRegistry(ctx context.Context, cfg appconfig.GithubConfig, defaultClient 
 		return Registry{}, err
 	}
 
-	// R19: with no registry configured the default app vends everything and
-	// startup queries no installation at all. Deployments not using the
-	// feature pay nothing for its existence.
+	// With no registry configured, startup queries no installation at all:
+	// deployments not using the feature pay nothing for it.
 	if len(entries) == 0 {
 		return Registry{apps: map[string]resolvedApp{DefaultAppName: defaultApp}}, nil
 	}
@@ -228,13 +192,8 @@ func NewRegistry(ctx context.Context, cfg appconfig.GithubConfig, defaultClient 
 	return registry, nil
 }
 
-// Resolve maps an app name to the identity its tokens are minted through.
-// A disabled app resolves to nothing: enabled state is not part of this
-// answer, so a caller cannot act on a disabled app by neglecting to check it.
-//
-// This is the single enforcement point shared by profile compilation and the
-// request path, which is what makes a compiled profile and a live request
-// agree on which apps are usable.
+// Resolve maps an app name to the identity its tokens are minted through. A
+// disabled app resolves to nothing.
 func (r Registry) Resolve(name string) (AppIdentity, bool) {
 	app, found := r.apps[name]
 	if !found || !app.enabled {
@@ -255,11 +214,9 @@ func (r Registry) DefaultIdentity() AppIdentity {
 	return r.apps[DefaultAppName].identity
 }
 
-// CreateAccessToken mints an installation token through the named app.
-//
-// The identity is re-resolved rather than trusted: it may have travelled
-// through a cache payload or a long-lived request value, and the registry is
-// the only authority on which apps are usable.
+// CreateAccessToken mints an installation token through the named app. The
+// identity is re-resolved rather than trusted: it may have arrived from a cache
+// payload, and the registry is the only authority on which apps are usable.
 func (r Registry) CreateAccessToken(ctx context.Context, app AppIdentity, repoNames []string, scopes []string) (string, time.Time, error) {
 	resolved, found := r.apps[app.Name]
 	if !found || !resolved.enabled {
@@ -277,13 +234,8 @@ func (r Registry) CreateAccessToken(ctx context.Context, app AppIdentity, repoNa
 }
 
 // verify establishes that every registry app is installed on the same account
-// as the default app.
-//
-// The default app's account is the reference, so no new variable is required
-// of an existing deployment. Queries are issued concurrently, so the phase
-// costs roughly the slowest one rather than their sum. No time budget governs
-// it: a budget's expiry would be evidence about this service rather than about
-// any app, which is the wrong basis on which to disable one.
+// as the default app. Queries run concurrently and under no time budget: an
+// expiring budget would be evidence about this service, not about an app.
 func (r Registry) verify(ctx context.Context) error {
 	type result struct {
 		name    string
@@ -314,10 +266,9 @@ func (r Registry) verify(ctx context.Context) error {
 		accounts[res.name] = res.account
 	}
 
-	// The default app is the exception to "disable, don't fail". If the
-	// service cannot query its own installation it cannot authenticate to
-	// GitHub as itself, so minting is broken regardless and a process that
-	// continued would serve failures while appearing healthy.
+	// The default app is the exception to "disable, don't fail": a service that
+	// cannot authenticate as itself would serve failures while appearing
+	// healthy.
 	if err, failed := failures[DefaultAppName]; failed {
 		return fmt.Errorf("default app installation could not be queried: %w", err)
 	}
@@ -354,19 +305,16 @@ func (r Registry) verify(ctx context.Context) error {
 	return nil
 }
 
-// logEntries records the whole registry once at startup: it is the operator's
-// only view of which apps a running instance considers usable, since disabled
-// is terminal until restart.
+// logEntries records the whole registry once at startup: the operator's only
+// view of which apps an instance considers usable.
 func (r Registry) logEntries() {
 	for _, app := range r.apps {
 		slog.Info("github app registry entry", "app", app)
 	}
 }
 
-// newRegistryClient builds the minting client for one registry entry.
-//
-// The entry inherits the default app's API URL: the registry is a set of
-// credentials against one GitHub deployment, not a set of GitHub deployments.
+// newRegistryClient builds the minting client for one registry entry. Entries
+// inherit the default app's API URL: one GitHub deployment, many credentials.
 func newRegistryClient(ctx context.Context, cfg appconfig.GithubConfig, entry appEntryConfig, loadAWS AWSConfigLoader) (Client, error) {
 	entryCfg := appconfig.GithubConfig{
 		APIURL:         cfg.APIURL,
@@ -377,8 +325,7 @@ func newRegistryClient(ctx context.Context, cfg appconfig.GithubConfig, entry ap
 	}
 
 	// Validate the key before building the client so an unparseable key is
-	// reported as such, rather than as a transport construction failure with
-	// the parser's message attached.
+	// reported as such, not as a transport construction failure.
 	if entry.PrivateKey != "" {
 		if _, err := parsePrivateKeyPEM(entry.PrivateKey); err != nil {
 			return Client{}, fmt.Errorf("app %q: %w", entry.Name, ErrPrivateKeyInvalid)
@@ -387,22 +334,15 @@ func newRegistryClient(ctx context.Context, cfg appconfig.GithubConfig, entry ap
 
 	client, err := New(ctx, entryCfg, WithAppTransport, WithAWSConfigLoader(loadAWS))
 	if err != nil {
-		// The wrapped error describes client construction, not key content:
-		// the key has already been parsed successfully above, and the KMS path
-		// contacts nothing here.
+		// Safe to wrap: the key has already parsed, so this cannot quote it.
 		return Client{}, fmt.Errorf("app %q: could not construct GitHub client: %w", entry.Name, err)
 	}
 
 	return client, nil
 }
 
-// parseAppEntries decodes and validates GITHUB_APPS.
-//
-// Every failure here is deploy-blocking rather than degrading: configuration
-// with no single unambiguous meaning fails identically on every instance,
-// where a partial interpretation would differ between them. Each message
-// identifies the offending entry by name, or by index when the name itself is
-// the problem, and never reproduces any part of a key or ARN.
+// parseAppEntries decodes and validates GITHUB_APPS. Failures are
+// deploy-blocking: ambiguous configuration must fail identically everywhere.
 func parseAppEntries(raw string) ([]appEntryConfig, error) {
 	if strings.TrimSpace(raw) == "" {
 		return nil, nil
@@ -410,9 +350,8 @@ func parseAppEntries(raw string) ([]appEntryConfig, error) {
 
 	decoder := json.NewDecoder(strings.NewReader(raw))
 
-	// An unrecognised field is rejected for the same reason the profile YAML
-	// rejects one: a typo that is silently ignored is a credential configured
-	// differently from how it reads.
+	// A silently ignored typo is a credential configured differently from how
+	// it reads.
 	decoder.DisallowUnknownFields()
 
 	var entries []appEntryConfig

--- a/internal/github/registry.go
+++ b/internal/github/registry.go
@@ -2,7 +2,7 @@ package github
 
 import (
 	"context"
-	"encoding/json"
+	"encoding/json/v2"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -329,15 +329,23 @@ func parseAppEntries(raw string) ([]appEntryConfig, error) {
 		return nil, nil
 	}
 
-	decoder := json.NewDecoder(strings.NewReader(raw))
-
-	// A silently ignored typo is a credential configured differently from how
-	// it reads.
-	decoder.DisallowUnknownFields()
-
+	// json/v2's Unmarshal requires the input to be exactly one JSON value: a
+	// streaming decoder stops at the end of the first value, so a truncated or
+	// concatenated variable would be silently accepted with the remainder
+	// discarded.
+	//
+	// RejectUnknownMembers: a silently ignored typo is a credential configured
+	// differently from how it reads.
 	var entries []appEntryConfig
-	if err := decoder.Decode(&entries); err != nil {
+	if err := json.Unmarshal([]byte(raw), &entries, json.RejectUnknownMembers(true)); err != nil {
 		return nil, fmt.Errorf("GITHUB_APPS is not valid: %w", err)
+	}
+
+	// JSON null unmarshals to a nil slice without error, and an empty registry
+	// skips installation verification entirely. A deployment that believes it
+	// configured apps must not start with only the default app.
+	if entries == nil {
+		return nil, errors.New("GITHUB_APPS is not valid: expected a JSON array, found null")
 	}
 
 	seen := make(map[string]struct{}, len(entries))

--- a/internal/github/registry.go
+++ b/internal/github/registry.go
@@ -256,49 +256,37 @@ func (r Registry) verify(ctx context.Context) error {
 	wg.Wait()
 	close(results)
 
-	accounts := make(map[string]installationAccount, len(r.apps))
-	failures := make(map[string]error, len(r.apps))
+	queried := make(map[string]result, len(r.apps))
 	for res := range results {
-		if res.err != nil {
-			failures[res.name] = res.err
-			continue
-		}
-		accounts[res.name] = res.account
+		queried[res.name] = res
 	}
 
 	// The default app is the exception to "disable, don't fail": a service that
 	// cannot authenticate as itself would serve failures while appearing
 	// healthy.
-	if err, failed := failures[DefaultAppName]; failed {
+	if err := queried[DefaultAppName].err; err != nil {
 		return fmt.Errorf("default app installation could not be queried: %w", err)
 	}
 
-	reference := accounts[DefaultAppName]
+	// The default app is the reference, so it passes the comparison below
+	// against itself: it needs no case of its own.
+	reference := queried[DefaultAppName].account
 
 	for name, app := range r.apps {
-		if name == DefaultAppName {
-			app.accountLogin = reference.Login
-			r.apps[name] = app
-			continue
-		}
+		res := queried[name]
 
-		if err, failed := failures[name]; failed {
+		switch {
+		case res.err != nil:
 			app.enabled = false
-			app.disabledReason = fmt.Sprintf("installation could not be queried: %v", err)
-			r.apps[name] = app
-			continue
-		}
-
-		account := accounts[name]
-		if account.ID != reference.ID {
+			app.disabledReason = fmt.Sprintf("installation could not be queried: %v", res.err)
+		case res.account.ID != reference.ID:
 			app.enabled = false
-			app.disabledReason = fmt.Sprintf("installed on account %q, expected %q", account.Login, reference.Login)
-			r.apps[name] = app
-			continue
+			app.disabledReason = fmt.Sprintf("installed on account %q, expected %q", res.account.Login, reference.Login)
+		default:
+			app.enabled = true
+			app.accountLogin = res.account.Login
 		}
 
-		app.enabled = true
-		app.accountLogin = account.Login
 		r.apps[name] = app
 	}
 

--- a/internal/github/registry.go
+++ b/internal/github/registry.go
@@ -1,0 +1,470 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	appconfig "github.com/chinmina/chinmina-bridge/internal/config"
+)
+
+// DefaultAppName is the reserved name of the app configured by the
+// GITHUB_APP_* variables. A profile may name it explicitly; omitting the app
+// property resolves to the same identity.
+const DefaultAppName = "default"
+
+// maxAppNameLength bounds a registry entry's name. Names appear in log lines,
+// audit entries and metric attributes, so an unbounded one is an unbounded
+// cardinality and an unbounded log record.
+const maxAppNameLength = 64
+
+// appNamePattern constrains a registry entry's name to a lower-case,
+// URL- and label-safe form. Names travel into metric attributes and audit
+// entries, so the set of accepted characters is deliberately small.
+var appNamePattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9._-]*[a-z0-9])?$`)
+
+// ErrPrivateKeyInvalid reports an unparseable private key.
+//
+// This is a deliberate, documented exception to the project's %w-wrapping
+// convention. The underlying error comes from a third-party parser whose
+// message content is outside our control and may change on any dependency
+// bump; a configuration error must never carry a substring of the key it
+// failed to parse. The entry is identified by name, and the operator has the
+// key — the library's message adds nothing they cannot reproduce.
+var ErrPrivateKeyInvalid = errors.New("private key could not be parsed")
+
+// ErrAppUnknown reports a name that resolves to no usable app. A disabled app
+// is indistinguishable from an absent one here by design: enabled state is
+// exposed for logging only, so no caller can resolve a disabled app by
+// forgetting to check a flag.
+var ErrAppUnknown = errors.New("no such app")
+
+// AppIdentity is what a profile's app name resolves to: enough to mint through
+// an installation and to attribute the result, and nothing else. It is plain
+// data rather than a client or a closure, so it can travel on the resolved
+// request value and into a cache key without carrying a credential with it.
+type AppIdentity struct {
+	Name           string
+	ApplicationID  int64
+	InstallationID int64
+}
+
+// IsZero reports whether the identity was never resolved. Callers that key on
+// an identity use this to refuse rather than silently key on zeroes.
+func (i AppIdentity) IsZero() bool {
+	return i == AppIdentity{}
+}
+
+// LogValue keeps the identity's log shape fixed at the three fields that
+// identify it. Key material never reaches this type, so there is nothing to
+// redact.
+func (i AppIdentity) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("name", i.Name),
+		slog.Int64("applicationID", i.ApplicationID),
+		slog.Int64("installationID", i.InstallationID),
+	)
+}
+
+// appEntryConfig is one GITHUB_APPS entry as configured. It is the only type
+// in the registry that holds key material, and its LogValue omits it: an
+// operator cannot leak a key by logging this value, whatever they add to the
+// struct later.
+type appEntryConfig struct {
+	Name           string `json:"name"`
+	ApplicationID  int64  `json:"appId"`
+	InstallationID int64  `json:"installationId"`
+	PrivateKey     string `json:"privateKey"`
+	PrivateKeyARN  string `json:"privateKeyArn"`
+}
+
+// keySource names where a key comes from without disclosing it. Exactly one
+// source is present by the time this is called.
+func keySource(privateKeyARN string) string {
+	if privateKeyARN != "" {
+		return "privateKeyArn"
+	}
+	return "privateKey"
+}
+
+// LogValue deliberately omits PrivateKey and PrivateKeyARN. The ARN is
+// omitted as well as the key: it names the credential and its account, and an
+// operator reading a log has no use for it that justifies publishing it.
+func (e appEntryConfig) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("name", e.Name),
+		slog.Int64("applicationID", e.ApplicationID),
+		slog.Int64("installationID", e.InstallationID),
+		slog.String("keySource", keySource(e.PrivateKeyARN)),
+	)
+}
+
+// resolvedApp is a registry entry after verification. It holds no key
+// material: the client it wraps has already absorbed the key, so nothing that
+// survives construction can disclose one.
+type resolvedApp struct {
+	identity  AppIdentity
+	client    Client
+	keySource string
+
+	// enabled is false for an app on a different account, or one whose
+	// installation could not be queried. Disabled is terminal until the
+	// process restarts: re-verification would make an instance's enabled set a
+	// function of when its timer fired rather than of its configuration.
+	enabled bool
+
+	// accountLogin is the verified organization, for logging. Empty when
+	// verification failed.
+	accountLogin string
+
+	// disabledReason explains a false enabled, for the startup log only.
+	disabledReason string
+}
+
+// LogValue is the R48 startup record: name, application ID, installation ID,
+// verified organization and enabled state.
+func (a resolvedApp) LogValue() slog.Value {
+	attrs := []slog.Attr{
+		slog.String("name", a.identity.Name),
+		slog.Int64("applicationID", a.identity.ApplicationID),
+		slog.Int64("installationID", a.identity.InstallationID),
+		slog.String("keySource", a.keySource),
+		slog.String("organization", a.accountLogin),
+		slog.Bool("enabled", a.enabled),
+	}
+	if a.disabledReason != "" {
+		attrs = append(attrs, slog.String("disabledReason", a.disabledReason))
+	}
+	return slog.GroupValue(attrs...)
+}
+
+// Registry maps a profile's app name to the installation its tokens are minted
+// through. It is built once at startup and never written afterwards: methods
+// take value receivers over a map that the constructor is the only writer of,
+// so a handler that captured it cannot observe it change, and no request path
+// needs a lock.
+//
+// The default app is always present under DefaultAppName, whether or not
+// GITHUB_APPS is configured.
+type Registry struct {
+	apps map[string]resolvedApp
+}
+
+// NewRegistry builds the app registry from the default app's configuration and
+// the GITHUB_APPS entries alongside it.
+//
+// ctx must be the long-lived server context. It reaches KMS-backed signing key
+// construction, and a key built under a startup- or verification-scoped
+// context would boot cleanly and then fail every mint once that context
+// expired.
+//
+// defaultClient is the already-constructed client for the default app, reused
+// rather than rebuilt so the default app has exactly one minting identity.
+//
+// Errors here are deploy-blocking and deterministic: they describe
+// configuration with no single unambiguous meaning, or a default app that
+// cannot authenticate as itself. An individual registry app that cannot be
+// verified is disabled instead, so one unreachable credential does not take
+// down vending for every other profile.
+func NewRegistry(ctx context.Context, cfg appconfig.GithubConfig, defaultClient Client) (Registry, error) {
+	defaultApp := resolvedApp{
+		identity: AppIdentity{
+			Name:           DefaultAppName,
+			ApplicationID:  cfg.ApplicationID,
+			InstallationID: cfg.InstallationID,
+		},
+		client:    defaultClient,
+		keySource: keySource(cfg.PrivateKeyARN),
+		enabled:   true,
+	}
+
+	entries, err := parseAppEntries(cfg.Apps)
+	if err != nil {
+		return Registry{}, err
+	}
+
+	// R19: with no registry configured the default app vends everything and
+	// startup queries no installation at all. Deployments not using the
+	// feature pay nothing for its existence.
+	if len(entries) == 0 {
+		return Registry{apps: map[string]resolvedApp{DefaultAppName: defaultApp}}, nil
+	}
+
+	loadAWS := newAWSConfigLoader(ctx)
+
+	apps := make(map[string]resolvedApp, len(entries)+1)
+	apps[DefaultAppName] = defaultApp
+
+	for _, entry := range entries {
+		client, err := newRegistryClient(ctx, cfg, entry, loadAWS)
+		if err != nil {
+			return Registry{}, err
+		}
+
+		apps[entry.Name] = resolvedApp{
+			identity: AppIdentity{
+				Name:           entry.Name,
+				ApplicationID:  entry.ApplicationID,
+				InstallationID: entry.InstallationID,
+			},
+			client:    client,
+			keySource: keySource(entry.PrivateKeyARN),
+		}
+	}
+
+	registry := Registry{apps: apps}
+	if err := registry.verify(ctx); err != nil {
+		return Registry{}, err
+	}
+
+	registry.logEntries()
+
+	return registry, nil
+}
+
+// Resolve maps an app name to the identity its tokens are minted through.
+// A disabled app resolves to nothing: enabled state is not part of this
+// answer, so a caller cannot act on a disabled app by neglecting to check it.
+//
+// This is the single enforcement point shared by profile compilation and the
+// request path, which is what makes a compiled profile and a live request
+// agree on which apps are usable.
+func (r Registry) Resolve(name string) (AppIdentity, bool) {
+	app, found := r.apps[name]
+	if !found || !app.enabled {
+		return AppIdentity{}, false
+	}
+	return app.identity, true
+}
+
+// IsUsable reports whether a profile may name this app. It is Resolve, so
+// compilation and the request path cannot drift apart.
+func (r Registry) IsUsable(name string) bool {
+	_, usable := r.Resolve(name)
+	return usable
+}
+
+// DefaultIdentity is the identity of the app configured by GITHUB_APP_*.
+func (r Registry) DefaultIdentity() AppIdentity {
+	return r.apps[DefaultAppName].identity
+}
+
+// CreateAccessToken mints an installation token through the named app.
+//
+// The identity is re-resolved rather than trusted: it may have travelled
+// through a cache payload or a long-lived request value, and the registry is
+// the only authority on which apps are usable.
+func (r Registry) CreateAccessToken(ctx context.Context, app AppIdentity, repoNames []string, scopes []string) (string, time.Time, error) {
+	resolved, found := r.apps[app.Name]
+	if !found || !resolved.enabled {
+		return "", time.Time{}, fmt.Errorf("cannot mint through app %q: %w", app.Name, ErrAppUnknown)
+	}
+
+	// A name is a label on an identity, and an operator may repoint it. A
+	// request carrying the old identity must not mint through the new one.
+	if resolved.identity != app {
+		return "", time.Time{}, fmt.Errorf("app %q no longer refers to application %d installation %d: %w",
+			app.Name, app.ApplicationID, app.InstallationID, ErrAppUnknown)
+	}
+
+	return resolved.client.CreateAccessToken(ctx, repoNames, scopes)
+}
+
+// verify establishes that every registry app is installed on the same account
+// as the default app.
+//
+// The default app's account is the reference, so no new variable is required
+// of an existing deployment. Queries are issued concurrently, so the phase
+// costs roughly the slowest one rather than their sum. No time budget governs
+// it: a budget's expiry would be evidence about this service rather than about
+// any app, which is the wrong basis on which to disable one.
+func (r Registry) verify(ctx context.Context) error {
+	type result struct {
+		name    string
+		account installationAccount
+		err     error
+	}
+
+	results := make(chan result, len(r.apps))
+
+	var wg sync.WaitGroup
+	for name, app := range r.apps {
+		wg.Go(func() {
+			account, err := app.client.InstallationAccount(ctx)
+			results <- result{name: name, account: account, err: err}
+		})
+	}
+
+	wg.Wait()
+	close(results)
+
+	accounts := make(map[string]installationAccount, len(r.apps))
+	failures := make(map[string]error, len(r.apps))
+	for res := range results {
+		if res.err != nil {
+			failures[res.name] = res.err
+			continue
+		}
+		accounts[res.name] = res.account
+	}
+
+	// The default app is the exception to "disable, don't fail". If the
+	// service cannot query its own installation it cannot authenticate to
+	// GitHub as itself, so minting is broken regardless and a process that
+	// continued would serve failures while appearing healthy.
+	if err, failed := failures[DefaultAppName]; failed {
+		return fmt.Errorf("default app installation could not be queried: %w", err)
+	}
+
+	reference := accounts[DefaultAppName]
+
+	for name, app := range r.apps {
+		if name == DefaultAppName {
+			app.accountLogin = reference.Login
+			r.apps[name] = app
+			continue
+		}
+
+		if err, failed := failures[name]; failed {
+			app.enabled = false
+			app.disabledReason = fmt.Sprintf("installation could not be queried: %v", err)
+			r.apps[name] = app
+			continue
+		}
+
+		account := accounts[name]
+		if account.ID != reference.ID {
+			app.enabled = false
+			app.disabledReason = fmt.Sprintf("installed on account %q, expected %q", account.Login, reference.Login)
+			r.apps[name] = app
+			continue
+		}
+
+		app.enabled = true
+		app.accountLogin = account.Login
+		r.apps[name] = app
+	}
+
+	return nil
+}
+
+// logEntries records the whole registry once at startup: it is the operator's
+// only view of which apps a running instance considers usable, since disabled
+// is terminal until restart.
+func (r Registry) logEntries() {
+	for _, app := range r.apps {
+		slog.Info("github app registry entry", "app", app)
+	}
+}
+
+// newRegistryClient builds the minting client for one registry entry.
+//
+// The entry inherits the default app's API URL: the registry is a set of
+// credentials against one GitHub deployment, not a set of GitHub deployments.
+func newRegistryClient(ctx context.Context, cfg appconfig.GithubConfig, entry appEntryConfig, loadAWS AWSConfigLoader) (Client, error) {
+	entryCfg := appconfig.GithubConfig{
+		APIURL:         cfg.APIURL,
+		PrivateKey:     entry.PrivateKey,
+		PrivateKeyARN:  entry.PrivateKeyARN,
+		ApplicationID:  entry.ApplicationID,
+		InstallationID: entry.InstallationID,
+	}
+
+	// Validate the key before building the client so an unparseable key is
+	// reported as such, rather than as a transport construction failure with
+	// the parser's message attached.
+	if entry.PrivateKey != "" {
+		if _, err := parsePrivateKeyPEM(entry.PrivateKey); err != nil {
+			return Client{}, fmt.Errorf("app %q: %w", entry.Name, ErrPrivateKeyInvalid)
+		}
+	}
+
+	client, err := New(ctx, entryCfg, WithAppTransport, WithAWSConfigLoader(loadAWS))
+	if err != nil {
+		// The wrapped error describes client construction, not key content:
+		// the key has already been parsed successfully above, and the KMS path
+		// contacts nothing here.
+		return Client{}, fmt.Errorf("app %q: could not construct GitHub client: %w", entry.Name, err)
+	}
+
+	return client, nil
+}
+
+// parseAppEntries decodes and validates GITHUB_APPS.
+//
+// Every failure here is deploy-blocking rather than degrading: configuration
+// with no single unambiguous meaning fails identically on every instance,
+// where a partial interpretation would differ between them. Each message
+// identifies the offending entry by name, or by index when the name itself is
+// the problem, and never reproduces any part of a key or ARN.
+func parseAppEntries(raw string) ([]appEntryConfig, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, nil
+	}
+
+	decoder := json.NewDecoder(strings.NewReader(raw))
+
+	// An unrecognised field is rejected for the same reason the profile YAML
+	// rejects one: a typo that is silently ignored is a credential configured
+	// differently from how it reads.
+	decoder.DisallowUnknownFields()
+
+	var entries []appEntryConfig
+	if err := decoder.Decode(&entries); err != nil {
+		return nil, fmt.Errorf("GITHUB_APPS is not valid: %w", err)
+	}
+
+	seen := make(map[string]struct{}, len(entries))
+	for index, entry := range entries {
+		if err := validateAppEntry(index, entry); err != nil {
+			return nil, err
+		}
+
+		if _, duplicate := seen[entry.Name]; duplicate {
+			return nil, fmt.Errorf("GITHUB_APPS entry %d: duplicate app name %q", index, entry.Name)
+		}
+		seen[entry.Name] = struct{}{}
+	}
+
+	return entries, nil
+}
+
+func validateAppEntry(index int, entry appEntryConfig) error {
+	if entry.Name == DefaultAppName {
+		return fmt.Errorf("GITHUB_APPS entry %d: name %q is reserved for the app configured by GITHUB_APP_ID", index, DefaultAppName)
+	}
+
+	if len(entry.Name) > maxAppNameLength {
+		return fmt.Errorf("GITHUB_APPS entry %d: name exceeds %d characters", index, maxAppNameLength)
+	}
+
+	if !appNamePattern.MatchString(entry.Name) {
+		return fmt.Errorf("GITHUB_APPS entry %d: name %q must match %s", index, entry.Name, appNamePattern)
+	}
+
+	if entry.ApplicationID <= 0 {
+		return fmt.Errorf("GITHUB_APPS entry %q: appId must be a positive integer", entry.Name)
+	}
+
+	if entry.InstallationID <= 0 {
+		return fmt.Errorf("GITHUB_APPS entry %q: installationId must be a positive integer", entry.Name)
+	}
+
+	hasKey := entry.PrivateKey != ""
+	hasARN := entry.PrivateKeyARN != ""
+
+	if hasKey && hasARN {
+		return fmt.Errorf("GITHUB_APPS entry %q: declares both privateKey and privateKeyArn, expected exactly one", entry.Name)
+	}
+	if !hasKey && !hasARN {
+		return fmt.Errorf("GITHUB_APPS entry %q: declares neither privateKey nor privateKeyArn, expected exactly one", entry.Name)
+	}
+
+	return nil
+}

--- a/internal/github/registry.go
+++ b/internal/github/registry.go
@@ -14,41 +14,36 @@ import (
 	appconfig "github.com/chinmina/chinmina-bridge/internal/config"
 )
 
-// DefaultAppName is the reserved name of the app configured by the
-// GITHUB_APP_* variables. A profile may name it explicitly; omitting the app
-// property resolves to the same identity.
+// DefaultAppName names the app configured by the GITHUB_APP_* variables. A
+// profile may name it explicitly; omitting the app property resolves the same.
 const DefaultAppName = "default"
 
 // maxAppNameLength bounds a registry entry's name: names become metric
 // attributes, so unbounded length is unbounded cardinality.
 const maxAppNameLength = 64
 
-// appNamePattern constrains a registry entry's name to a lower-case, URL- and
-// label-safe form.
 var appNamePattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9._-]*[a-z0-9])?$`)
 
-// ErrPrivateKeyInvalid reports an unparseable private key. A deliberate
-// exception to the %w convention: the parser's message may quote the key.
+// ErrPrivateKeyInvalid deliberately breaks the %w convention: the parser's
+// message may quote the key.
 var ErrPrivateKeyInvalid = errors.New("private key could not be parsed")
 
-// ErrAppUnknown reports a name that resolves to no usable app. Disabled apps
-// are indistinguishable from absent ones: enabled state is for logging only.
+// ErrAppUnknown does not distinguish a disabled app from an absent one:
+// enabled state is for logging only.
 var ErrAppUnknown = errors.New("no such app")
 
-// AppIdentity is what a profile's app name resolves to. It is plain data, not a
-// client, so it can travel on a request value or into a cache key.
+// AppIdentity is plain data rather than a client, so it can travel on a request
+// value or into a cache key.
 type AppIdentity struct {
 	Name           string
 	ApplicationID  int64
 	InstallationID int64
 }
 
-// IsZero reports whether the identity was never resolved.
 func (i AppIdentity) IsZero() bool {
 	return i == AppIdentity{}
 }
 
-// appEntryConfig is one GITHUB_APPS entry as configured.
 type appEntryConfig struct {
 	Name           string `json:"name"`
 	ApplicationID  int64  `json:"appId"`
@@ -65,10 +60,8 @@ func keySource(privateKeyARN string) string {
 	return "privateKey"
 }
 
-// LogValue omits both the private key and its ARN: the ARN names the
-// credential and its account, and neither belongs in a log. Nothing logs an
-// entry today; this exists so that the first thing to do so cannot print a
-// private key by default.
+// LogValue withholds the key and its ARN: this record identifies an entry, not
+// its credential. Diagnostics may carry an ARN; disabledReason does.
 func (e appEntryConfig) LogValue() slog.Value {
 	return slog.GroupValue(
 		slog.String("name", e.Name),
@@ -84,19 +77,17 @@ type resolvedApp struct {
 	client    Client
 	keySource string
 
-	// enabled is false for an app on another account, or one whose installation
-	// could not be queried. Disabled is terminal until restart: re-verification
-	// would make the enabled set depend on when a timer fired.
+	// Disabled is terminal until restart: re-verification would make the enabled
+	// set depend on when a timer fired.
 	enabled bool
 
-	// accountLogin is the verified organization. Empty when verification failed.
+	// Empty when verification failed.
 	accountLogin string
 
-	// disabledReason explains a false enabled, for the startup log only.
+	// Carries upstream error text, so it may name a credential. Startup log only.
 	disabledReason string
 }
 
-// LogValue is the startup record for one registry entry.
 func (a resolvedApp) LogValue() slog.Value {
 	attrs := []slog.Attr{
 		slog.String("name", a.identity.Name),
@@ -112,24 +103,14 @@ func (a resolvedApp) LogValue() slog.Value {
 	return slog.GroupValue(attrs...)
 }
 
-// Registry maps a profile's app name to the installation its tokens are minted
-// through. It is written only by the constructor and never afterwards, so the
-// request path needs no lock. The default app is always present under
-// DefaultAppName.
+// Registry is written only by its constructor, so the request path needs no
+// lock. DefaultAppName is always present.
 type Registry struct {
 	apps map[string]resolvedApp
 }
 
-// NewRegistry builds the app registry from the default app's configuration and
-// the GITHUB_APPS entries alongside it.
-//
-// ctx must be the long-lived server context: it reaches KMS-backed signing key
-// construction, and a key built under a startup-scoped context would boot
-// cleanly and then fail every mint.
-//
-// Errors here are deploy-blocking: ambiguous configuration, or a default app
-// that cannot authenticate as itself. A registry app that cannot be verified is
-// disabled instead, so one unreachable credential does not stop the rest.
+// NewRegistry requires the long-lived server context: ctx reaches KMS signing
+// key construction, and a startup-scoped one boots cleanly then fails every mint.
 func NewRegistry(ctx context.Context, cfg appconfig.GithubConfig, defaultClient Client) (Registry, error) {
 	defaultApp := resolvedApp{
 		identity: AppIdentity{
@@ -147,8 +128,7 @@ func NewRegistry(ctx context.Context, cfg appconfig.GithubConfig, defaultClient 
 		return Registry{}, err
 	}
 
-	// With no registry configured, startup queries no installation at all:
-	// deployments not using the feature pay nothing for it.
+	// Deliberate: deployments not using the feature query no installation at all.
 	if len(entries) == 0 {
 		return Registry{apps: map[string]resolvedApp{DefaultAppName: defaultApp}}, nil
 	}
@@ -185,8 +165,8 @@ func NewRegistry(ctx context.Context, cfg appconfig.GithubConfig, defaultClient 
 	return registry, nil
 }
 
-// Resolve maps an app name to the identity its tokens are minted through. A
-// disabled app resolves to nothing.
+// Resolve yields nothing for a disabled app, so no caller can act on one by
+// neglecting to check a flag.
 func (r Registry) Resolve(name string) (AppIdentity, bool) {
 	app, found := r.apps[name]
 	if !found || !app.enabled {
@@ -195,29 +175,25 @@ func (r Registry) Resolve(name string) (AppIdentity, bool) {
 	return app.identity, true
 }
 
-// IsUsable reports whether a profile may name this app. It is Resolve, so
-// compilation and the request path cannot drift apart.
+// IsUsable is Resolve, so compilation and the request path cannot drift apart.
 func (r Registry) IsUsable(name string) bool {
 	_, usable := r.Resolve(name)
 	return usable
 }
 
-// DefaultIdentity is the identity of the app configured by GITHUB_APP_*.
 func (r Registry) DefaultIdentity() AppIdentity {
 	return r.apps[DefaultAppName].identity
 }
 
-// CreateAccessToken mints an installation token through the named app. The
-// identity is re-resolved rather than trusted: it may have arrived from a cache
-// payload, and the registry is the only authority on which apps are usable.
+// CreateAccessToken re-resolves the identity rather than trusting it: it may
+// have come from a cache payload, and only the registry knows what is usable.
 func (r Registry) CreateAccessToken(ctx context.Context, app AppIdentity, repoNames []string, scopes []string) (string, time.Time, error) {
 	resolved, found := r.apps[app.Name]
 	if !found || !resolved.enabled {
 		return "", time.Time{}, fmt.Errorf("cannot mint through app %q: %w", app.Name, ErrAppUnknown)
 	}
 
-	// A name is a label on an identity, and an operator may repoint it. A
-	// request carrying the old identity must not mint through the new one.
+	// An operator may repoint a name; the old identity must not mint through it.
 	if resolved.identity != app {
 		return "", time.Time{}, fmt.Errorf("app %q no longer refers to application %d installation %d: %w",
 			app.Name, app.ApplicationID, app.InstallationID, ErrAppUnknown)
@@ -226,9 +202,8 @@ func (r Registry) CreateAccessToken(ctx context.Context, app AppIdentity, repoNa
 	return resolved.client.CreateAccessToken(ctx, repoNames, scopes)
 }
 
-// verify establishes that every registry app is installed on the same account
-// as the default app. Queries run concurrently and under no time budget: an
-// expiring budget would be evidence about this service, not about an app.
+// verify runs under no time budget: an expiring budget would be evidence about
+// this service, not about an app.
 func (r Registry) verify(ctx context.Context) error {
 	type result struct {
 		name    string
@@ -254,15 +229,13 @@ func (r Registry) verify(ctx context.Context) error {
 		queried[res.name] = res
 	}
 
-	// The default app is the exception to "disable, don't fail": a service that
-	// cannot authenticate as itself would serve failures while appearing
-	// healthy.
+	// The exception to "disable, don't fail": a service that cannot authenticate
+	// as itself would serve failures while appearing healthy.
 	if err := queried[DefaultAppName].err; err != nil {
 		return fmt.Errorf("default app installation could not be queried: %w", err)
 	}
 
-	// The default app is the reference, so it passes the comparison below
-	// against itself: it needs no case of its own.
+	// The reference compares equal to itself, so the default app needs no case.
 	reference := queried[DefaultAppName].account
 
 	for name, app := range r.apps {
@@ -286,16 +259,16 @@ func (r Registry) verify(ctx context.Context) error {
 	return nil
 }
 
-// logEntries records the whole registry once at startup: the operator's only
-// view of which apps an instance considers usable.
+// logEntries is the operator's only view of which apps an instance considers
+// usable.
 func (r Registry) logEntries() {
 	for _, app := range r.apps {
 		slog.Info("github app registry entry", "app", app)
 	}
 }
 
-// newRegistryClient builds the minting client for one registry entry. Entries
-// inherit the default app's API URL: one GitHub deployment, many credentials.
+// newRegistryClient gives every entry the default app's API URL: one GitHub
+// deployment, many credentials.
 func newRegistryClient(ctx context.Context, cfg appconfig.GithubConfig, entry appEntryConfig, loadAWS AWSConfigLoader) (Client, error) {
 	entryCfg := appconfig.GithubConfig{
 		APIURL:         cfg.APIURL,
@@ -305,8 +278,8 @@ func newRegistryClient(ctx context.Context, cfg appconfig.GithubConfig, entry ap
 		InstallationID: entry.InstallationID,
 	}
 
-	// Validate the key before building the client so an unparseable key is
-	// reported as such, not as a transport construction failure.
+	// Parse first, so an unparseable key is reported as such rather than as a
+	// transport construction failure.
 	if entry.PrivateKey != "" {
 		if _, err := parsePrivateKeyPEM(entry.PrivateKey); err != nil {
 			return Client{}, fmt.Errorf("app %q: %w", entry.Name, ErrPrivateKeyInvalid)
@@ -322,28 +295,22 @@ func newRegistryClient(ctx context.Context, cfg appconfig.GithubConfig, entry ap
 	return client, nil
 }
 
-// parseAppEntries decodes and validates GITHUB_APPS. Failures are
-// deploy-blocking: ambiguous configuration must fail identically everywhere.
+// parseAppEntries treats every failure as deploy-blocking: ambiguous
+// configuration must fail identically on every instance.
 func parseAppEntries(raw string) ([]appEntryConfig, error) {
 	if strings.TrimSpace(raw) == "" {
 		return nil, nil
 	}
 
-	// json/v2's Unmarshal requires the input to be exactly one JSON value: a
-	// streaming decoder stops at the end of the first value, so a truncated or
-	// concatenated variable would be silently accepted with the remainder
-	// discarded.
-	//
-	// RejectUnknownMembers: a silently ignored typo is a credential configured
-	// differently from how it reads.
+	// Unmarshal rather than a streaming decoder: json/v2 requires exactly one JSON
+	// value, so a concatenated variable cannot pass with the remainder discarded.
 	var entries []appEntryConfig
 	if err := json.Unmarshal([]byte(raw), &entries, json.RejectUnknownMembers(true)); err != nil {
 		return nil, fmt.Errorf("GITHUB_APPS is not valid: %w", err)
 	}
 
-	// JSON null unmarshals to a nil slice without error, and an empty registry
-	// skips installation verification entirely. A deployment that believes it
-	// configured apps must not start with only the default app.
+	// null unmarshals to a nil slice without error, and an empty registry skips
+	// verification: a deployment that configured apps must not start without them.
 	if entries == nil {
 		return nil, errors.New("GITHUB_APPS is not valid: expected a JSON array, found null")
 	}

--- a/internal/github/registry.go
+++ b/internal/github/registry.go
@@ -44,12 +44,20 @@ func (i AppIdentity) IsZero() bool {
 	return i == AppIdentity{}
 }
 
+// privateKeyPEM redacts under every fmt verb, so no format string can print a
+// key: LogValue guards slog, this guards fmt.
+type privateKeyPEM string
+
+func (privateKeyPEM) String() string { return "[redacted]" }
+
+func (privateKeyPEM) GoString() string { return `"[redacted]"` }
+
 type appEntryConfig struct {
-	Name           string `json:"name"`
-	ApplicationID  int64  `json:"appId"`
-	InstallationID int64  `json:"installationId"`
-	PrivateKey     string `json:"privateKey"`
-	PrivateKeyARN  string `json:"privateKeyArn"`
+	Name           string        `json:"name"`
+	ApplicationID  int64         `json:"appId"`
+	InstallationID int64         `json:"installationId"`
+	PrivateKey     privateKeyPEM `json:"privateKey"`
+	PrivateKeyARN  string        `json:"privateKeyArn"`
 }
 
 // keySource names where a key comes from without disclosing it.
@@ -272,7 +280,7 @@ func (r Registry) logEntries() {
 func newRegistryClient(ctx context.Context, cfg appconfig.GithubConfig, entry appEntryConfig, loadAWS AWSConfigLoader) (Client, error) {
 	entryCfg := appconfig.GithubConfig{
 		APIURL:         cfg.APIURL,
-		PrivateKey:     entry.PrivateKey,
+		PrivateKey:     string(entry.PrivateKey),
 		PrivateKeyARN:  entry.PrivateKeyARN,
 		ApplicationID:  entry.ApplicationID,
 		InstallationID: entry.InstallationID,
@@ -281,7 +289,7 @@ func newRegistryClient(ctx context.Context, cfg appconfig.GithubConfig, entry ap
 	// Parse first, so an unparseable key is reported as such rather than as a
 	// transport construction failure.
 	if entry.PrivateKey != "" {
-		if _, err := parsePrivateKeyPEM(entry.PrivateKey); err != nil {
+		if _, err := parsePrivateKeyPEM(string(entry.PrivateKey)); err != nil {
 			return Client{}, fmt.Errorf("app %q: %w", entry.Name, ErrPrivateKeyInvalid)
 		}
 	}

--- a/internal/github/registry.go
+++ b/internal/github/registry.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json/v2"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"regexp"
 	"strings"
@@ -51,6 +52,10 @@ type privateKeyPEM string
 func (privateKeyPEM) String() string { return "[redacted]" }
 
 func (privateKeyPEM) GoString() string { return `"[redacted]"` }
+
+func (privateKeyPEM) Format(state fmt.State, _ rune) {
+	_, _ = io.WriteString(state, "[redacted]")
+}
 
 type appEntryConfig struct {
 	Name           string        `json:"name"`

--- a/internal/github/registry.go
+++ b/internal/github/registry.go
@@ -48,15 +48,6 @@ func (i AppIdentity) IsZero() bool {
 	return i == AppIdentity{}
 }
 
-// LogValue implements slog.LogValuer.
-func (i AppIdentity) LogValue() slog.Value {
-	return slog.GroupValue(
-		slog.String("name", i.Name),
-		slog.Int64("applicationID", i.ApplicationID),
-		slog.Int64("installationID", i.InstallationID),
-	)
-}
-
 // appEntryConfig is one GITHUB_APPS entry as configured.
 type appEntryConfig struct {
 	Name           string `json:"name"`
@@ -75,7 +66,9 @@ func keySource(privateKeyARN string) string {
 }
 
 // LogValue omits both the private key and its ARN: the ARN names the
-// credential and its account, and neither belongs in a log.
+// credential and its account, and neither belongs in a log. Nothing logs an
+// entry today; this exists so that the first thing to do so cannot print a
+// private key by default.
 func (e appEntryConfig) LogValue() slog.Value {
 	return slog.GroupValue(
 		slog.String("name", e.Name),

--- a/internal/github/registry_test.go
+++ b/internal/github/registry_test.go
@@ -234,6 +234,32 @@ func TestRegistry_ConfigurationErrorsOmitKeyMaterial(t *testing.T) {
 	}
 }
 
+// An entry whose signing key cannot be built blocks startup rather than being
+// disabled. Unlike an installation that cannot be queried, nothing about this
+// can recover without a configuration change, and a disabled app would hide it
+// behind per-profile failures instead of a failed deploy.
+func TestRegistry_FailsWhenAnEntrysSigningKeyCannotBeBuilt(t *testing.T) {
+	const arn = "arn:aws:kms:ap-southeast-2:123456789012:key/super-secret-key-id"
+
+	// A malformed AWS_MAX_ATTEMPTS fails the load in the SDK's environment
+	// parsing, with no credentials, network or region lookup involved.
+	t.Setenv("AWS_REGION", "ap-southeast-2")
+	t.Setenv("AWS_MAX_ATTEMPTS", "not-a-number")
+
+	fixture := newRegistryFixture(t, appsJSON(t, map[string]any{
+		"name":           "packages",
+		"appId":          333,
+		"installationId": 444,
+		"privateKeyArn":  arn,
+	}))
+
+	_, err := fixture.build(t)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, `app "packages": could not construct GitHub client`)
+	assert.NotContains(t, err.Error(), arn)
+}
+
 func TestRegistry_EnablesAppsOnTheDefaultAppsAccount(t *testing.T) {
 	fixture := newRegistryFixture(t, appsJSON(t,
 		validEntry(t, "packages", 333, 444),

--- a/internal/github/registry_test.go
+++ b/internal/github/registry_test.go
@@ -120,6 +120,31 @@ func TestRegistry_MalformedConfigurationPreventsStartup(t *testing.T) {
 			errContains: "GITHUB_APPS is not valid",
 		},
 		{
+			name:        "JSON null",
+			apps:        `null`,
+			errContains: "expected a JSON array, found null",
+		},
+		{
+			name:        "trailing JSON value",
+			apps:        `[] {"ignored":true}`,
+			errContains: "GITHUB_APPS is not valid",
+		},
+		{
+			name:        "trailing garbage",
+			apps:        fmt.Sprintf(`[{"name":"packages","appId":1,"installationId":2,"privateKey":%q}] trailing`, validKey),
+			errContains: "GITHUB_APPS is not valid",
+		},
+		{
+			name:        "duplicate object member",
+			apps:        `[{"name":"packages","name":"other","appId":1,"installationId":2,"privateKeyArn":"arn:aws:kms:x"}]`,
+			errContains: "GITHUB_APPS is not valid",
+		},
+		{
+			name:        "field name differs in case",
+			apps:        `[{"Name":"packages","appId":1,"installationId":2,"privateKeyArn":"arn:aws:kms:x"}]`,
+			errContains: "GITHUB_APPS is not valid",
+		},
+		{
 			name:        "unrecognised field",
 			apps:        `[{"name":"packages","appId":1,"installationId":2,"privateKeyArn":"arn:aws:kms:x","organization":"acme"}]`,
 			errContains: "GITHUB_APPS is not valid",

--- a/internal/github/registry_test.go
+++ b/internal/github/registry_test.go
@@ -16,25 +16,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// The registry's contract is: which names are usable, which installation each
-// mints through, and what reaches the log. Enabled state is deliberately not
-// readable except through a name failing to resolve, so these tests assert
-// resolution rather than internal flags.
+// Enabled state is deliberately not readable except through a name failing to
+// resolve, so these tests assert resolution rather than internal flags.
 
 const (
 	defaultAppID          = int64(111)
 	defaultInstallationID = int64(222)
 
-	// accountSameOrg is the default app's installation account. Apps are
-	// compared on account ID, never login, so tests distinguish organizations
-	// by ID alone.
+	// Apps are compared on account ID, never login.
 	accountSameOrg  = int64(9001)
 	accountOtherOrg = int64(9002)
 )
 
-// registryFixture is one GitHub mock plus the default app configuration
-// pointed at it. Registry entries inherit the API URL, so everything a test
-// configures resolves against the same mock.
+// registryFixture is a GitHub mock plus the default app configuration pointed
+// at it. Registry entries inherit the API URL, so everything resolves against
+// the same mock.
 type registryFixture struct {
 	mock *testhelpers.MockGitHubServer
 	cfg  config.GithubConfig
@@ -81,9 +77,8 @@ func (f registryFixture) buildWithContext(t *testing.T, ctx context.Context) (gi
 	return github.NewRegistry(ctx, f.cfg, defaultClient)
 }
 
-// appsJSON renders a GITHUB_APPS array from entries expressed as maps, so a
-// test can express a malformed entry (unknown field, missing key, wrong type)
-// as directly as a well-formed one.
+// appsJSON renders a GITHUB_APPS array from maps, so a test can express a
+// malformed entry as directly as a well-formed one.
 func appsJSON(t *testing.T, entries ...map[string]any) string {
 	t.Helper()
 
@@ -104,11 +99,8 @@ func validEntry(t *testing.T, name string, appID, installationID int64) map[stri
 	}
 }
 
-// --- Configuration validation (R5–R11, R15) ---
-
-// Every case here is deploy-blocking: configuration with no single
-// unambiguous meaning must fail identically on every instance rather than
-// being partially interpreted.
+// Configuration with no single unambiguous meaning must fail identically on
+// every instance rather than being partially interpreted.
 func TestRegistry_MalformedConfigurationPreventsStartup(t *testing.T) {
 	validKey := generateKey(t)
 
@@ -206,8 +198,7 @@ func TestRegistry_MalformedConfigurationPreventsStartup(t *testing.T) {
 	}
 }
 
-// A configuration error must never reproduce the credential it failed on: the
-// operator already has the key, and a log aggregator should not.
+// A configuration error must never reproduce the credential it failed on.
 func TestRegistry_ConfigurationErrorsOmitKeyMaterial(t *testing.T) {
 	const arn = "arn:aws:kms:ap-southeast-2:123456789012:key/super-secret-key-id"
 	badKey := "-----BEGIN RSA PRIVATE KEY-----\nQUJDREVGRw==\n-----END RSA PRIVATE KEY-----"
@@ -237,14 +228,11 @@ func TestRegistry_ConfigurationErrorsOmitKeyMaterial(t *testing.T) {
 
 			require.Error(t, err)
 			assert.NotContains(t, err.Error(), tt.secret)
-			// The entry is still identifiable: an error naming nothing is not
-			// actionable.
+			// An error naming nothing is not actionable.
 			assert.Contains(t, err.Error(), "packages")
 		})
 	}
 }
-
-// --- Verification outcomes (R12–R19) ---
 
 func TestRegistry_EnablesAppsOnTheDefaultAppsAccount(t *testing.T) {
 	fixture := newRegistryFixture(t, appsJSON(t,
@@ -267,10 +255,8 @@ func TestRegistry_EnablesAppsOnTheDefaultAppsAccount(t *testing.T) {
 		registry.DefaultIdentity())
 }
 
-// A registry app on another account is disabled rather than fatal: one
-// misconfigured credential must not take down vending for every other profile.
-// Disabled is indistinguishable from absent, so no caller can act on it by
-// forgetting to check a flag.
+// One misconfigured credential must not take down vending for every other
+// profile, so a mismatched app is disabled rather than fatal.
 func TestRegistry_DisablesAppOnADifferentAccount(t *testing.T) {
 	fixture := newRegistryFixture(t, appsJSON(t,
 		validEntry(t, "packages", 333, 444),
@@ -303,10 +289,9 @@ func TestRegistry_DisablesAppWhoseInstallationCannotBeQueried(t *testing.T) {
 	assert.True(t, registry.IsUsable("deploy"))
 }
 
-// The default app is the exception. If the service cannot query its own
-// installation it cannot authenticate as itself, so minting is broken
-// regardless and a process that continued would serve failures while
-// appearing healthy.
+// The default app is the exception: unable to query its own installation, the
+// service cannot authenticate as itself, and continuing would serve failures
+// while appearing healthy.
 func TestRegistry_FailsWhenTheDefaultAppsInstallationCannotBeQueried(t *testing.T) {
 	fixture := newRegistryFixture(t, appsJSON(t, validEntry(t, "packages", 333, 444)))
 	fixture.mock.SetInstallation(defaultInstallationID, testhelpers.MockInstallation{StatusCode: 401})
@@ -316,7 +301,7 @@ func TestRegistry_FailsWhenTheDefaultAppsInstallationCannotBeQueried(t *testing.
 	assert.ErrorContains(t, err, "default app installation could not be queried")
 }
 
-// R19: a deployment not using the feature pays nothing for its existence.
+// A deployment not using the feature pays nothing for its existence.
 func TestRegistry_QueriesNoInstallationWithoutAConfiguredRegistry(t *testing.T) {
 	fixture := newRegistryFixture(t, "")
 
@@ -327,8 +312,6 @@ func TestRegistry_QueriesNoInstallationWithoutAConfiguredRegistry(t *testing.T) 
 	assert.True(t, registry.IsUsable("default"))
 	assert.False(t, registry.IsUsable("packages"))
 }
-
-// --- Minting (R2, R33) ---
 
 func TestRegistry_MintsThroughTheResolvedAppsInstallation(t *testing.T) {
 	fixture := newRegistryFixture(t, appsJSON(t, validEntry(t, "packages", 333, 444)))
@@ -352,8 +335,7 @@ func TestRegistry_MintsThroughTheResolvedAppsInstallation(t *testing.T) {
 }
 
 // An identity may arrive from a long-lived request value, so the registry
-// re-resolves rather than trusting it. An unknown or repointed name must not
-// mint.
+// re-resolves rather than trusting it.
 func TestRegistry_RefusesToMintThroughAnUnresolvableIdentity(t *testing.T) {
 	fixture := newRegistryFixture(t, appsJSON(t, validEntry(t, "packages", 333, 444)))
 	fixture.mock.SetInstallation(444, testhelpers.MockInstallation{StatusCode: 500})
@@ -388,14 +370,11 @@ func TestRegistry_RefusesToMintThroughAnUnresolvableIdentity(t *testing.T) {
 	}
 }
 
-// --- Startup logging (R48, R49) ---
-
 func TestRegistry_LogsEveryEntryWithoutKeyMaterial(t *testing.T) {
 	const arn = "arn:aws:kms:ap-southeast-2:123456789012:key/super-secret-key-id"
 	privateKey := generateKey(t)
 
-	// A purposely unbound endpoint: KMS key construction contacts nothing, so
-	// this must not be reached during startup.
+	// Purposely unbound: KMS key construction must contact nothing at startup.
 	t.Setenv("AWS_ENDPOINT_URL", "http://localhost:20987/not-bound")
 
 	fixture := newRegistryFixture(t, appsJSON(t,
@@ -416,8 +395,6 @@ func TestRegistry_LogsEveryEntryWithoutKeyMaterial(t *testing.T) {
 
 	output := logged.String()
 
-	// R48: every configured app is identifiable, with its verified
-	// organization and enabled state.
 	for _, expected := range []string{
 		"name=packages", "applicationID=333", "installationID=444",
 		"name=deploy", "applicationID=555", "installationID=666",
@@ -426,8 +403,8 @@ func TestRegistry_LogsEveryEntryWithoutKeyMaterial(t *testing.T) {
 		assert.Contains(t, output, expected)
 	}
 
-	// R49: nothing else. The ARN is withheld along with the key — it names the
-	// credential and its account, which a log has no use for.
+	// The ARN is withheld along with the key: it names the credential and its
+	// account.
 	assert.NotContains(t, output, arn)
 	assert.NotContains(t, output, "super-secret-key-id")
 	assert.NotContains(t, output, privateKey)
@@ -454,7 +431,7 @@ func TestRegistry_LogsWhyAnAppIsDisabled(t *testing.T) {
 }
 
 // captureLog redirects the default logger into a buffer for the duration of
-// the test, so assertions can be made about what an operator would see.
+// the test.
 func captureLog(t *testing.T) *bytes.Buffer {
 	t.Helper()
 

--- a/internal/github/registry_test.go
+++ b/internal/github/registry_test.go
@@ -1,0 +1,468 @@
+package github_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/chinmina/chinmina-bridge/internal/config"
+	"github.com/chinmina/chinmina-bridge/internal/github"
+	"github.com/chinmina/chinmina-bridge/internal/testhelpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The registry's contract is: which names are usable, which installation each
+// mints through, and what reaches the log. Enabled state is deliberately not
+// readable except through a name failing to resolve, so these tests assert
+// resolution rather than internal flags.
+
+const (
+	defaultAppID          = int64(111)
+	defaultInstallationID = int64(222)
+
+	// accountSameOrg is the default app's installation account. Apps are
+	// compared on account ID, never login, so tests distinguish organizations
+	// by ID alone.
+	accountSameOrg  = int64(9001)
+	accountOtherOrg = int64(9002)
+)
+
+// registryFixture is one GitHub mock plus the default app configuration
+// pointed at it. Registry entries inherit the API URL, so everything a test
+// configures resolves against the same mock.
+type registryFixture struct {
+	mock *testhelpers.MockGitHubServer
+	cfg  config.GithubConfig
+}
+
+func newRegistryFixture(t *testing.T, appsJSON string) registryFixture {
+	t.Helper()
+	testhelpers.SetupLogger(t)
+
+	mock := testhelpers.SetupMockGitHubServer(t)
+	t.Cleanup(mock.Close)
+
+	mock.DefaultInstallation = testhelpers.MockInstallation{
+		AccountID:    accountSameOrg,
+		AccountLogin: "acme",
+	}
+
+	return registryFixture{
+		mock: mock,
+		cfg: config.GithubConfig{
+			APIURL:         mock.Server.URL,
+			PrivateKey:     generateKey(t),
+			ApplicationID:  defaultAppID,
+			InstallationID: defaultInstallationID,
+			Apps:           appsJSON,
+		},
+	}
+}
+
+// build constructs the registry the way production does: a default client
+// first, then the registry reusing it.
+func (f registryFixture) build(t *testing.T) (github.Registry, error) {
+	t.Helper()
+
+	return f.buildWithContext(t, t.Context())
+}
+
+func (f registryFixture) buildWithContext(t *testing.T, ctx context.Context) (github.Registry, error) {
+	t.Helper()
+
+	defaultClient, err := github.New(ctx, f.cfg)
+	require.NoError(t, err)
+
+	return github.NewRegistry(ctx, f.cfg, defaultClient)
+}
+
+// appsJSON renders a GITHUB_APPS array from entries expressed as maps, so a
+// test can express a malformed entry (unknown field, missing key, wrong type)
+// as directly as a well-formed one.
+func appsJSON(t *testing.T, entries ...map[string]any) string {
+	t.Helper()
+
+	encoded, err := json.Marshal(entries)
+	require.NoError(t, err)
+
+	return string(encoded)
+}
+
+func validEntry(t *testing.T, name string, appID, installationID int64) map[string]any {
+	t.Helper()
+
+	return map[string]any{
+		"name":           name,
+		"appId":          appID,
+		"installationId": installationID,
+		"privateKey":     generateKey(t),
+	}
+}
+
+// --- Configuration validation (R5–R11, R15) ---
+
+// Every case here is deploy-blocking: configuration with no single
+// unambiguous meaning must fail identically on every instance rather than
+// being partially interpreted.
+func TestRegistry_MalformedConfigurationPreventsStartup(t *testing.T) {
+	validKey := generateKey(t)
+
+	tests := []struct {
+		name        string
+		apps        string
+		errContains string
+	}{
+		{
+			name:        "not JSON",
+			apps:        `{not json`,
+			errContains: "GITHUB_APPS is not valid",
+		},
+		{
+			name:        "not a JSON array",
+			apps:        `{"name":"packages"}`,
+			errContains: "GITHUB_APPS is not valid",
+		},
+		{
+			name:        "unrecognised field",
+			apps:        `[{"name":"packages","appId":1,"installationId":2,"privateKeyArn":"arn:aws:kms:x","organization":"acme"}]`,
+			errContains: "GITHUB_APPS is not valid",
+		},
+		{
+			name:        "duplicate name",
+			apps:        fmt.Sprintf(`[{"name":"packages","appId":1,"installationId":2,"privateKey":%q},{"name":"packages","appId":3,"installationId":4,"privateKey":%q}]`, validKey, validKey),
+			errContains: `duplicate app name "packages"`,
+		},
+		{
+			name:        "name is default",
+			apps:        `[{"name":"default","appId":1,"installationId":2,"privateKeyArn":"arn:aws:kms:x"}]`,
+			errContains: "is reserved",
+		},
+		{
+			name:        "name has uppercase",
+			apps:        `[{"name":"Packages","appId":1,"installationId":2,"privateKeyArn":"arn:aws:kms:x"}]`,
+			errContains: "must match",
+		},
+		{
+			name:        "name has a leading separator",
+			apps:        `[{"name":"-packages","appId":1,"installationId":2,"privateKeyArn":"arn:aws:kms:x"}]`,
+			errContains: "must match",
+		},
+		{
+			name:        "name is empty",
+			apps:        `[{"name":"","appId":1,"installationId":2,"privateKeyArn":"arn:aws:kms:x"}]`,
+			errContains: "must match",
+		},
+		{
+			name:        "name exceeds 64 characters",
+			apps:        fmt.Sprintf(`[{"name":%q,"appId":1,"installationId":2,"privateKeyArn":"arn:aws:kms:x"}]`, strings.Repeat("a", 65)),
+			errContains: "exceeds 64 characters",
+		},
+		{
+			name:        "application ID is zero",
+			apps:        `[{"name":"packages","appId":0,"installationId":2,"privateKeyArn":"arn:aws:kms:x"}]`,
+			errContains: "appId must be a positive integer",
+		},
+		{
+			name:        "application ID is negative",
+			apps:        `[{"name":"packages","appId":-1,"installationId":2,"privateKeyArn":"arn:aws:kms:x"}]`,
+			errContains: "appId must be a positive integer",
+		},
+		{
+			name:        "installation ID is zero",
+			apps:        `[{"name":"packages","appId":1,"installationId":0,"privateKeyArn":"arn:aws:kms:x"}]`,
+			errContains: "installationId must be a positive integer",
+		},
+		{
+			name:        "both key sources",
+			apps:        fmt.Sprintf(`[{"name":"packages","appId":1,"installationId":2,"privateKey":%q,"privateKeyArn":"arn:aws:kms:x"}]`, validKey),
+			errContains: "declares both privateKey and privateKeyArn",
+		},
+		{
+			name:        "neither key source",
+			apps:        `[{"name":"packages","appId":1,"installationId":2}]`,
+			errContains: "declares neither privateKey nor privateKeyArn",
+		},
+		{
+			name:        "unparseable private key",
+			apps:        `[{"name":"packages","appId":1,"installationId":2,"privateKey":"-----BEGIN RSA PRIVATE KEY-----\nnope\n-----END RSA PRIVATE KEY-----"}]`,
+			errContains: "private key could not be parsed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fixture := newRegistryFixture(t, tt.apps)
+
+			_, err := fixture.build(t)
+
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tt.errContains)
+		})
+	}
+}
+
+// A configuration error must never reproduce the credential it failed on: the
+// operator already has the key, and a log aggregator should not.
+func TestRegistry_ConfigurationErrorsOmitKeyMaterial(t *testing.T) {
+	const arn = "arn:aws:kms:ap-southeast-2:123456789012:key/super-secret-key-id"
+	badKey := "-----BEGIN RSA PRIVATE KEY-----\nQUJDREVGRw==\n-----END RSA PRIVATE KEY-----"
+
+	tests := []struct {
+		name   string
+		apps   string
+		secret string
+	}{
+		{
+			name:   "unparseable key is not echoed",
+			apps:   fmt.Sprintf(`[{"name":"packages","appId":1,"installationId":2,"privateKey":%q}]`, badKey),
+			secret: "QUJDREVGRw==",
+		},
+		{
+			name:   "ARN is not echoed",
+			apps:   fmt.Sprintf(`[{"name":"packages","appId":0,"installationId":2,"privateKeyArn":%q}]`, arn),
+			secret: arn,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fixture := newRegistryFixture(t, tt.apps)
+
+			_, err := fixture.build(t)
+
+			require.Error(t, err)
+			assert.NotContains(t, err.Error(), tt.secret)
+			// The entry is still identifiable: an error naming nothing is not
+			// actionable.
+			assert.Contains(t, err.Error(), "packages")
+		})
+	}
+}
+
+// --- Verification outcomes (R12–R19) ---
+
+func TestRegistry_EnablesAppsOnTheDefaultAppsAccount(t *testing.T) {
+	fixture := newRegistryFixture(t, appsJSON(t,
+		validEntry(t, "packages", 333, 444),
+		validEntry(t, "deploy", 555, 666),
+	))
+
+	registry, err := fixture.build(t)
+	require.NoError(t, err)
+
+	packages, usable := registry.Resolve("packages")
+	assert.True(t, usable)
+	assert.Equal(t, github.AppIdentity{Name: "packages", ApplicationID: 333, InstallationID: 444}, packages)
+
+	deploy, usable := registry.Resolve("deploy")
+	assert.True(t, usable)
+	assert.Equal(t, github.AppIdentity{Name: "deploy", ApplicationID: 555, InstallationID: 666}, deploy)
+
+	assert.Equal(t, github.AppIdentity{Name: "default", ApplicationID: defaultAppID, InstallationID: defaultInstallationID},
+		registry.DefaultIdentity())
+}
+
+// A registry app on another account is disabled rather than fatal: one
+// misconfigured credential must not take down vending for every other profile.
+// Disabled is indistinguishable from absent, so no caller can act on it by
+// forgetting to check a flag.
+func TestRegistry_DisablesAppOnADifferentAccount(t *testing.T) {
+	fixture := newRegistryFixture(t, appsJSON(t,
+		validEntry(t, "packages", 333, 444),
+		validEntry(t, "deploy", 555, 666),
+	))
+	fixture.mock.SetInstallation(444, testhelpers.MockInstallation{
+		AccountID:    accountOtherOrg,
+		AccountLogin: "someone-else",
+	})
+
+	registry, err := fixture.build(t)
+	require.NoError(t, err)
+
+	assert.False(t, registry.IsUsable("packages"))
+	assert.True(t, registry.IsUsable("deploy"), "an unrelated app must be unaffected")
+	assert.True(t, registry.IsUsable("default"))
+}
+
+func TestRegistry_DisablesAppWhoseInstallationCannotBeQueried(t *testing.T) {
+	fixture := newRegistryFixture(t, appsJSON(t,
+		validEntry(t, "packages", 333, 444),
+		validEntry(t, "deploy", 555, 666),
+	))
+	fixture.mock.SetInstallation(444, testhelpers.MockInstallation{StatusCode: 500})
+
+	registry, err := fixture.build(t)
+	require.NoError(t, err, "one unreachable app must not prevent startup")
+
+	assert.False(t, registry.IsUsable("packages"))
+	assert.True(t, registry.IsUsable("deploy"))
+}
+
+// The default app is the exception. If the service cannot query its own
+// installation it cannot authenticate as itself, so minting is broken
+// regardless and a process that continued would serve failures while
+// appearing healthy.
+func TestRegistry_FailsWhenTheDefaultAppsInstallationCannotBeQueried(t *testing.T) {
+	fixture := newRegistryFixture(t, appsJSON(t, validEntry(t, "packages", 333, 444)))
+	fixture.mock.SetInstallation(defaultInstallationID, testhelpers.MockInstallation{StatusCode: 401})
+
+	_, err := fixture.build(t)
+
+	assert.ErrorContains(t, err, "default app installation could not be queried")
+}
+
+// R19: a deployment not using the feature pays nothing for its existence.
+func TestRegistry_QueriesNoInstallationWithoutAConfiguredRegistry(t *testing.T) {
+	fixture := newRegistryFixture(t, "")
+
+	registry, err := fixture.build(t)
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, fixture.mock.InstallationQueryCount())
+	assert.True(t, registry.IsUsable("default"))
+	assert.False(t, registry.IsUsable("packages"))
+}
+
+// --- Minting (R2, R33) ---
+
+func TestRegistry_MintsThroughTheResolvedAppsInstallation(t *testing.T) {
+	fixture := newRegistryFixture(t, appsJSON(t, validEntry(t, "packages", 333, 444)))
+	fixture.mock.SetInstallation(444, testhelpers.MockInstallation{
+		AccountID:    accountSameOrg,
+		AccountLogin: "acme",
+		Token:        "packages-token",
+	})
+
+	registry, err := fixture.build(t)
+	require.NoError(t, err)
+
+	packages, usable := registry.Resolve("packages")
+	require.True(t, usable)
+
+	token, _, err := registry.CreateAccessToken(t.Context(), packages, []string{"widget"}, []string{"contents:read"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "packages-token", token)
+	assert.Equal(t, 1, fixture.mock.TokenRequestCount())
+}
+
+// An identity may arrive from a long-lived request value, so the registry
+// re-resolves rather than trusting it. An unknown or repointed name must not
+// mint.
+func TestRegistry_RefusesToMintThroughAnUnresolvableIdentity(t *testing.T) {
+	fixture := newRegistryFixture(t, appsJSON(t, validEntry(t, "packages", 333, 444)))
+	fixture.mock.SetInstallation(444, testhelpers.MockInstallation{StatusCode: 500})
+
+	registry, err := fixture.build(t)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		identity github.AppIdentity
+	}{
+		{
+			name:     "disabled app",
+			identity: github.AppIdentity{Name: "packages", ApplicationID: 333, InstallationID: 444},
+		},
+		{
+			name:     "unknown app",
+			identity: github.AppIdentity{Name: "nonexistent", ApplicationID: 1, InstallationID: 2},
+		},
+		{
+			name:     "name repointed to another installation",
+			identity: github.AppIdentity{Name: "default", ApplicationID: defaultAppID, InstallationID: 999},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := registry.CreateAccessToken(t.Context(), tt.identity, nil, []string{"contents:read"})
+
+			assert.ErrorIs(t, err, github.ErrAppUnknown)
+		})
+	}
+}
+
+// --- Startup logging (R48, R49) ---
+
+func TestRegistry_LogsEveryEntryWithoutKeyMaterial(t *testing.T) {
+	const arn = "arn:aws:kms:ap-southeast-2:123456789012:key/super-secret-key-id"
+	privateKey := generateKey(t)
+
+	// A purposely unbound endpoint: KMS key construction contacts nothing, so
+	// this must not be reached during startup.
+	t.Setenv("AWS_ENDPOINT_URL", "http://localhost:20987/not-bound")
+
+	fixture := newRegistryFixture(t, appsJSON(t,
+		validEntry(t, "packages", 333, 444),
+		map[string]any{
+			"name":           "deploy",
+			"appId":          555,
+			"installationId": 666,
+			"privateKeyArn":  arn,
+		},
+	))
+	fixture.cfg.PrivateKey = privateKey
+
+	logged := captureLog(t)
+
+	_, err := fixture.build(t)
+	require.NoError(t, err)
+
+	output := logged.String()
+
+	// R48: every configured app is identifiable, with its verified
+	// organization and enabled state.
+	for _, expected := range []string{
+		"name=packages", "applicationID=333", "installationID=444",
+		"name=deploy", "applicationID=555", "installationID=666",
+		"name=default", "organization=acme", "enabled=true",
+	} {
+		assert.Contains(t, output, expected)
+	}
+
+	// R49: nothing else. The ARN is withheld along with the key — it names the
+	// credential and its account, which a log has no use for.
+	assert.NotContains(t, output, arn)
+	assert.NotContains(t, output, "super-secret-key-id")
+	assert.NotContains(t, output, privateKey)
+	assert.NotContains(t, output, "PRIVATE KEY")
+	assert.Contains(t, output, "keySource=privateKeyArn")
+	assert.Contains(t, output, "keySource=privateKey")
+}
+
+func TestRegistry_LogsWhyAnAppIsDisabled(t *testing.T) {
+	fixture := newRegistryFixture(t, appsJSON(t, validEntry(t, "packages", 333, 444)))
+	fixture.mock.SetInstallation(444, testhelpers.MockInstallation{
+		AccountID:    accountOtherOrg,
+		AccountLogin: "someone-else",
+	})
+
+	logged := captureLog(t)
+
+	_, err := fixture.build(t)
+	require.NoError(t, err)
+
+	output := logged.String()
+	assert.Contains(t, output, "enabled=false")
+	assert.Contains(t, output, "someone-else")
+}
+
+// captureLog redirects the default logger into a buffer for the duration of
+// the test, so assertions can be made about what an operator would see.
+func captureLog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+
+	buffer := &bytes.Buffer{}
+	original := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(original) })
+
+	slog.SetDefault(slog.New(slog.NewTextHandler(buffer, &slog.HandlerOptions{Level: slog.LevelDebug})))
+
+	return buffer
+}

--- a/internal/github/registry_test.go
+++ b/internal/github/registry_test.go
@@ -275,6 +275,45 @@ func TestRegistry_DisablesAppOnADifferentAccount(t *testing.T) {
 	assert.True(t, registry.IsUsable("default"))
 }
 
+// User and organization accounts share one numeric ID space by GitHub's own
+// documentation; enterprise accounts are a different object with no such
+// guarantee, so an enterprise-owned installation must never be trusted to
+// compare safely against another app's account ID.
+func TestRegistry_DisablesAppInstalledOnAnEnterprise(t *testing.T) {
+	fixture := newRegistryFixture(t, appsJSON(t,
+		validEntry(t, "packages", 333, 444),
+		validEntry(t, "deploy", 555, 666),
+	))
+	fixture.mock.SetInstallation(444, testhelpers.MockInstallation{
+		AccountID:    accountSameOrg,
+		AccountLogin: "acme",
+		AccountType:  "Enterprise",
+	})
+
+	registry, err := fixture.build(t)
+	require.NoError(t, err, "one misconfigured app must not prevent startup")
+
+	assert.False(t, registry.IsUsable("packages"))
+	assert.True(t, registry.IsUsable("deploy"), "an unrelated app must be unaffected")
+	assert.True(t, registry.IsUsable("default"))
+}
+
+// The default app is held to the same rule as any other: if its own
+// installation turns out to be enterprise-owned, the numeric ID comparison
+// every other app relies on is meaningless, so the service must not start.
+func TestRegistry_FailsWhenTheDefaultAppIsInstalledOnAnEnterprise(t *testing.T) {
+	fixture := newRegistryFixture(t, appsJSON(t, validEntry(t, "packages", 333, 444)))
+	fixture.mock.SetInstallation(defaultInstallationID, testhelpers.MockInstallation{
+		AccountID:    accountSameOrg,
+		AccountLogin: "acme",
+		AccountType:  "Enterprise",
+	})
+
+	_, err := fixture.build(t)
+
+	assert.ErrorContains(t, err, "default app installation could not be queried")
+}
+
 func TestRegistry_DisablesAppWhoseInstallationCannotBeQueried(t *testing.T) {
 	fixture := newRegistryFixture(t, appsJSON(t,
 		validEntry(t, "packages", 333, 444),

--- a/internal/github/registryinternal_test.go
+++ b/internal/github/registryinternal_test.go
@@ -1,0 +1,71 @@
+package github
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A configured entry carries a private key and the ARN naming one. Nothing logs
+// an entry today, so this asserts the guard itself: whatever first logs one must
+// not be able to disclose either credential by accident.
+func TestAppEntryConfig_LogValueOmitsKeyMaterial(t *testing.T) {
+	const (
+		privateKey = "-----BEGIN RSA PRIVATE KEY-----\nc3VwZXItc2VjcmV0\n-----END RSA PRIVATE KEY-----"
+		arn        = "arn:aws:kms:ap-southeast-2:123456789012:key/super-secret-key-id"
+	)
+
+	tests := []struct {
+		name              string
+		entry             appEntryConfig
+		expectedKeySource string
+		secrets           []string
+	}{
+		{
+			name: "inline key",
+			entry: appEntryConfig{
+				Name:           "packages",
+				ApplicationID:  333,
+				InstallationID: 444,
+				PrivateKey:     privateKey,
+			},
+			expectedKeySource: "privateKey",
+			secrets:           []string{"c3VwZXItc2VjcmV0"},
+		},
+		{
+			name: "KMS-backed key",
+			entry: appEntryConfig{
+				Name:           "packages",
+				ApplicationID:  333,
+				InstallationID: 444,
+				PrivateKeyARN:  arn,
+			},
+			expectedKeySource: "privateKeyArn",
+			secrets:           []string{arn, "123456789012", "super-secret-key-id"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			logger := slog.New(slog.NewJSONHandler(&buf, nil))
+
+			logger.Info("entry", "app", tt.entry)
+			logged := buf.String()
+
+			for _, secret := range tt.secrets {
+				assert.NotContains(t, logged, secret)
+			}
+
+			// A record naming nothing is not actionable, so the
+			// non-credential fields must survive the redaction.
+			require.Contains(t, logged, `"name":"packages"`)
+			assert.Contains(t, logged, `"applicationID":333`)
+			assert.Contains(t, logged, `"installationID":444`)
+			assert.Contains(t, logged, `"keySource":"`+tt.expectedKeySource+`"`)
+		})
+	}
+}

--- a/internal/github/registryinternal_test.go
+++ b/internal/github/registryinternal_test.go
@@ -107,9 +107,16 @@ func TestParseAppEntries_ErrorsNeverQuoteTheKey(t *testing.T) {
 	}
 }
 
-// LogValue guards slog, but fmt consults Stringer instead, so a format string
-// anywhere would otherwise print the key. %#v is excluded by design: it renders
-// Go syntax, and no production path formats a configuration entry that way.
+func TestPrivateKeyPEM_RedactsStringRepresentations(t *testing.T) {
+	key := privateKeyPEM("private key material")
+
+	assert.Equal(t, "[redacted]", key.String())
+	assert.Equal(t, `"[redacted]"`, key.GoString())
+}
+
+// LogValue guards slog, but fmt consults the value's formatting methods instead,
+// so every verb must redact the key, including verbs that do not match its
+// underlying string type.
 func TestPrivateKeyPEM_RedactsUnderFmt(t *testing.T) {
 	const canary = "c3VwZXItc2VjcmV0"
 
@@ -120,7 +127,7 @@ func TestPrivateKeyPEM_RedactsUnderFmt(t *testing.T) {
 		PrivateKey:     "-----BEGIN RSA PRIVATE KEY-----" + canary + "-----END RSA PRIVATE KEY-----",
 	}
 
-	for _, verb := range []string{"%v", "%+v", "%s", "%q", "%#v"} {
+	for _, verb := range []string{"%v", "%+v", "%s", "%q", "%#v", "%d"} {
 		t.Run("entry "+verb, func(t *testing.T) {
 			assert.NotContains(t, fmt.Sprintf(verb, entry), canary)
 		})

--- a/internal/github/registryinternal_test.go
+++ b/internal/github/registryinternal_test.go
@@ -2,7 +2,9 @@ package github
 
 import (
 	"bytes"
+	"fmt"
 	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -68,4 +70,72 @@ func TestAppEntryConfig_LogValueOmitsKeyMaterial(t *testing.T) {
 			assert.Contains(t, logged, `"keySource":"`+tt.expectedKeySource+`"`)
 		})
 	}
+}
+
+// A malformed GITHUB_APPS entry is reported to the operator's startup log, so
+// the decoder must never quote the value it choked on. json/v2 reports a type
+// and a JSON pointer rather than a value; this pins that, because the guard is
+// the library's behaviour rather than anything this package enforces.
+func TestParseAppEntries_ErrorsNeverQuoteTheKey(t *testing.T) {
+	const (
+		pem    = "-----BEGIN RSA PRIVATE KEY-----c3VwZXItc2VjcmV0-----END RSA PRIVATE KEY-----"
+		canary = "c3VwZXItc2VjcmV0"
+	)
+
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{"key where a number belongs", `[{"name":"a","appId":"` + pem + `","installationId":1}]`},
+		{"key in an unknown member", `[{"name":"a","appId":1,"installationId":1,"privateKeyy":"` + pem + `"}]`},
+		{"key in a duplicated member", `[{"name":"a","appId":1,"installationId":1,"privateKey":"` + pem + `","privateKey":"x"}]`},
+		{"truncated mid-key", `[{"name":"a","appId":1,"installationId":1,"privateKey":"` + pem},
+		{"unescaped newline in key", `[{"name":"a","appId":1,"installationId":1,"privateKey":"` + pem + "\n" + `"}]`},
+		{"trailing document after key", `[{"name":"a","appId":1,"installationId":1,"privateKey":"` + pem + `"}] {"x":1}`},
+		{"object where an array belongs", `{"name":"a","appId":1,"installationId":1,"privateKey":"` + pem + `"}`},
+		{"key as the whole document", `"` + pem + `"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseAppEntries(tt.raw)
+
+			require.Error(t, err)
+			assert.NotContains(t, err.Error(), canary)
+			assert.NotContains(t, err.Error(), "BEGIN RSA")
+		})
+	}
+}
+
+// LogValue guards slog, but fmt consults Stringer instead, so a format string
+// anywhere would otherwise print the key. %#v is excluded by design: it renders
+// Go syntax, and no production path formats a configuration entry that way.
+func TestPrivateKeyPEM_RedactsUnderFmt(t *testing.T) {
+	const canary = "c3VwZXItc2VjcmV0"
+
+	entry := appEntryConfig{
+		Name:           "packages",
+		ApplicationID:  333,
+		InstallationID: 444,
+		PrivateKey:     "-----BEGIN RSA PRIVATE KEY-----" + canary + "-----END RSA PRIVATE KEY-----",
+	}
+
+	for _, verb := range []string{"%v", "%+v", "%s", "%q", "%#v"} {
+		t.Run("entry "+verb, func(t *testing.T) {
+			assert.NotContains(t, fmt.Sprintf(verb, entry), canary)
+		})
+
+		// The field travelling alone: a String method on the struct would not
+		// reach this, which is why the redaction lives on the field's type.
+		t.Run("key alone "+verb, func(t *testing.T) {
+			assert.NotContains(t, fmt.Sprintf(verb, entry.PrivateKey), canary)
+		})
+	}
+
+	t.Run("wrapped in an error", func(t *testing.T) {
+		err := fmt.Errorf("app %q: %v", entry.Name, entry)
+
+		assert.NotContains(t, err.Error(), canary)
+		assert.True(t, strings.Contains(err.Error(), "packages"))
+	})
 }

--- a/internal/github/signer.go
+++ b/internal/github/signer.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rsa"
 	"crypto/sha256"
 	"fmt"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/kms"
@@ -34,13 +35,24 @@ type KMSClient interface {
 }
 
 // kmsSigningKey is the key type passed to kmsSigner.Sign(). It carries the
-// context and KMS client needed for AWS KMS-based signing without exposing
-// private key material.
+// KMS client needed for AWS KMS-based signing without exposing private key
+// material.
+//
+// It deliberately holds no context. Signing is lazy and recurring — a fresh
+// App JWT roughly every ten minutes for the life of the process — so a
+// context captured at construction (startup, or app registry verification)
+// would produce a clean boot followed by permanent `context canceled` on
+// every mint once that context expired. The failure reproduces only for
+// ARN-backed keys, never PEM, so it is invisible to most tests.
 type kmsSigningKey struct {
-	ctx    context.Context // startup context for cancellation
 	client KMSClient
 	arn    string
 }
+
+// kmsSignTimeout bounds a single KMS signing call. Sign has no caller-supplied
+// context (jws.Signer2 does not carry one), so the call supplies its own
+// rather than inheriting a lifetime it cannot reason about.
+const kmsSignTimeout = 30 * time.Second
 
 // kmsSigner implements jws.Signer2 for AWS KMS-based signing. The actual
 // signing parameters are extracted from the kmsSigningKey passed to Sign().
@@ -59,8 +71,11 @@ func (kmsSigner) Sign(key any, payload []byte) ([]byte, error) {
 		return nil, fmt.Errorf("kmsSigner requires kmsSigningKey, got %T", key)
 	}
 
+	ctx, cancel := context.WithTimeout(context.Background(), kmsSignTimeout)
+	defer cancel()
+
 	hash := sha256.Sum256(payload)
-	out, err := k.client.Sign(k.ctx, &kms.SignInput{
+	out, err := k.client.Sign(ctx, &kms.SignInput{
 		KeyId:            aws.String(k.arn),
 		Message:          hash[:],
 		MessageType:      types.MessageTypeDigest,

--- a/internal/github/signer.go
+++ b/internal/github/signer.go
@@ -38,20 +38,17 @@ type KMSClient interface {
 // KMS client needed for AWS KMS-based signing without exposing private key
 // material.
 //
-// It deliberately holds no context. Signing is lazy and recurring — a fresh
-// App JWT roughly every ten minutes for the life of the process — so a
-// context captured at construction (startup, or app registry verification)
-// would produce a clean boot followed by permanent `context canceled` on
-// every mint once that context expired. The failure reproduces only for
-// ARN-backed keys, never PEM, so it is invisible to most tests.
+// It must hold no context. JWTs are re-minted roughly every ten minutes for
+// the life of the process, so a context captured at construction gives a clean
+// boot then permanent `context canceled` on every mint. Only ARN-backed keys
+// are affected, so PEM-based tests will not catch a regression.
 type kmsSigningKey struct {
 	client KMSClient
 	arn    string
 }
 
-// kmsSignTimeout bounds a single KMS signing call. Sign has no caller-supplied
-// context (jws.Signer2 does not carry one), so the call supplies its own
-// rather than inheriting a lifetime it cannot reason about.
+// kmsSignTimeout bounds a single KMS signing call: jws.Signer2 gives Sign no
+// caller context, so the call must supply its own.
 const kmsSignTimeout = 30 * time.Second
 
 // kmsSigner implements jws.Signer2 for AWS KMS-based signing. The actual

--- a/internal/github/signer_test.go
+++ b/internal/github/signer_test.go
@@ -34,7 +34,6 @@ func TestKMSSigner_Sign(t *testing.T) {
 	}
 
 	key := kmsSigningKey{
-		ctx:    context.Background(),
 		client: mockClient,
 		arn:    "arn:aws:kms:us-east-1:123456789:key/test-key",
 	}
@@ -62,7 +61,6 @@ func TestKMSSigner_Sign_KMSError(t *testing.T) {
 	}
 
 	key := kmsSigningKey{
-		ctx:    context.Background(),
 		client: mockClient,
 		arn:    "arn:aws:kms:us-east-1:123456789:key/test-key",
 	}
@@ -107,7 +105,6 @@ func TestDelegatingSigner_Sign_KMSKey(t *testing.T) {
 	}
 
 	key := kmsSigningKey{
-		ctx:    context.Background(),
 		client: mockClient,
 		arn:    "arn:aws:kms:us-east-1:123456789:key/test-key",
 	}

--- a/internal/github/signingkeycontext_test.go
+++ b/internal/github/signingkeycontext_test.go
@@ -1,0 +1,151 @@
+package github
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	appconfig "github.com/chinmina/chinmina-bridge/internal/config"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Signing is lazy and recurring: a fresh App JWT roughly every ten minutes for
+// the life of the process. If a signing key captures the context it was
+// constructed under, the service boots cleanly, verifies cleanly, and then
+// fails every mint with `context canceled` once that context ends —
+// permanently, and with no configuration change to point at.
+//
+// The defect cannot reproduce with a PEM key: only a KMS-backed key makes a
+// call that takes a context at all, and every other test in this package uses
+// PEM. This test is the only thing standing between that regression and
+// production, so it exercises signing directly rather than through a token
+// source — an App JWT is cached for ten minutes once minted, so a test driving
+// the cached path would pass whether or not the defect were present.
+func TestKMSSigningKey_SignsAfterTheConstructionContextEnds(t *testing.T) {
+	kms := setupMockKMS(t)
+	setAWSTestEnvironment(t, kms.URL)
+
+	constructionCtx, cancelConstruction := context.WithCancel(context.Background())
+
+	key, err := createKMSSigningKey(
+		"arn:aws:kms:ap-southeast-2:123456789012:key/test-key",
+		newAWSConfigLoader(constructionCtx),
+	)
+	require.NoError(t, err)
+
+	// Sign once while the construction context is live, so a key that captures
+	// a context has certainly captured this one.
+	_, err = kmsSigner{}.Sign(key, []byte("first-jwt"))
+	require.NoError(t, err)
+
+	// Startup is over. Everything scoped to it is now cancelled.
+	cancelConstruction()
+
+	_, err = kmsSigner{}.Sign(key, []byte("later-jwt"))
+
+	require.NoError(t, err, "signing must not depend on the context the key was built under")
+}
+
+// The App JWT path is where the recurring signing actually happens, so it is
+// asserted separately: a key that signs but a token source that cannot build a
+// JWT from it is the same outage.
+func TestKMSSigningKey_MintsAppJWTAfterTheConstructionContextEnds(t *testing.T) {
+	kms := setupMockKMS(t)
+	setAWSTestEnvironment(t, kms.URL)
+
+	constructionCtx, cancelConstruction := context.WithCancel(context.Background())
+
+	signingKey, err := createSigningKey(
+		testGithubConfig("arn:aws:kms:ap-southeast-2:123456789012:key/test-key"),
+		newAWSConfigLoader(constructionCtx),
+	)
+	require.NoError(t, err)
+
+	cancelConstruction()
+
+	// newAppTokenSource rather than NewAppTokenSource: the caching wrapper
+	// would serve a JWT minted before cancellation and prove nothing.
+	token, err := newAppTokenSource(signingKey, "333").Token()
+
+	require.NoError(t, err, "App JWT minting must survive the end of the construction context")
+	assert.NotEmpty(t, token.AccessToken)
+}
+
+// A PEM-backed key never touched a context, so it is the control: if this
+// fails, the tests above are measuring something other than context capture.
+func TestPEMSigningKey_IsUnaffectedByContextCancellation(t *testing.T) {
+	constructionCtx, cancelConstruction := context.WithCancel(context.Background())
+
+	cfg := testGithubConfig("")
+	cfg.PrivateKey = generatePEMKey(t)
+
+	signingKey, err := createSigningKey(cfg, newAWSConfigLoader(constructionCtx))
+	require.NoError(t, err)
+
+	cancelConstruction()
+
+	token, err := newAppTokenSource(signingKey, "333").Token()
+
+	require.NoError(t, err)
+	assert.NotEmpty(t, token.AccessToken)
+}
+
+func testGithubConfig(arn string) appconfig.GithubConfig {
+	return appconfig.GithubConfig{
+		PrivateKeyARN:  arn,
+		ApplicationID:  333,
+		InstallationID: 444,
+	}
+}
+
+// setupMockKMS answers KMS Sign with a well-formed but meaningless signature.
+// Nothing verifies it: these tests are about whether the signing call can
+// happen at all, not about what it produces.
+func setupMockKMS(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	signature := make([]byte, 256)
+	_, err := rand.Read(signature)
+	require.NoError(t, err)
+
+	body := `{"KeyId":"test-key","Signature":"` +
+		base64.StdEncoding.EncodeToString(signature) +
+		`","SigningAlgorithm":"RSASSA_PKCS1_V1_5_SHA_256"}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/x-amz-json-1.1")
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(server.Close)
+
+	return server
+}
+
+func setAWSTestEnvironment(t *testing.T, endpoint string) {
+	t.Helper()
+
+	t.Setenv("AWS_ENDPOINT_URL", endpoint)
+	t.Setenv("AWS_REGION", "ap-southeast-2")
+	t.Setenv("AWS_ACCESS_KEY_ID", "test")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "test")
+}
+
+func generatePEMKey(t *testing.T) string {
+	t.Helper()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	return string(pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
+	}))
+}

--- a/internal/github/signingkeycontext_test.go
+++ b/internal/github/signingkeycontext_test.go
@@ -17,18 +17,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Signing is lazy and recurring: a fresh App JWT roughly every ten minutes for
-// the life of the process. If a signing key captures the context it was
-// constructed under, the service boots cleanly, verifies cleanly, and then
-// fails every mint with `context canceled` once that context ends —
-// permanently, and with no configuration change to point at.
-//
-// The defect cannot reproduce with a PEM key: only a KMS-backed key makes a
-// call that takes a context at all, and every other test in this package uses
-// PEM. This test is the only thing standing between that regression and
-// production, so it exercises signing directly rather than through a token
-// source — an App JWT is cached for ten minutes once minted, so a test driving
-// the cached path would pass whether or not the defect were present.
+// A signing key that captures its construction context boots and verifies
+// cleanly, then fails every mint with `context canceled` once that context
+// ends. Only a KMS-backed key makes a call taking a context at all. Signing is
+// exercised directly rather than through a token source: an App JWT is cached
+// for ten minutes, so the cached path would pass either way.
 func TestKMSSigningKey_SignsAfterTheConstructionContextEnds(t *testing.T) {
 	kms := setupMockKMS(t)
 	setAWSTestEnvironment(t, kms.URL)
@@ -41,12 +34,11 @@ func TestKMSSigningKey_SignsAfterTheConstructionContextEnds(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	// Sign once while the construction context is live, so a key that captures
-	// a context has certainly captured this one.
+	// Sign once while the construction context is live, so a capturing key has
+	// certainly captured this one.
 	_, err = kmsSigner{}.Sign(key, []byte("first-jwt"))
 	require.NoError(t, err)
 
-	// Startup is over. Everything scoped to it is now cancelled.
 	cancelConstruction()
 
 	_, err = kmsSigner{}.Sign(key, []byte("later-jwt"))
@@ -54,9 +46,8 @@ func TestKMSSigningKey_SignsAfterTheConstructionContextEnds(t *testing.T) {
 	require.NoError(t, err, "signing must not depend on the context the key was built under")
 }
 
-// The App JWT path is where the recurring signing actually happens, so it is
-// asserted separately: a key that signs but a token source that cannot build a
-// JWT from it is the same outage.
+// The App JWT path is where the recurring signing happens: a key that signs
+// but a token source that cannot build a JWT from it is the same outage.
 func TestKMSSigningKey_MintsAppJWTAfterTheConstructionContextEnds(t *testing.T) {
 	kms := setupMockKMS(t)
 	setAWSTestEnvironment(t, kms.URL)
@@ -71,16 +62,16 @@ func TestKMSSigningKey_MintsAppJWTAfterTheConstructionContextEnds(t *testing.T) 
 
 	cancelConstruction()
 
-	// newAppTokenSource rather than NewAppTokenSource: the caching wrapper
-	// would serve a JWT minted before cancellation and prove nothing.
+	// newAppTokenSource, not NewAppTokenSource: the caching wrapper would serve
+	// a JWT minted before cancellation.
 	token, err := newAppTokenSource(signingKey, "333").Token()
 
 	require.NoError(t, err, "App JWT minting must survive the end of the construction context")
 	assert.NotEmpty(t, token.AccessToken)
 }
 
-// A PEM-backed key never touched a context, so it is the control: if this
-// fails, the tests above are measuring something other than context capture.
+// The PEM-backed control: if this fails, the tests above are measuring
+// something other than context capture.
 func TestPEMSigningKey_IsUnaffectedByContextCancellation(t *testing.T) {
 	constructionCtx, cancelConstruction := context.WithCancel(context.Background())
 
@@ -106,9 +97,8 @@ func testGithubConfig(arn string) appconfig.GithubConfig {
 	}
 }
 
-// setupMockKMS answers KMS Sign with a well-formed but meaningless signature.
-// Nothing verifies it: these tests are about whether the signing call can
-// happen at all, not about what it produces.
+// setupMockKMS answers KMS Sign with a well-formed but meaningless signature;
+// nothing verifies it.
 func setupMockKMS(t *testing.T) *httptest.Server {
 	t.Helper()
 

--- a/internal/github/token.go
+++ b/internal/github/token.go
@@ -109,19 +109,15 @@ func (c Client) GetFileContent(ctx context.Context, owner string, repo string, p
 	return "", fmt.Errorf("path %s in repo %s/%s returned no content", path, owner, repo)
 }
 
-// installationAccount identifies the account a GitHub App installation belongs
-// to. The numeric ID is what installations are compared on: a login is
-// renameable and, once released, claimable by another account, so comparing
-// logins would let an unrelated account inherit an app's association. The
-// login is carried for logging only.
+// installationAccount identifies the account an installation belongs to.
+// Installations are compared on the numeric ID: a login is renameable and, once
+// released, claimable by another account. Login is carried for logging only.
 type installationAccount struct {
 	ID    int64
 	Login string
 }
 
-// InstallationAccount queries the account this client's installation belongs
-// to. It is the only call the registry makes to verify that every configured
-// app shares one organization.
+// InstallationAccount queries the account this client's installation belongs to.
 func (c Client) InstallationAccount(ctx context.Context) (installationAccount, error) {
 	installation, _, err := c.client.Apps.GetInstallation(ctx, c.installationID)
 	if err != nil {
@@ -158,9 +154,8 @@ func (c Client) CreateAccessToken(ctx context.Context, repoNames []string, scope
 type ClientConfig struct {
 	TransportFactory func(context.Context, appconfig.GithubConfig, http.RoundTripper, AWSConfigLoader) (http.RoundTripper, error)
 
-	// LoadAWS is shared across every client built from one registry, so a
-	// multi-app deployment resolves AWS credentials once rather than once per
-	// app. Nil means "resolve privately", which is correct for a lone client.
+	// LoadAWS is nil for a lone client, which then resolves AWS configuration
+	// privately. Callers building several clients pass a shared loader.
 	LoadAWS AWSConfigLoader
 }
 
@@ -228,9 +223,7 @@ func createAppTransport(_ context.Context, cfg appconfig.GithubConfig, wrapped h
 // Returns either a jwk.Key for PEM-based signing or a kmsSigningKey for AWS
 // KMS-based signing.
 //
-// loadAWS resolves the AWS configuration for KMS-backed keys. Callers building
-// more than one key share a single loader so credentials are resolved once for
-// every app rather than once per app.
+// loadAWS resolves the AWS configuration for KMS-backed keys.
 func createSigningKey(cfg appconfig.GithubConfig, loadAWS AWSConfigLoader) (any, error) {
 	if cfg.PrivateKeyARN != "" {
 		return createKMSSigningKey(cfg.PrivateKeyARN, loadAWS)
@@ -248,13 +241,10 @@ func createSigningKey(cfg appconfig.GithubConfig, loadAWS AWSConfigLoader) (any,
 // path may capture one.
 type AWSConfigLoader func() (aws.Config, error)
 
-// newAWSConfigLoader resolves the default AWS configuration at most once, on
-// first use. Deployments with no ARN-backed key never resolve credentials at
-// all, and a registry of several ARN-backed apps resolves them once between
-// them.
+// newAWSConfigLoader resolves the default AWS configuration once, on first use:
+// a deployment with no ARN-backed key never resolves credentials at all.
 //
-// ctx governs the resolution only; the resulting aws.Config outlives it, and
-// each SDK operation supplies its own context.
+// ctx governs the resolution only; the resulting aws.Config outlives it.
 func newAWSConfigLoader(ctx context.Context) AWSConfigLoader {
 	return sync.OnceValues(func() (aws.Config, error) {
 		return config.LoadDefaultConfig(ctx)
@@ -262,9 +252,8 @@ func newAWSConfigLoader(ctx context.Context) AWSConfigLoader {
 }
 
 // createKMSSigningKey creates a KMS signing key using the AWS SDK. It contacts
-// nothing: the first network call a KMS-backed app makes is the signing
-// operation itself, so a bad ARN, an IAM denial or a KMS outage surfaces on
-// the verification or minting path, never here.
+// nothing, so a bad ARN, an IAM denial or a KMS outage surfaces on the first
+// signing attempt rather than here.
 func createKMSSigningKey(arn string, loadAWS AWSConfigLoader) (kmsSigningKey, error) {
 	awsCfg, err := loadAWS()
 	if err != nil {

--- a/internal/github/token.go
+++ b/internal/github/token.go
@@ -253,11 +253,37 @@ type AWSConfigLoader func() (aws.Config, error)
 // newAWSConfigLoader resolves the default AWS configuration once, on first use:
 // a deployment with no ARN-backed key never resolves credentials at all.
 //
+// Only success is remembered. A failure is returned uncached so the next caller
+// tries again: every KMS-backed app in the registry shares one loader, and a
+// remembered error would disable all of them for the process lifetime.
+//
+// Resolution runs under the lock, so concurrent callers wait for the first
+// attempt rather than each starting their own.
+//
 // ctx governs the resolution only; the resulting aws.Config outlives it.
 func newAWSConfigLoader(ctx context.Context) AWSConfigLoader {
-	return sync.OnceValues(func() (aws.Config, error) {
-		return config.LoadDefaultConfig(ctx)
-	})
+	var (
+		mu       sync.Mutex
+		resolved *aws.Config
+	)
+
+	return func() (aws.Config, error) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		if resolved != nil {
+			return *resolved, nil
+		}
+
+		cfg, err := config.LoadDefaultConfig(ctx)
+		if err != nil {
+			return aws.Config{}, err
+		}
+
+		resolved = &cfg
+
+		return cfg, nil
+	}
 }
 
 // createKMSSigningKey creates a KMS signing key using the AWS SDK. It contacts

--- a/internal/github/token.go
+++ b/internal/github/token.go
@@ -129,6 +129,15 @@ func (c Client) InstallationAccount(ctx context.Context) (installationAccount, e
 		return installationAccount{}, fmt.Errorf("installation %d has no account", c.installationID)
 	}
 
+	// Comparing installations by account ID is only safe because GitHub
+	// documents user and organization accounts as sharing one numeric ID
+	// space. Enterprise accounts are a separate object with no such
+	// guarantee, so one could collide with an unrelated user or
+	// organization's ID.
+	if targetType := installation.GetTargetType(); targetType != "User" && targetType != "Organization" {
+		return installationAccount{}, fmt.Errorf("installation %d is installed on a %q account, not a user or organization", c.installationID, targetType)
+	}
+
 	return installationAccount{ID: account.GetID(), Login: account.GetLogin()}, nil
 }
 

--- a/internal/github/token.go
+++ b/internal/github/token.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/kms"
 	appconfig "github.com/chinmina/chinmina-bridge/internal/config"
@@ -54,7 +55,11 @@ func New(ctx context.Context, cfg appconfig.GithubConfig, config ...ClientOption
 		c(clientConfig)
 	}
 
-	authTransport, err := clientConfig.TransportFactory(ctx, cfg, http.DefaultTransport)
+	if clientConfig.LoadAWS == nil {
+		clientConfig.LoadAWS = newAWSConfigLoader(ctx)
+	}
+
+	authTransport, err := clientConfig.TransportFactory(ctx, cfg, http.DefaultTransport, clientConfig.LoadAWS)
 	if err != nil {
 		return Client{}, fmt.Errorf("could not create GitHub transport: %w", err)
 	}
@@ -104,6 +109,33 @@ func (c Client) GetFileContent(ctx context.Context, owner string, repo string, p
 	return "", fmt.Errorf("path %s in repo %s/%s returned no content", path, owner, repo)
 }
 
+// installationAccount identifies the account a GitHub App installation belongs
+// to. The numeric ID is what installations are compared on: a login is
+// renameable and, once released, claimable by another account, so comparing
+// logins would let an unrelated account inherit an app's association. The
+// login is carried for logging only.
+type installationAccount struct {
+	ID    int64
+	Login string
+}
+
+// InstallationAccount queries the account this client's installation belongs
+// to. It is the only call the registry makes to verify that every configured
+// app shares one organization.
+func (c Client) InstallationAccount(ctx context.Context) (installationAccount, error) {
+	installation, _, err := c.client.Apps.GetInstallation(ctx, c.installationID)
+	if err != nil {
+		return installationAccount{}, fmt.Errorf("could not query installation %d: %w", c.installationID, err)
+	}
+
+	account := installation.GetAccount()
+	if account == nil || account.GetID() == 0 {
+		return installationAccount{}, fmt.Errorf("installation %d has no account", c.installationID)
+	}
+
+	return installationAccount{ID: account.GetID(), Login: account.GetLogin()}, nil
+}
+
 func (c Client) CreateAccessToken(ctx context.Context, repoNames []string, scopes []string) (string, time.Time, error) {
 	tokenPermissions, err := scopesToPermissions(scopes)
 	if err != nil {
@@ -124,7 +156,12 @@ func (c Client) CreateAccessToken(ctx context.Context, repoNames []string, scope
 }
 
 type ClientConfig struct {
-	TransportFactory func(context.Context, appconfig.GithubConfig, http.RoundTripper) (http.RoundTripper, error)
+	TransportFactory func(context.Context, appconfig.GithubConfig, http.RoundTripper, AWSConfigLoader) (http.RoundTripper, error)
+
+	// LoadAWS is shared across every client built from one registry, so a
+	// multi-app deployment resolves AWS credentials once rather than once per
+	// app. Nil means "resolve privately", which is correct for a lone client.
+	LoadAWS AWSConfigLoader
 }
 
 type ClientOption func(*ClientConfig)
@@ -133,9 +170,16 @@ func WithAppTransport(clientConfig *ClientConfig) {
 	clientConfig.TransportFactory = createAppTransport
 }
 
+// WithAWSConfigLoader shares one AWS configuration resolution across clients.
+func WithAWSConfigLoader(loadAWS AWSConfigLoader) ClientOption {
+	return func(clientConfig *ClientConfig) {
+		clientConfig.LoadAWS = loadAWS
+	}
+}
+
 func WithTokenTransport(clientConfig *ClientConfig) {
-	clientConfig.TransportFactory = func(ctx context.Context, cfg appconfig.GithubConfig, wrapped http.RoundTripper) (http.RoundTripper, error) {
-		signingKey, err := createSigningKey(ctx, cfg)
+	clientConfig.TransportFactory = func(_ context.Context, cfg appconfig.GithubConfig, wrapped http.RoundTripper, loadAWS AWSConfigLoader) (http.RoundTripper, error) {
+		signingKey, err := createSigningKey(cfg, loadAWS)
 		if err != nil {
 			return nil, fmt.Errorf("create signing key: %w", err)
 		}
@@ -163,8 +207,8 @@ func WithTokenTransport(clientConfig *ClientConfig) {
 	}
 }
 
-func createAppTransport(ctx context.Context, cfg appconfig.GithubConfig, wrapped http.RoundTripper) (http.RoundTripper, error) {
-	signingKey, err := createSigningKey(ctx, cfg)
+func createAppTransport(_ context.Context, cfg appconfig.GithubConfig, wrapped http.RoundTripper, loadAWS AWSConfigLoader) (http.RoundTripper, error) {
+	signingKey, err := createSigningKey(cfg, loadAWS)
 	if err != nil {
 		return nil, fmt.Errorf("could not create signing key for GitHub transport: %w", err)
 	}
@@ -183,9 +227,13 @@ func createAppTransport(ctx context.Context, cfg appconfig.GithubConfig, wrapped
 // createSigningKey returns the appropriate signing key based on configuration.
 // Returns either a jwk.Key for PEM-based signing or a kmsSigningKey for AWS
 // KMS-based signing.
-func createSigningKey(ctx context.Context, cfg appconfig.GithubConfig) (any, error) {
+//
+// loadAWS resolves the AWS configuration for KMS-backed keys. Callers building
+// more than one key share a single loader so credentials are resolved once for
+// every app rather than once per app.
+func createSigningKey(cfg appconfig.GithubConfig, loadAWS AWSConfigLoader) (any, error) {
 	if cfg.PrivateKeyARN != "" {
-		return createKMSSigningKey(ctx, cfg.PrivateKeyARN)
+		return createKMSSigningKey(cfg.PrivateKeyARN, loadAWS)
 	}
 
 	if cfg.PrivateKey != "" {
@@ -195,9 +243,30 @@ func createSigningKey(ctx context.Context, cfg appconfig.GithubConfig) (any, err
 	return nil, fmt.Errorf("no private key configuration specified")
 }
 
-// createKMSSigningKey creates a KMS signing key using the AWS SDK.
-func createKMSSigningKey(ctx context.Context, arn string) (kmsSigningKey, error) {
-	awsCfg, err := config.LoadDefaultConfig(ctx)
+// AWSConfigLoader resolves the AWS configuration used by KMS-backed signing
+// keys. It takes no context: see kmsSigningKey for why nothing on the signing
+// path may capture one.
+type AWSConfigLoader func() (aws.Config, error)
+
+// newAWSConfigLoader resolves the default AWS configuration at most once, on
+// first use. Deployments with no ARN-backed key never resolve credentials at
+// all, and a registry of several ARN-backed apps resolves them once between
+// them.
+//
+// ctx governs the resolution only; the resulting aws.Config outlives it, and
+// each SDK operation supplies its own context.
+func newAWSConfigLoader(ctx context.Context) AWSConfigLoader {
+	return sync.OnceValues(func() (aws.Config, error) {
+		return config.LoadDefaultConfig(ctx)
+	})
+}
+
+// createKMSSigningKey creates a KMS signing key using the AWS SDK. It contacts
+// nothing: the first network call a KMS-backed app makes is the signing
+// operation itself, so a bad ARN, an IAM denial or a KMS outage surfaces on
+// the verification or minting path, never here.
+func createKMSSigningKey(arn string, loadAWS AWSConfigLoader) (kmsSigningKey, error) {
+	awsCfg, err := loadAWS()
 	if err != nil {
 		return kmsSigningKey{}, fmt.Errorf("load AWS config: %w", err)
 	}
@@ -205,7 +274,6 @@ func createKMSSigningKey(ctx context.Context, arn string) (kmsSigningKey, error)
 	client := kms.NewFromConfig(awsCfg)
 
 	return kmsSigningKey{
-		ctx:    ctx,
 		client: client,
 		arn:    arn,
 	}, nil

--- a/internal/github/token_internal_test.go
+++ b/internal/github/token_internal_test.go
@@ -1,11 +1,82 @@
 package github
 
 import (
+	"context"
+	"os"
+	"sync"
 	"testing"
 
 	api "github.com/google/go-github/v90/github"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// A malformed AWS_MAX_ATTEMPTS fails the load in the SDK's environment parsing,
+// with no credentials, network or region lookup involved: the cheapest
+// deterministic stand-in for the transient credential-provider failures this
+// loader has to survive.
+const invalidAWSMaxAttempts = "not-a-number"
+
+// One failed resolution must not become the answer for the process lifetime:
+// every KMS-backed app in the registry shares a single loader, so a cached
+// error would disable all of them until a restart.
+func TestAWSConfigLoader_RetriesAfterAFailedLoad(t *testing.T) {
+	t.Setenv("AWS_REGION", "ap-southeast-2")
+	t.Setenv("AWS_MAX_ATTEMPTS", invalidAWSMaxAttempts)
+
+	load := newAWSConfigLoader(context.Background())
+
+	_, err := load()
+	require.Error(t, err)
+
+	require.NoError(t, os.Unsetenv("AWS_MAX_ATTEMPTS"))
+
+	cfg, err := load()
+
+	require.NoError(t, err, "a failed load must not be cached")
+	assert.Equal(t, "ap-southeast-2", cfg.Region)
+}
+
+// The loader exists so that resolution happens once, lazily: a deployment with
+// no ARN-backed key never resolves at all, and one with several resolves once.
+// Poisoning the environment after the first success makes a second resolution
+// visible — it would either fail or report the new region.
+func TestAWSConfigLoader_ReusesASuccessfulLoad(t *testing.T) {
+	t.Setenv("AWS_REGION", "ap-southeast-2")
+
+	load := newAWSConfigLoader(context.Background())
+
+	first, err := load()
+	require.NoError(t, err)
+
+	t.Setenv("AWS_REGION", "us-east-1")
+	t.Setenv("AWS_MAX_ATTEMPTS", invalidAWSMaxAttempts)
+
+	second, err := load()
+
+	require.NoError(t, err, "a resolved configuration must not be resolved again")
+	assert.Equal(t, first.Region, second.Region)
+	assert.Equal(t, "ap-southeast-2", second.Region)
+}
+
+// Registry startup verifies every app concurrently, so apps sharing a loader
+// can call it at the same time. Run under -race, this is the check that the
+// cache is guarded.
+func TestAWSConfigLoader_IsSafeForConcurrentUse(t *testing.T) {
+	t.Setenv("AWS_REGION", "ap-southeast-2")
+
+	load := newAWSConfigLoader(context.Background())
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Go(func() {
+			cfg, err := load()
+			assert.NoError(t, err)
+			assert.Equal(t, "ap-southeast-2", cfg.Region)
+		})
+	}
+	wg.Wait()
+}
 
 func TestScopesToPermissions(t *testing.T) {
 	tests := []struct {

--- a/internal/github/token_internal_test.go
+++ b/internal/github/token_internal_test.go
@@ -2,7 +2,6 @@ package github
 
 import (
 	"context"
-	"os"
 	"sync"
 	"testing"
 
@@ -29,7 +28,9 @@ func TestAWSConfigLoader_RetriesAfterAFailedLoad(t *testing.T) {
 	_, err := load()
 	require.Error(t, err)
 
-	require.NoError(t, os.Unsetenv("AWS_MAX_ATTEMPTS"))
+	// A tracked t.Setenv, not a raw unset: the latter bypasses the
+	// testing package's env synchronization and escapes its cleanup.
+	t.Setenv("AWS_MAX_ATTEMPTS", "3")
 
 	cfg, err := load()
 

--- a/internal/github/token_test.go
+++ b/internal/github/token_test.go
@@ -532,6 +532,63 @@ func TestValidateScope(t *testing.T) {
 	}
 }
 
+// User and organization accounts are documented by GitHub as sharing one
+// numeric ID space; enterprise accounts are not part of that guarantee, so an
+// installation reporting itself as enterprise-owned must not be trusted to
+// compare safely against another app's account ID.
+func TestInstallationAccount_TargetType(t *testing.T) {
+	tests := []struct {
+		name        string
+		targetType  string
+		errContains string
+	}{
+		{name: "organization is accepted", targetType: "Organization"},
+		{name: "user is accepted", targetType: "User"},
+		{name: "enterprise is rejected", targetType: "Enterprise", errContains: `installation 20 is installed on a "Enterprise" account, not a user or organization`},
+		{name: "unrecognised type is rejected", targetType: "Bot", errContains: `installation 20 is installed on a "Bot" account, not a user or organization`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router := http.NewServeMux()
+			router.HandleFunc("GET /app/installations/{installationID}", func(w http.ResponseWriter, r *http.Request) {
+				JSON(w, &api.Installation{
+					ID:         new(int64(20)),
+					TargetType: new(tt.targetType),
+					Account: &api.User{
+						ID:    new(int64(1)),
+						Login: new("acme"),
+					},
+				})
+			})
+
+			svr := httptest.NewServer(router)
+			defer svr.Close()
+
+			gh, err := github.New(
+				context.Background(),
+				config.GithubConfig{
+					APIURL:         svr.URL,
+					PrivateKey:     generateKey(t),
+					ApplicationID:  10,
+					InstallationID: 20,
+				},
+			)
+			require.NoError(t, err)
+
+			account, err := gh.InstallationAccount(context.Background())
+
+			if tt.errContains != "" {
+				assert.ErrorContains(t, err, tt.errContains)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, int64(1), account.ID)
+		})
+	}
+}
+
 func JSON(w http.ResponseWriter, payload any) {
 	w.Header().Set("Content-Type", "application/json")
 	res, _ := json.Marshal(payload)

--- a/internal/github/token_test.go
+++ b/internal/github/token_test.go
@@ -557,7 +557,7 @@ func generateKey(t *testing.T) string {
 
 // withPlainTransport creates a transport with no auth - for testing only
 func withPlainTransport(clientConfig *github.ClientConfig) {
-	clientConfig.TransportFactory = func(ctx context.Context, cfg config.GithubConfig, wrapped http.RoundTripper) (http.RoundTripper, error) {
+	clientConfig.TransportFactory = func(ctx context.Context, cfg config.GithubConfig, wrapped http.RoundTripper, _ github.AWSConfigLoader) (http.RoundTripper, error) {
 		return wrapped, nil
 	}
 }

--- a/internal/github/token_test.go
+++ b/internal/github/token_test.go
@@ -589,6 +589,52 @@ func TestInstallationAccount_TargetType(t *testing.T) {
 	}
 }
 
+// Installations are compared on the account's numeric ID, so an absent or zero
+// ID must be rejected rather than carried forward: a zero would compare equal
+// to every other account whose ID was also unreadable, making two unrelated
+// installations look like the same one.
+func TestInstallationAccount_RejectsAnUnidentifiableAccount(t *testing.T) {
+	tests := []struct {
+		name    string
+		account *api.User
+	}{
+		{name: "no account object"},
+		{name: "account with no id", account: &api.User{Login: new("acme")}},
+		{name: "account with a zero id", account: &api.User{ID: new(int64(0)), Login: new("acme")}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router := http.NewServeMux()
+			router.HandleFunc("GET /app/installations/{installationID}", func(w http.ResponseWriter, r *http.Request) {
+				JSON(w, &api.Installation{
+					ID:         new(int64(20)),
+					TargetType: new("Organization"),
+					Account:    tt.account,
+				})
+			})
+
+			svr := httptest.NewServer(router)
+			defer svr.Close()
+
+			gh, err := github.New(
+				context.Background(),
+				config.GithubConfig{
+					APIURL:         svr.URL,
+					PrivateKey:     generateKey(t),
+					ApplicationID:  10,
+					InstallationID: 20,
+				},
+			)
+			require.NoError(t, err)
+
+			_, err = gh.InstallationAccount(context.Background())
+
+			assert.ErrorContains(t, err, "installation 20 has no account")
+		})
+	}
+}
+
 func JSON(w http.ResponseWriter, payload any) {
 	w.Header().Set("Content-Type", "application/json")
 	res, _ := json.Marshal(payload)

--- a/internal/profile/compilation.go
+++ b/internal/profile/compilation.go
@@ -66,103 +66,163 @@ func resolveProfileApp(app *string, usable AppLookup) (string, error) {
 	return *app, nil
 }
 
-// validateOrganizationProfile checks one profile in isolation and returns the
-// app its tokens mint through.
-func validateOrganizationProfile(prof organizationProfile, usableApp AppLookup) (string, error) {
+// appNameValidator resolves a profile's declared app (nil meaning "default")
+// to the name its tokens mint through, or explains why it can't. It is
+// resolveProfileApp curried with the registry's usability check, so
+// compileProfile itself carries no registry-shaped dependency — only a
+// function from "declared app" to "resolved name or error".
+type appNameValidator func(app *string) (string, error)
+
+func newAppNameValidator(usable AppLookup) appNameValidator {
+	return func(app *string) (string, error) {
+		return resolveProfileApp(app, usable)
+	}
+}
+
+// compileOrganizationProfile compiles one profile in isolation: it either
+// produces a complete AuthorizedProfile, or fails, so no attribute of the
+// result can come from a different configuration entry.
+func compileOrganizationProfile(
+	prof organizationProfile,
+	checkDuplicate duplicateNameValidator,
+	checkAppName appNameValidator,
+) (AuthorizedProfile[OrganizationProfileAttr], error) {
+	if err := checkDuplicate(prof.Name); err != nil {
+		return AuthorizedProfile[OrganizationProfileAttr]{}, err
+	}
+
 	// Reject names that would produce an ambiguous URN
 	if err := validateProfileName(prof.Name); err != nil {
-		return "", err
+		return AuthorizedProfile[OrganizationProfileAttr]{}, err
 	}
 
 	if len(prof.Repositories) == 0 {
-		return "", fmt.Errorf("repositories list must be non-empty")
+		return AuthorizedProfile[OrganizationProfileAttr]{}, fmt.Errorf("repositories list must be non-empty")
 	}
 
 	if err := validateRepositories(prof.Repositories); err != nil {
-		return "", fmt.Errorf("invalid repositories: %w", err)
+		return AuthorizedProfile[OrganizationProfileAttr]{}, fmt.Errorf("invalid repositories: %w", err)
 	}
 
 	if len(prof.Permissions) == 0 {
-		return "", fmt.Errorf("permissions list must be non-empty")
+		return AuthorizedProfile[OrganizationProfileAttr]{}, fmt.Errorf("permissions list must be non-empty")
 	}
 
 	if err := validatePermissions(prof.Permissions); err != nil {
-		return "", fmt.Errorf("invalid permissions: %w", err)
+		return AuthorizedProfile[OrganizationProfileAttr]{}, fmt.Errorf("invalid permissions: %w", err)
 	}
 
-	return resolveProfileApp(prof.App, usableApp)
+	app, err := checkAppName(prof.App)
+	if err != nil {
+		return AuthorizedProfile[OrganizationProfileAttr]{}, err
+	}
+
+	matcher, err := compileMatchRules(prof.Match)
+	if err != nil {
+		return AuthorizedProfile[OrganizationProfileAttr]{}, err
+	}
+
+	// Emit deprecation warning for "*" wildcard
+	if len(prof.Repositories) == 1 && prof.Repositories[0] == LiteralDeprecatedWildcard {
+		slog.Warn("organization profile: '*' is deprecated, use '{{all-repositories}}' instead",
+			"profile", prof.Name,
+		)
+	}
+
+	attrs := OrganizationProfileAttr{
+		Scope:       resolveRepositoryScope(prof.Repositories),
+		Permissions: ensureMetadataRead(prof.Permissions),
+		App:         app,
+	}
+
+	return NewAuthorizedProfile(matcher, attrs), nil
 }
 
 // compileOrganizationProfiles compiles organization profiles from config.
 // Returns a ProfileStoreOf containing valid and invalid profiles.
 func compileOrganizationProfiles(profiles []organizationProfile, usableApp AppLookup) ProfileStoreOf[OrganizationProfileAttr] {
-	validMatchers := make(map[string]Matcher)
-	validApps := make(map[string]string)
+	validProfiles := make(map[string]AuthorizedProfile[OrganizationProfileAttr])
 	invalidProfiles := make(map[string]error)
-	duplicateNameCheck := duplicateNameValidator()
+	checkDuplicate := newDuplicateNameValidator()
+	checkAppName := newAppNameValidator(usableApp)
 
 	for _, prof := range profiles {
-		// Check for duplicate profile names
-		if err := duplicateNameCheck(prof.Name); err != nil {
-			invalidProfiles[prof.Name] = err
-			continue
-		}
-
-		app, err := validateOrganizationProfile(prof, usableApp)
+		compiled, err := compileOrganizationProfile(prof, checkDuplicate, checkAppName)
 		if err != nil {
 			invalidProfiles[prof.Name] = err
 			continue
 		}
 
-		matcher, err := compileMatchRules(prof.Match)
-		if err != nil {
-			invalidProfiles[prof.Name] = err
-			continue
-		}
-
-		validMatchers[prof.Name] = matcher
-		validApps[prof.Name] = app
+		validProfiles[prof.Name] = compiled
 	}
 
-	// Log warnings for invalid profiles
-	if len(invalidProfiles) > 0 {
-		attrs := make([]slog.Attr, 0, len(invalidProfiles))
-		for name, err := range invalidProfiles {
-			attrs = append(attrs, slog.String(name, err.Error()))
-		}
-		slog.Warn("organization profile: some profiles failed validation and were ignored",
-			slog.Attr{Key: "invalid_profiles", Value: slog.GroupValue(attrs...)})
-	}
-
-	// Build maps for ProfileStoreOf
-	validProfiles := make(map[string]AuthorizedProfile[OrganizationProfileAttr])
-
-	// Convert valid profiles to AuthorizedProfile format
-	for _, p := range profiles {
-		matcher, ok := validMatchers[p.Name]
-		if !ok {
-			// Profile was invalid, skip it
-			continue
-		}
-
-		// Emit deprecation warning for "*" wildcard
-		if len(p.Repositories) == 1 && p.Repositories[0] == LiteralDeprecatedWildcard {
-			slog.Warn("organization profile: '*' is deprecated, use '{{all-repositories}}' instead",
-				"profile", p.Name,
-			)
-		}
-
-		scope := resolveRepositoryScope(p.Repositories)
-		attrs := OrganizationProfileAttr{
-			Scope:       scope,
-			Permissions: ensureMetadataRead(p.Permissions),
-			App:         validApps[p.Name],
-		}
-
-		validProfiles[p.Name] = NewAuthorizedProfile(matcher, attrs)
-	}
+	logInvalidProfiles("organization", invalidProfiles)
 
 	return NewProfileStoreOf(validProfiles, invalidProfiles)
+}
+
+// logInvalidProfiles reports the profiles that failed validation, so an
+// operator sees the rejections that a successful load would otherwise hide.
+func logInvalidProfiles(kind string, invalidProfiles map[string]error) {
+	if len(invalidProfiles) == 0 {
+		return
+	}
+
+	attrs := make([]slog.Attr, 0, len(invalidProfiles))
+	for name, err := range invalidProfiles {
+		attrs = append(attrs, slog.String(name, err.Error()))
+	}
+
+	slog.Warn(kind+" profile: some profiles failed validation and were ignored",
+		slog.Attr{Key: "invalid_profiles", Value: slog.GroupValue(attrs...)})
+}
+
+// compilePipelineProfile compiles one profile in isolation. As for
+// organization profiles, the result is either complete or absent.
+func compilePipelineProfile(
+	prof pipelineProfile,
+	checkDuplicate duplicateNameValidator,
+	checkAppName appNameValidator,
+) (AuthorizedProfile[PipelineProfileAttr], error) {
+	// Check for reserved "default" name
+	if prof.Name == "default" {
+		return AuthorizedProfile[PipelineProfileAttr]{}, fmt.Errorf("profile name %q is reserved", "default")
+	}
+
+	if err := checkDuplicate(prof.Name); err != nil {
+		return AuthorizedProfile[PipelineProfileAttr]{}, err
+	}
+
+	// Reject names that would produce an ambiguous URN
+	if err := validateProfileName(prof.Name); err != nil {
+		return AuthorizedProfile[PipelineProfileAttr]{}, err
+	}
+
+	if len(prof.Permissions) == 0 {
+		return AuthorizedProfile[PipelineProfileAttr]{}, fmt.Errorf("permissions list must be non-empty")
+	}
+
+	if err := validatePermissions(prof.Permissions); err != nil {
+		return AuthorizedProfile[PipelineProfileAttr]{}, fmt.Errorf("invalid permissions: %w", err)
+	}
+
+	app, err := checkAppName(prof.App)
+	if err != nil {
+		return AuthorizedProfile[PipelineProfileAttr]{}, err
+	}
+
+	// Compile match rules (empty rules are allowed)
+	matcher, err := compileMatchRules(prof.Match)
+	if err != nil {
+		return AuthorizedProfile[PipelineProfileAttr]{}, err
+	}
+
+	attrs := PipelineProfileAttr{
+		Permissions: ensureMetadataRead(prof.Permissions),
+		App:         app,
+	}
+
+	return NewAuthorizedProfile(matcher, attrs), nil
 }
 
 // compilePipelineProfiles compiles pipeline profiles from config.
@@ -170,89 +230,22 @@ func compileOrganizationProfiles(profiles []organizationProfile, usableApp AppLo
 // Validates that user-defined profiles don't use the reserved "default" name.
 // Returns a ProfileStoreOf containing valid and invalid profiles.
 func compilePipelineProfiles(profiles []pipelineProfile, defaultPermissions []string, usableApp AppLookup) ProfileStoreOf[PipelineProfileAttr] {
-	validMatchers := make(map[string]Matcher)
-	validApps := make(map[string]string)
+	validProfiles := make(map[string]AuthorizedProfile[PipelineProfileAttr])
 	invalidProfiles := make(map[string]error)
-	duplicateNameCheck := duplicateNameValidator()
+	checkDuplicate := newDuplicateNameValidator()
+	checkAppName := newAppNameValidator(usableApp)
 
 	for _, prof := range profiles {
-		// Check for reserved "default" name
-		if prof.Name == "default" {
-			err := fmt.Errorf("profile name %q is reserved", "default")
-			invalidProfiles[prof.Name] = err
-			continue
-		}
-
-		// Check for duplicate profile names
-		if err := duplicateNameCheck(prof.Name); err != nil {
-			invalidProfiles[prof.Name] = err
-			continue
-		}
-
-		// Reject names that would produce an ambiguous URN
-		if err := validateProfileName(prof.Name); err != nil {
-			invalidProfiles[prof.Name] = err
-			continue
-		}
-
-		// Check for empty permissions list
-		if len(prof.Permissions) == 0 {
-			err := fmt.Errorf("permissions list must be non-empty")
-			invalidProfiles[prof.Name] = err
-			continue
-		}
-
-		// Validate permissions format
-		if err := validatePermissions(prof.Permissions); err != nil {
-			invalidProfiles[prof.Name] = fmt.Errorf("invalid permissions: %w", err)
-			continue
-		}
-
-		app, err := resolveProfileApp(prof.App, usableApp)
+		compiled, err := compilePipelineProfile(prof, checkDuplicate, checkAppName)
 		if err != nil {
 			invalidProfiles[prof.Name] = err
 			continue
 		}
 
-		// Compile match rules (empty rules are allowed)
-		matcher, err := compileMatchRules(prof.Match)
-		if err != nil {
-			invalidProfiles[prof.Name] = err
-			continue
-		}
-
-		validMatchers[prof.Name] = matcher
-		validApps[prof.Name] = app
+		validProfiles[prof.Name] = compiled
 	}
 
-	// Log warnings for invalid profiles
-	if len(invalidProfiles) > 0 {
-		attrs := make([]slog.Attr, 0, len(invalidProfiles))
-		for name, err := range invalidProfiles {
-			attrs = append(attrs, slog.String(name, err.Error()))
-		}
-		slog.Warn("pipeline profile: some profiles failed validation and were ignored",
-			slog.Attr{Key: "invalid_profiles", Value: slog.GroupValue(attrs...)})
-	}
-
-	// Build maps for ProfileStoreOf
-	validProfiles := make(map[string]AuthorizedProfile[PipelineProfileAttr])
-
-	// Convert valid profiles to AuthorizedProfile format
-	for _, p := range profiles {
-		matcher, ok := validMatchers[p.Name]
-		if !ok {
-			// Profile was invalid, skip it
-			continue
-		}
-
-		attrs := PipelineProfileAttr{
-			Permissions: ensureMetadataRead(p.Permissions),
-			App:         validApps[p.Name],
-		}
-
-		validProfiles[p.Name] = NewAuthorizedProfile(matcher, attrs)
-	}
+	logInvalidProfiles("pipeline", invalidProfiles)
 
 	// Add "default" profile from defaultPermissions
 	// Empty match rules means it matches all pipelines
@@ -355,8 +348,12 @@ func validateRepositories(repos []string) error {
 	return nil
 }
 
-// duplicateNameValidator creates a validator function that checks for duplicate profile names.
-func duplicateNameValidator() func(string) error {
+// duplicateNameValidator rejects a profile name already seen by an earlier
+// call, so a second entry sharing a name never reaches the maps a first entry
+// already populated.
+type duplicateNameValidator func(name string) error
+
+func newDuplicateNameValidator() duplicateNameValidator {
 	seenNames := make(map[string]struct{})
 
 	return func(name string) error {

--- a/internal/profile/compilation.go
+++ b/internal/profile/compilation.go
@@ -35,27 +35,21 @@ func resolveRepositoryScope(repos []string) RepositoryScope {
 	return NewSpecificScope(repos...)
 }
 
-// AppLookup reports whether a profile may name this app: present in the app
-// registry, and enabled. It is the registry's own resolution function, so a
-// compiled profile and a live request can never disagree about which apps are
-// usable.
+// AppLookup reports whether a profile may name this app: registered, and
+// enabled. It is the registry's own resolution function, so compiled profiles
+// and live requests cannot disagree about which apps are usable.
 type AppLookup func(name string) bool
 
-// DefaultAppOnly is the lookup for a deployment with no app registry: the
-// default app is usable and nothing else is. It is also what compilation
-// outside a running service (tests, tooling) should use.
+// DefaultAppOnly is the lookup for deployments with no app registry, and for
+// compilation outside a running service: only the default app is usable.
 func DefaultAppOnly(name string) bool {
 	return name == github.DefaultAppName
 }
 
-// resolveProfileApp normalises and validates a profile's declared app.
-//
-// Normalisation happens here rather than at the request boundary so that an
-// omitted `app` and an explicit `app: default` produce the same attribute
-// value: the two spellings are indistinguishable downstream, and so produce
-// identical audit attribution for identical behaviour. It also means a valid
-// profile's app name is never empty, which is what lets the resolver treat an
-// empty one as a defect rather than a default.
+// resolveProfileApp normalises and validates a profile's declared app. An
+// omitted `app` and an explicit `app: default` produce the same value, so a
+// valid profile's app name is never empty and the resolver can treat an empty
+// one as a defect.
 func resolveProfileApp(app *string, usable AppLookup) (string, error) {
 	if app == nil {
 		return github.DefaultAppName, nil
@@ -66,9 +60,6 @@ func resolveProfileApp(app *string, usable AppLookup) (string, error) {
 	}
 
 	if !usable(*app) {
-		// Unknown and disabled are one answer by design: the registry does not
-		// distinguish them, so that no caller can resolve a disabled app by
-		// forgetting to check a flag.
 		return "", fmt.Errorf("app %q is not a configured, enabled application", *app)
 	}
 
@@ -76,10 +67,7 @@ func resolveProfileApp(app *string, usable AppLookup) (string, error) {
 }
 
 // validateOrganizationProfile checks one profile in isolation and returns the
-// app its tokens mint through. Validation is separated from the loop so that
-// adding a rule does not make the compilation loop harder to read: the loop's
-// job is bookkeeping across profiles, this function's is one profile's
-// validity.
+// app its tokens mint through.
 func validateOrganizationProfile(prof organizationProfile, usableApp AppLookup) (string, error) {
 	// Reject names that would produce an ambiguous URN
 	if err := validateProfileName(prof.Name); err != nil {
@@ -268,10 +256,8 @@ func compilePipelineProfiles(profiles []pipelineProfile, defaultPermissions []st
 
 	// Add "default" profile from defaultPermissions
 	// Empty match rules means it matches all pipelines
-	//
-	// It always mints through the default app: it is synthesised rather than
-	// declared, so there is no YAML to carry an `app` property, and the
-	// reserved name means none can be declared to override it.
+	// Always the default app: it is synthesised, so there is no YAML to name
+	// one, and the reserved name prevents a declared override.
 	defaultMatcher, _ := compileMatchRules(nil) // Empty rules always succeed
 	validProfiles["default"] = NewAuthorizedProfile(defaultMatcher, PipelineProfileAttr{
 		Permissions: ensureMetadataRead(defaultPermissions),
@@ -286,10 +272,8 @@ func compilePipelineProfiles(profiles []pipelineProfile, defaultPermissions []st
 // The digest is passed through to the returned Profiles.
 // Returns an error if the default pipeline permissions are invalid.
 //
-// usableApp is consulted on every compile, not only the first. Profile
-// validity is a function of both the YAML and the registry, and compilation
-// runs again on every background refresh, so a profile naming an enabled app
-// stays valid across refreshes and one naming a disabled app stays invalid.
+// Validity depends on the registry as well as the YAML: a profile naming an
+// app that usableApp rejects is compiled as invalid.
 func compile(config profileConfig, digest string, location string, usableApp AppLookup) (Profiles, error) {
 	// Compile organization profiles
 	orgProfiles := compileOrganizationProfiles(config.Organization.Profiles, usableApp)

--- a/internal/profile/compilation.go
+++ b/internal/profile/compilation.go
@@ -145,7 +145,7 @@ func compilePipelineProfiles(profiles []pipelineProfile, defaultPermissions []st
 	// Always the default app: it is synthesised, so there is no YAML to name
 	// one, and the reserved name prevents a declared override.
 	defaultMatcher, _ := compileMatchRules(nil) // Empty rules always succeed
-	validProfiles["default"] = NewAuthorizedProfile(defaultMatcher, PipelineProfileAttr{
+	validProfiles[ProfileNameDefault] = NewAuthorizedProfile(defaultMatcher, PipelineProfileAttr{
 		Permissions: ensureMetadataRead(defaultPermissions),
 		App:         github.DefaultAppName,
 	})
@@ -160,8 +160,8 @@ func compilePipelineProfile(
 	checkDuplicate duplicateNameValidator,
 	checkAppName appNameValidator,
 ) (AuthorizedProfile[PipelineProfileAttr], error) {
-	if prof.Name == "default" {
-		return AuthorizedProfile[PipelineProfileAttr]{}, fmt.Errorf("profile name %q is reserved", "default")
+	if prof.Name == ProfileNameDefault {
+		return AuthorizedProfile[PipelineProfileAttr]{}, fmt.Errorf("profile name %q is reserved", ProfileNameDefault)
 	}
 
 	if err := checkDuplicate(prof.Name); err != nil {

--- a/internal/profile/compilation.go
+++ b/internal/profile/compilation.go
@@ -35,10 +35,81 @@ func resolveRepositoryScope(repos []string) RepositoryScope {
 	return NewSpecificScope(repos...)
 }
 
+// AppLookup reports whether a profile may name this app: present in the app
+// registry, and enabled. It is the registry's own resolution function, so a
+// compiled profile and a live request can never disagree about which apps are
+// usable.
+type AppLookup func(name string) bool
+
+// DefaultAppOnly is the lookup for a deployment with no app registry: the
+// default app is usable and nothing else is. It is also what compilation
+// outside a running service (tests, tooling) should use.
+func DefaultAppOnly(name string) bool {
+	return name == github.DefaultAppName
+}
+
+// resolveProfileApp normalises and validates a profile's declared app.
+//
+// Normalisation happens here rather than at the request boundary so that an
+// omitted `app` and an explicit `app: default` produce the same attribute
+// value: the two spellings are indistinguishable downstream, and so produce
+// identical audit attribution for identical behaviour. It also means a valid
+// profile's app name is never empty, which is what lets the resolver treat an
+// empty one as a defect rather than a default.
+func resolveProfileApp(app *string, usable AppLookup) (string, error) {
+	if app == nil {
+		return github.DefaultAppName, nil
+	}
+
+	if *app == "" {
+		return "", fmt.Errorf("app must not be empty")
+	}
+
+	if !usable(*app) {
+		// Unknown and disabled are one answer by design: the registry does not
+		// distinguish them, so that no caller can resolve a disabled app by
+		// forgetting to check a flag.
+		return "", fmt.Errorf("app %q is not a configured, enabled application", *app)
+	}
+
+	return *app, nil
+}
+
+// validateOrganizationProfile checks one profile in isolation and returns the
+// app its tokens mint through. Validation is separated from the loop so that
+// adding a rule does not make the compilation loop harder to read: the loop's
+// job is bookkeeping across profiles, this function's is one profile's
+// validity.
+func validateOrganizationProfile(prof organizationProfile, usableApp AppLookup) (string, error) {
+	// Reject names that would produce an ambiguous URN
+	if err := validateProfileName(prof.Name); err != nil {
+		return "", err
+	}
+
+	if len(prof.Repositories) == 0 {
+		return "", fmt.Errorf("repositories list must be non-empty")
+	}
+
+	if err := validateRepositories(prof.Repositories); err != nil {
+		return "", fmt.Errorf("invalid repositories: %w", err)
+	}
+
+	if len(prof.Permissions) == 0 {
+		return "", fmt.Errorf("permissions list must be non-empty")
+	}
+
+	if err := validatePermissions(prof.Permissions); err != nil {
+		return "", fmt.Errorf("invalid permissions: %w", err)
+	}
+
+	return resolveProfileApp(prof.App, usableApp)
+}
+
 // compileOrganizationProfiles compiles organization profiles from config.
 // Returns a ProfileStoreOf containing valid and invalid profiles.
-func compileOrganizationProfiles(profiles []organizationProfile) ProfileStoreOf[OrganizationProfileAttr] {
+func compileOrganizationProfiles(profiles []organizationProfile, usableApp AppLookup) ProfileStoreOf[OrganizationProfileAttr] {
 	validMatchers := make(map[string]Matcher)
+	validApps := make(map[string]string)
 	invalidProfiles := make(map[string]error)
 	duplicateNameCheck := duplicateNameValidator()
 
@@ -49,35 +120,9 @@ func compileOrganizationProfiles(profiles []organizationProfile) ProfileStoreOf[
 			continue
 		}
 
-		// Reject names that would produce an ambiguous URN
-		if err := validateProfileName(prof.Name); err != nil {
+		app, err := validateOrganizationProfile(prof, usableApp)
+		if err != nil {
 			invalidProfiles[prof.Name] = err
-			continue
-		}
-
-		// Check for empty repositories list
-		if len(prof.Repositories) == 0 {
-			err := fmt.Errorf("repositories list must be non-empty")
-			invalidProfiles[prof.Name] = err
-			continue
-		}
-
-		// Validate repository format
-		if err := validateRepositories(prof.Repositories); err != nil {
-			invalidProfiles[prof.Name] = fmt.Errorf("invalid repositories: %w", err)
-			continue
-		}
-
-		// Check for empty permissions list
-		if len(prof.Permissions) == 0 {
-			err := fmt.Errorf("permissions list must be non-empty")
-			invalidProfiles[prof.Name] = err
-			continue
-		}
-
-		// Validate permissions format
-		if err := validatePermissions(prof.Permissions); err != nil {
-			invalidProfiles[prof.Name] = fmt.Errorf("invalid permissions: %w", err)
 			continue
 		}
 
@@ -88,6 +133,7 @@ func compileOrganizationProfiles(profiles []organizationProfile) ProfileStoreOf[
 		}
 
 		validMatchers[prof.Name] = matcher
+		validApps[prof.Name] = app
 	}
 
 	// Log warnings for invalid profiles
@@ -122,6 +168,7 @@ func compileOrganizationProfiles(profiles []organizationProfile) ProfileStoreOf[
 		attrs := OrganizationProfileAttr{
 			Scope:       scope,
 			Permissions: ensureMetadataRead(p.Permissions),
+			App:         validApps[p.Name],
 		}
 
 		validProfiles[p.Name] = NewAuthorizedProfile(matcher, attrs)
@@ -134,8 +181,9 @@ func compileOrganizationProfiles(profiles []organizationProfile) ProfileStoreOf[
 // Creates a "default" profile from defaultPermissions.
 // Validates that user-defined profiles don't use the reserved "default" name.
 // Returns a ProfileStoreOf containing valid and invalid profiles.
-func compilePipelineProfiles(profiles []pipelineProfile, defaultPermissions []string) ProfileStoreOf[PipelineProfileAttr] {
+func compilePipelineProfiles(profiles []pipelineProfile, defaultPermissions []string, usableApp AppLookup) ProfileStoreOf[PipelineProfileAttr] {
 	validMatchers := make(map[string]Matcher)
+	validApps := make(map[string]string)
 	invalidProfiles := make(map[string]error)
 	duplicateNameCheck := duplicateNameValidator()
 
@@ -172,6 +220,12 @@ func compilePipelineProfiles(profiles []pipelineProfile, defaultPermissions []st
 			continue
 		}
 
+		app, err := resolveProfileApp(prof.App, usableApp)
+		if err != nil {
+			invalidProfiles[prof.Name] = err
+			continue
+		}
+
 		// Compile match rules (empty rules are allowed)
 		matcher, err := compileMatchRules(prof.Match)
 		if err != nil {
@@ -180,6 +234,7 @@ func compilePipelineProfiles(profiles []pipelineProfile, defaultPermissions []st
 		}
 
 		validMatchers[prof.Name] = matcher
+		validApps[prof.Name] = app
 	}
 
 	// Log warnings for invalid profiles
@@ -205,6 +260,7 @@ func compilePipelineProfiles(profiles []pipelineProfile, defaultPermissions []st
 
 		attrs := PipelineProfileAttr{
 			Permissions: ensureMetadataRead(p.Permissions),
+			App:         validApps[p.Name],
 		}
 
 		validProfiles[p.Name] = NewAuthorizedProfile(matcher, attrs)
@@ -212,9 +268,14 @@ func compilePipelineProfiles(profiles []pipelineProfile, defaultPermissions []st
 
 	// Add "default" profile from defaultPermissions
 	// Empty match rules means it matches all pipelines
+	//
+	// It always mints through the default app: it is synthesised rather than
+	// declared, so there is no YAML to carry an `app` property, and the
+	// reserved name means none can be declared to override it.
 	defaultMatcher, _ := compileMatchRules(nil) // Empty rules always succeed
 	validProfiles["default"] = NewAuthorizedProfile(defaultMatcher, PipelineProfileAttr{
 		Permissions: ensureMetadataRead(defaultPermissions),
+		App:         github.DefaultAppName,
 	})
 
 	return NewProfileStoreOf(validProfiles, invalidProfiles)
@@ -224,9 +285,14 @@ func compilePipelineProfiles(profiles []pipelineProfile, defaultPermissions []st
 // Invalid profiles are tracked in ProfileStoreOf's invalidProfiles map.
 // The digest is passed through to the returned Profiles.
 // Returns an error if the default pipeline permissions are invalid.
-func compile(config profileConfig, digest string, location string) (Profiles, error) {
+//
+// usableApp is consulted on every compile, not only the first. Profile
+// validity is a function of both the YAML and the registry, and compilation
+// runs again on every background refresh, so a profile naming an enabled app
+// stays valid across refreshes and one naming a disabled app stays invalid.
+func compile(config profileConfig, digest string, location string, usableApp AppLookup) (Profiles, error) {
 	// Compile organization profiles
-	orgProfiles := compileOrganizationProfiles(config.Organization.Profiles)
+	orgProfiles := compileOrganizationProfiles(config.Organization.Profiles, usableApp)
 
 	// Extract pipeline defaults with fallback
 	pipelineDefaults := config.Pipeline.Defaults.Permissions
@@ -240,7 +306,7 @@ func compile(config profileConfig, digest string, location string) (Profiles, er
 	}
 
 	// Compile pipeline profiles
-	pipelineProfiles := compilePipelineProfiles(config.Pipeline.Profiles, pipelineDefaults)
+	pipelineProfiles := compilePipelineProfiles(config.Pipeline.Profiles, pipelineDefaults, usableApp)
 
 	// Create and return Profiles
 	return NewProfiles(orgProfiles, pipelineProfiles, digest, location), nil

--- a/internal/profile/compilation.go
+++ b/internal/profile/compilation.go
@@ -21,18 +21,181 @@ const (
 	LiteralDeprecatedWildcard = "*"
 )
 
-// resolveRepositoryScope converts a raw repositories list into a typed RepositoryScope.
-// This is called after validation, so the input is known to be well-formed.
-func resolveRepositoryScope(repos []string) RepositoryScope {
-	if len(repos) == 1 {
-		switch repos[0] {
-		case LiteralCallerScoped:
-			return NewCallerScopedScope()
-		case LiteralAllRepositories, LiteralDeprecatedWildcard:
-			return NewWildcardScope()
-		}
+// compile transforms profileConfig into runtime Profiles. A profile naming an
+// app the registry has not authorised is compiled as invalid rather than
+// failing the whole load.
+func compile(config profileConfig, digest string, location string, usableApp AppLookup) (Profiles, error) {
+	orgProfiles := compileOrganizationProfiles(config.Organization.Profiles, usableApp)
+
+	pipelineDefaults := config.Pipeline.Defaults.Permissions
+	if len(pipelineDefaults) == 0 {
+		pipelineDefaults = []string{"contents:read"}
 	}
-	return NewSpecificScope(repos...)
+
+	if err := validatePermissions(pipelineDefaults); err != nil {
+		return Profiles{}, fmt.Errorf("invalid default permissions for pipeline profiles: %w", err)
+	}
+
+	pipelineProfiles := compilePipelineProfiles(config.Pipeline.Profiles, pipelineDefaults, usableApp)
+
+	return NewProfiles(orgProfiles, pipelineProfiles, digest, location), nil
+}
+
+// compileOrganizationProfiles validates and compiles every organization
+// profile, discarding invalid ones rather than failing the whole load.
+func compileOrganizationProfiles(profiles []organizationProfile, usableApp AppLookup) ProfileStoreOf[OrganizationProfileAttr] {
+	validProfiles := make(map[string]AuthorizedProfile[OrganizationProfileAttr])
+	invalidProfiles := make(map[string]error)
+	checkDuplicate := newDuplicateNameValidator()
+	checkAppName := newAppNameValidator(usableApp)
+
+	for _, prof := range profiles {
+		compiled, err := compileOrganizationProfile(prof, checkDuplicate, checkAppName)
+		if err != nil {
+			invalidProfiles[prof.Name] = err
+			continue
+		}
+
+		validProfiles[prof.Name] = compiled
+	}
+
+	logInvalidProfiles("organization", invalidProfiles)
+
+	return NewProfileStoreOf(validProfiles, invalidProfiles)
+}
+
+// compileOrganizationProfile compiles one profile in isolation: it either
+// produces a complete AuthorizedProfile, or fails, so no attribute of the
+// result can come from a different configuration entry.
+func compileOrganizationProfile(
+	prof organizationProfile,
+	checkDuplicate duplicateNameValidator,
+	checkAppName appNameValidator,
+) (AuthorizedProfile[OrganizationProfileAttr], error) {
+	if err := checkDuplicate(prof.Name); err != nil {
+		return AuthorizedProfile[OrganizationProfileAttr]{}, err
+	}
+
+	if err := validateProfileName(prof.Name); err != nil {
+		return AuthorizedProfile[OrganizationProfileAttr]{}, err
+	}
+
+	if len(prof.Repositories) == 0 {
+		return AuthorizedProfile[OrganizationProfileAttr]{}, fmt.Errorf("repositories list must be non-empty")
+	}
+
+	if err := validateRepositories(prof.Repositories); err != nil {
+		return AuthorizedProfile[OrganizationProfileAttr]{}, fmt.Errorf("invalid repositories: %w", err)
+	}
+
+	if len(prof.Permissions) == 0 {
+		return AuthorizedProfile[OrganizationProfileAttr]{}, fmt.Errorf("permissions list must be non-empty")
+	}
+
+	if err := validatePermissions(prof.Permissions); err != nil {
+		return AuthorizedProfile[OrganizationProfileAttr]{}, fmt.Errorf("invalid permissions: %w", err)
+	}
+
+	app, err := checkAppName(prof.App)
+	if err != nil {
+		return AuthorizedProfile[OrganizationProfileAttr]{}, err
+	}
+
+	matcher, err := compileMatchRules(prof.Match)
+	if err != nil {
+		return AuthorizedProfile[OrganizationProfileAttr]{}, err
+	}
+
+	if len(prof.Repositories) == 1 && prof.Repositories[0] == LiteralDeprecatedWildcard {
+		slog.Warn("organization profile: '*' is deprecated, use '{{all-repositories}}' instead",
+			"profile", prof.Name,
+		)
+	}
+
+	attrs := OrganizationProfileAttr{
+		Scope:       resolveRepositoryScope(prof.Repositories),
+		Permissions: ensureMetadataRead(prof.Permissions),
+		App:         app,
+	}
+
+	return NewAuthorizedProfile(matcher, attrs), nil
+}
+
+// compilePipelineProfiles validates and compiles every pipeline profile, then
+// appends the synthesised "default" profile that always mints through the
+// default app.
+func compilePipelineProfiles(profiles []pipelineProfile, defaultPermissions []string, usableApp AppLookup) ProfileStoreOf[PipelineProfileAttr] {
+	validProfiles := make(map[string]AuthorizedProfile[PipelineProfileAttr])
+	invalidProfiles := make(map[string]error)
+	checkDuplicate := newDuplicateNameValidator()
+	checkAppName := newAppNameValidator(usableApp)
+
+	for _, prof := range profiles {
+		compiled, err := compilePipelineProfile(prof, checkDuplicate, checkAppName)
+		if err != nil {
+			invalidProfiles[prof.Name] = err
+			continue
+		}
+
+		validProfiles[prof.Name] = compiled
+	}
+
+	logInvalidProfiles("pipeline", invalidProfiles)
+
+	// Always the default app: it is synthesised, so there is no YAML to name
+	// one, and the reserved name prevents a declared override.
+	defaultMatcher, _ := compileMatchRules(nil) // Empty rules always succeed
+	validProfiles["default"] = NewAuthorizedProfile(defaultMatcher, PipelineProfileAttr{
+		Permissions: ensureMetadataRead(defaultPermissions),
+		App:         github.DefaultAppName,
+	})
+
+	return NewProfileStoreOf(validProfiles, invalidProfiles)
+}
+
+// compilePipelineProfile compiles one profile in isolation. As for
+// organization profiles, the result is either complete or absent.
+func compilePipelineProfile(
+	prof pipelineProfile,
+	checkDuplicate duplicateNameValidator,
+	checkAppName appNameValidator,
+) (AuthorizedProfile[PipelineProfileAttr], error) {
+	if prof.Name == "default" {
+		return AuthorizedProfile[PipelineProfileAttr]{}, fmt.Errorf("profile name %q is reserved", "default")
+	}
+
+	if err := checkDuplicate(prof.Name); err != nil {
+		return AuthorizedProfile[PipelineProfileAttr]{}, err
+	}
+
+	if err := validateProfileName(prof.Name); err != nil {
+		return AuthorizedProfile[PipelineProfileAttr]{}, err
+	}
+
+	if len(prof.Permissions) == 0 {
+		return AuthorizedProfile[PipelineProfileAttr]{}, fmt.Errorf("permissions list must be non-empty")
+	}
+
+	if err := validatePermissions(prof.Permissions); err != nil {
+		return AuthorizedProfile[PipelineProfileAttr]{}, fmt.Errorf("invalid permissions: %w", err)
+	}
+
+	app, err := checkAppName(prof.App)
+	if err != nil {
+		return AuthorizedProfile[PipelineProfileAttr]{}, err
+	}
+
+	matcher, err := compileMatchRules(prof.Match)
+	if err != nil {
+		return AuthorizedProfile[PipelineProfileAttr]{}, err
+	}
+
+	attrs := PipelineProfileAttr{
+		Permissions: ensureMetadataRead(prof.Permissions),
+		App:         app,
+	}
+
+	return NewAuthorizedProfile(matcher, attrs), nil
 }
 
 // AppLookup reports whether a profile may name this app: registered, and
@@ -66,11 +229,9 @@ func resolveProfileApp(app *string, usable AppLookup) (string, error) {
 	return *app, nil
 }
 
-// appNameValidator resolves a profile's declared app (nil meaning "default")
-// to the name its tokens mint through, or explains why it can't. It is
-// resolveProfileApp curried with the registry's usability check, so
-// compileProfile itself carries no registry-shaped dependency — only a
-// function from "declared app" to "resolved name or error".
+// appNameValidator resolves a profile's declared app to the name its tokens
+// mint through. It keeps compileOrganizationProfile/compilePipelineProfile
+// independent of registry lookups.
 type appNameValidator func(app *string) (string, error)
 
 func newAppNameValidator(usable AppLookup) appNameValidator {
@@ -79,86 +240,21 @@ func newAppNameValidator(usable AppLookup) appNameValidator {
 	}
 }
 
-// compileOrganizationProfile compiles one profile in isolation: it either
-// produces a complete AuthorizedProfile, or fails, so no attribute of the
-// result can come from a different configuration entry.
-func compileOrganizationProfile(
-	prof organizationProfile,
-	checkDuplicate duplicateNameValidator,
-	checkAppName appNameValidator,
-) (AuthorizedProfile[OrganizationProfileAttr], error) {
-	if err := checkDuplicate(prof.Name); err != nil {
-		return AuthorizedProfile[OrganizationProfileAttr]{}, err
-	}
+// duplicateNameValidator rejects a profile name already seen by an earlier
+// call, so a second entry sharing a name is rejected outright rather than
+// contributing any of its attributes to the first.
+type duplicateNameValidator func(name string) error
 
-	// Reject names that would produce an ambiguous URN
-	if err := validateProfileName(prof.Name); err != nil {
-		return AuthorizedProfile[OrganizationProfileAttr]{}, err
-	}
+func newDuplicateNameValidator() duplicateNameValidator {
+	seenNames := make(map[string]struct{})
 
-	if len(prof.Repositories) == 0 {
-		return AuthorizedProfile[OrganizationProfileAttr]{}, fmt.Errorf("repositories list must be non-empty")
-	}
-
-	if err := validateRepositories(prof.Repositories); err != nil {
-		return AuthorizedProfile[OrganizationProfileAttr]{}, fmt.Errorf("invalid repositories: %w", err)
-	}
-
-	if len(prof.Permissions) == 0 {
-		return AuthorizedProfile[OrganizationProfileAttr]{}, fmt.Errorf("permissions list must be non-empty")
-	}
-
-	if err := validatePermissions(prof.Permissions); err != nil {
-		return AuthorizedProfile[OrganizationProfileAttr]{}, fmt.Errorf("invalid permissions: %w", err)
-	}
-
-	app, err := checkAppName(prof.App)
-	if err != nil {
-		return AuthorizedProfile[OrganizationProfileAttr]{}, err
-	}
-
-	matcher, err := compileMatchRules(prof.Match)
-	if err != nil {
-		return AuthorizedProfile[OrganizationProfileAttr]{}, err
-	}
-
-	// Emit deprecation warning for "*" wildcard
-	if len(prof.Repositories) == 1 && prof.Repositories[0] == LiteralDeprecatedWildcard {
-		slog.Warn("organization profile: '*' is deprecated, use '{{all-repositories}}' instead",
-			"profile", prof.Name,
-		)
-	}
-
-	attrs := OrganizationProfileAttr{
-		Scope:       resolveRepositoryScope(prof.Repositories),
-		Permissions: ensureMetadataRead(prof.Permissions),
-		App:         app,
-	}
-
-	return NewAuthorizedProfile(matcher, attrs), nil
-}
-
-// compileOrganizationProfiles compiles organization profiles from config.
-// Returns a ProfileStoreOf containing valid and invalid profiles.
-func compileOrganizationProfiles(profiles []organizationProfile, usableApp AppLookup) ProfileStoreOf[OrganizationProfileAttr] {
-	validProfiles := make(map[string]AuthorizedProfile[OrganizationProfileAttr])
-	invalidProfiles := make(map[string]error)
-	checkDuplicate := newDuplicateNameValidator()
-	checkAppName := newAppNameValidator(usableApp)
-
-	for _, prof := range profiles {
-		compiled, err := compileOrganizationProfile(prof, checkDuplicate, checkAppName)
-		if err != nil {
-			invalidProfiles[prof.Name] = err
-			continue
+	return func(name string) error {
+		if _, exists := seenNames[name]; exists {
+			return fmt.Errorf("duplicate profile name: %q", name)
 		}
-
-		validProfiles[prof.Name] = compiled
+		seenNames[name] = struct{}{}
+		return nil
 	}
-
-	logInvalidProfiles("organization", invalidProfiles)
-
-	return NewProfileStoreOf(validProfiles, invalidProfiles)
 }
 
 // logInvalidProfiles reports the profiles that failed validation, so an
@@ -177,120 +273,55 @@ func logInvalidProfiles(kind string, invalidProfiles map[string]error) {
 		slog.Attr{Key: "invalid_profiles", Value: slog.GroupValue(attrs...)})
 }
 
-// compilePipelineProfile compiles one profile in isolation. As for
-// organization profiles, the result is either complete or absent.
-func compilePipelineProfile(
-	prof pipelineProfile,
-	checkDuplicate duplicateNameValidator,
-	checkAppName appNameValidator,
-) (AuthorizedProfile[PipelineProfileAttr], error) {
-	// Check for reserved "default" name
-	if prof.Name == "default" {
-		return AuthorizedProfile[PipelineProfileAttr]{}, fmt.Errorf("profile name %q is reserved", "default")
-	}
-
-	if err := checkDuplicate(prof.Name); err != nil {
-		return AuthorizedProfile[PipelineProfileAttr]{}, err
-	}
-
-	// Reject names that would produce an ambiguous URN
-	if err := validateProfileName(prof.Name); err != nil {
-		return AuthorizedProfile[PipelineProfileAttr]{}, err
-	}
-
-	if len(prof.Permissions) == 0 {
-		return AuthorizedProfile[PipelineProfileAttr]{}, fmt.Errorf("permissions list must be non-empty")
-	}
-
-	if err := validatePermissions(prof.Permissions); err != nil {
-		return AuthorizedProfile[PipelineProfileAttr]{}, fmt.Errorf("invalid permissions: %w", err)
-	}
-
-	app, err := checkAppName(prof.App)
-	if err != nil {
-		return AuthorizedProfile[PipelineProfileAttr]{}, err
-	}
-
-	// Compile match rules (empty rules are allowed)
-	matcher, err := compileMatchRules(prof.Match)
-	if err != nil {
-		return AuthorizedProfile[PipelineProfileAttr]{}, err
-	}
-
-	attrs := PipelineProfileAttr{
-		Permissions: ensureMetadataRead(prof.Permissions),
-		App:         app,
-	}
-
-	return NewAuthorizedProfile(matcher, attrs), nil
-}
-
-// compilePipelineProfiles compiles pipeline profiles from config.
-// Creates a "default" profile from defaultPermissions.
-// Validates that user-defined profiles don't use the reserved "default" name.
-// Returns a ProfileStoreOf containing valid and invalid profiles.
-func compilePipelineProfiles(profiles []pipelineProfile, defaultPermissions []string, usableApp AppLookup) ProfileStoreOf[PipelineProfileAttr] {
-	validProfiles := make(map[string]AuthorizedProfile[PipelineProfileAttr])
-	invalidProfiles := make(map[string]error)
-	checkDuplicate := newDuplicateNameValidator()
-	checkAppName := newAppNameValidator(usableApp)
-
-	for _, prof := range profiles {
-		compiled, err := compilePipelineProfile(prof, checkDuplicate, checkAppName)
-		if err != nil {
-			invalidProfiles[prof.Name] = err
-			continue
+// resolveRepositoryScope converts a raw repositories list into a typed
+// RepositoryScope. Called only after validation, so the input is known to be
+// well-formed.
+func resolveRepositoryScope(repos []string) RepositoryScope {
+	if len(repos) == 1 {
+		switch repos[0] {
+		case LiteralCallerScoped:
+			return NewCallerScopedScope()
+		case LiteralAllRepositories, LiteralDeprecatedWildcard:
+			return NewWildcardScope()
 		}
-
-		validProfiles[prof.Name] = compiled
 	}
-
-	logInvalidProfiles("pipeline", invalidProfiles)
-
-	// Add "default" profile from defaultPermissions
-	// Empty match rules means it matches all pipelines
-	// Always the default app: it is synthesised, so there is no YAML to name
-	// one, and the reserved name prevents a declared override.
-	defaultMatcher, _ := compileMatchRules(nil) // Empty rules always succeed
-	validProfiles["default"] = NewAuthorizedProfile(defaultMatcher, PipelineProfileAttr{
-		Permissions: ensureMetadataRead(defaultPermissions),
-		App:         github.DefaultAppName,
-	})
-
-	return NewProfileStoreOf(validProfiles, invalidProfiles)
+	return NewSpecificScope(repos...)
 }
 
-// compile transforms profileConfig into runtime Profiles.
-// Invalid profiles are tracked in ProfileStoreOf's invalidProfiles map.
-// The digest is passed through to the returned Profiles.
-// Returns an error if the default pipeline permissions are invalid.
-//
-// Validity depends on the registry as well as the YAML: a profile naming an
-// app that usableApp rejects is compiled as invalid.
-func compile(config profileConfig, digest string, location string, usableApp AppLookup) (Profiles, error) {
-	// Compile organization profiles
-	orgProfiles := compileOrganizationProfiles(config.Organization.Profiles, usableApp)
-
-	// Extract pipeline defaults with fallback
-	pipelineDefaults := config.Pipeline.Defaults.Permissions
-	if len(pipelineDefaults) == 0 {
-		pipelineDefaults = []string{"contents:read"}
+// validateProfileName rejects profile names containing characters that would
+// produce an ambiguous profile URN: '/' is the URN path separator and ':' is
+// the ShortString type prefix separator (see ProfileRef.String/ShortString).
+func validateProfileName(name string) error {
+	if strings.ContainsAny(name, "/:") {
+		return fmt.Errorf("profile name %q must not contain '/' or ':'", name)
 	}
-
-	// Validate pipeline default permissions
-	if err := validatePermissions(pipelineDefaults); err != nil {
-		return Profiles{}, fmt.Errorf("invalid default permissions for pipeline profiles: %w", err)
-	}
-
-	// Compile pipeline profiles
-	pipelineProfiles := compilePipelineProfiles(config.Pipeline.Profiles, pipelineDefaults, usableApp)
-
-	// Create and return Profiles
-	return NewProfiles(orgProfiles, pipelineProfiles, digest, location), nil
+	return nil
 }
 
-// validatePermissions validates an array of permissions in "field:value" format.
-// Returns a combined error containing all validation failures, or nil if all are valid.
+// validateRepositories rejects a repositories list that mixes a literal
+// (e.g. {{all-repositories}}) with other entries, or names a repository with
+// an owner prefix.
+func validateRepositories(repos []string) error {
+	for _, repo := range repos {
+		switch repo {
+		case LiteralCallerScoped, LiteralAllRepositories, LiteralDeprecatedWildcard:
+			if len(repos) > 1 {
+				return fmt.Errorf("%q must be the only repository entry", repo)
+			}
+			return nil
+		}
+	}
+
+	for _, repo := range repos {
+		if strings.Contains(repo, "/") {
+			return fmt.Errorf("repository %q must not contain owner prefix", repo)
+		}
+	}
+	return nil
+}
+
+// validatePermissions checks that every permission is in "field:value"
+// format, collecting all failures into one combined error.
 func validatePermissions(permissions []string) error {
 	var errs []error
 	for _, perm := range permissions {
@@ -312,64 +343,9 @@ func ensureMetadataRead(permissions []string) []string {
 	return append(permissions, metadataRead)
 }
 
-// validateProfileName rejects profile names containing characters that would
-// produce an ambiguous profile URN. '/' is the URN path separator and ':' is
-// the ShortString type prefix separator (see ProfileRef.String/ShortString),
-// so a name containing either could not be represented or round-tripped
-// unambiguously — and a '/' in particular would inject extra segments into the
-// cache-key URN.
-func validateProfileName(name string) error {
-	if strings.ContainsAny(name, "/:") {
-		return fmt.Errorf("profile name %q must not contain '/' or ':'", name)
-	}
-	return nil
-}
-
-// validateRepositories validates that the repositories list follows the required format:
-// - If a literal ({{caller-scoped-repository}}, {{all-repositories}}, or "*") is present, it must be the only entry
-// - Repository names must not contain "/" (no owner prefix)
-func validateRepositories(repos []string) error {
-	for _, repo := range repos {
-		switch repo {
-		case LiteralCallerScoped, LiteralAllRepositories, LiteralDeprecatedWildcard:
-			if len(repos) > 1 {
-				return fmt.Errorf("%q must be the only repository entry", repo)
-			}
-			return nil
-		}
-	}
-
-	// Static repo names: check for owner prefix (slash)
-	for _, repo := range repos {
-		if strings.Contains(repo, "/") {
-			return fmt.Errorf("repository %q must not contain owner prefix", repo)
-		}
-	}
-	return nil
-}
-
-// duplicateNameValidator rejects a profile name already seen by an earlier
-// call, so a second entry sharing a name never reaches the maps a first entry
-// already populated.
-type duplicateNameValidator func(name string) error
-
-func newDuplicateNameValidator() duplicateNameValidator {
-	seenNames := make(map[string]struct{})
-
-	return func(name string) error {
-		if _, exists := seenNames[name]; exists {
-			return fmt.Errorf("duplicate profile name: %q", name)
-		}
-		seenNames[name] = struct{}{}
-		return nil
-	}
-}
-
-// validateMatchRule validates that a match rule is well-formed:
-// - Exactly one of value or valuePattern must be specified
-// - The claim must be in the allowed list
+// validateMatchRule rejects a rule that doesn't specify exactly one of
+// value/valuePattern, or names a claim outside the allowed list.
 func validateMatchRule(rule matchRule) error {
-	// Exactly one of value or valuePattern
 	if rule.Value != "" && rule.ValuePattern != "" {
 		return errors.New("exactly one of 'value' or 'valuePattern' must be specified")
 	}
@@ -377,7 +353,6 @@ func validateMatchRule(rule matchRule) error {
 		return errors.New("one of 'value' or 'valuePattern' is required")
 	}
 
-	// Validate claim name is allowed and valid
 	if !IsAllowedClaim(rule.Claim) {
 		return fmt.Errorf("claim %q is not allowed for matching", rule.Claim)
 	}
@@ -385,26 +360,23 @@ func validateMatchRule(rule matchRule) error {
 	return nil
 }
 
-// compileMatchRules compiles a list of matchRules into a single Matcher.
-// Returns an error if any rule is invalid or fails to compile.
+// compileMatchRules compiles a list of matchRules into a single Matcher,
+// failing if any rule is invalid or its pattern won't compile. An empty rule
+// list always matches.
 func compileMatchRules(rules []matchRule) (Matcher, error) {
 	matchers := make([]Matcher, 0, len(rules))
 
 	for _, rule := range rules {
-		// Validate the rule
 		if err := validateMatchRule(rule); err != nil {
 			return nil, fmt.Errorf("invalid match rule for claim %q: %w", rule.Claim, err)
 		}
 
-		// Create appropriate matcher based on rule type
 		var matcher Matcher
 		var err error
 
 		if rule.Value != "" {
-			// Exact match
 			matcher = ExactMatcher(rule.Claim, rule.Value)
 		} else {
-			// Regex match
 			matcher, err = RegexMatcher(rule.Claim, rule.ValuePattern)
 			if err != nil {
 				return nil, fmt.Errorf("failed to compile regex pattern for claim %q: %w", rule.Claim, err)
@@ -414,7 +386,6 @@ func compileMatchRules(rules []matchRule) (Matcher, error) {
 		matchers = append(matchers, matcher)
 	}
 
-	// Return composite matcher -- an empty list will always match
 	return CompositeMatcher(matchers...), nil
 }
 
@@ -431,10 +402,9 @@ var allowedClaims = map[string]bool{
 	"queue_key":     true,
 }
 
-// IsAllowedClaim checks if a claim is allowed for matching.
-// Allowed claims are standard Buildkite JWT claims or agent_tag: prefixed claims.
+// IsAllowedClaim checks if a claim is allowed for matching. Allowed claims
+// are standard Buildkite JWT claims or agent_tag: prefixed claims.
 func IsAllowedClaim(claim string) bool {
-
 	if allowedClaims[claim] {
 		return true
 	}

--- a/internal/profile/compilation_test.go
+++ b/internal/profile/compilation_test.go
@@ -243,7 +243,7 @@ func TestCompile_GracefulDegradation(t *testing.T) {
 	config, digest, err := parse(string(yamlContent))
 	require.NoError(t, err)
 
-	profiles, err := compile(config, digest, "local")
+	profiles, err := compile(config, digest, "local", DefaultAppOnly)
 	require.NoError(t, err)
 
 	// Valid profiles should be accessible
@@ -286,7 +286,7 @@ func TestCompile_DuplicateNameHandling(t *testing.T) {
 	config, digest, err := parse(string(yamlContent))
 	require.NoError(t, err)
 
-	profiles, err := compile(config, digest, "local")
+	profiles, err := compile(config, digest, "local", DefaultAppOnly)
 	require.NoError(t, err)
 	orgProfiles := profiles.orgProfiles
 
@@ -308,7 +308,7 @@ func TestCompile_EmptyListsHandling(t *testing.T) {
 	config, digest, err := parse(string(yamlContent))
 	require.NoError(t, err)
 
-	profiles, err := compile(config, digest, "local")
+	profiles, err := compile(config, digest, "local", DefaultAppOnly)
 	require.NoError(t, err)
 	orgProfiles := profiles.orgProfiles
 
@@ -340,7 +340,7 @@ func TestCompile_DigestPreservation(t *testing.T) {
 	config, digest, err := parse(string(yamlContent))
 	require.NoError(t, err)
 
-	profiles, err := compile(config, digest, "local")
+	profiles, err := compile(config, digest, "local", DefaultAppOnly)
 	require.NoError(t, err)
 
 	assert.Equal(t, digest, profiles.digest, "digest should be preserved through compilation")
@@ -354,7 +354,7 @@ func TestCompile_LocationPreservation(t *testing.T) {
 	require.NoError(t, err)
 
 	location := "github://acme/profiles/main/profiles.yaml"
-	profiles, err := compile(config, digest, location)
+	profiles, err := compile(config, digest, location, DefaultAppOnly)
 	require.NoError(t, err)
 
 	stats := profiles.Stats()
@@ -390,7 +390,7 @@ func TestCompile_PipelineDefaultsFallback(t *testing.T) {
 			config, digest, err := parse(string(yamlContent))
 			require.NoError(t, err)
 
-			profiles, err := compile(config, digest, "local")
+			profiles, err := compile(config, digest, "local", DefaultAppOnly)
 			require.NoError(t, err)
 
 			defaultProfile, err := profiles.GetPipelineProfile("default")
@@ -407,7 +407,7 @@ func TestProfileMatching_ExactMatch_Success(t *testing.T) {
 	config, digest, err := parse(string(yamlContent))
 	require.NoError(t, err)
 
-	profiles, err := compile(config, digest, "local")
+	profiles, err := compile(config, digest, "local", DefaultAppOnly)
 	require.NoError(t, err)
 
 	// Get the profile and test matching
@@ -431,7 +431,7 @@ func TestProfileMatching_ExactMatch_Failure(t *testing.T) {
 	config, digest, err := parse(string(yamlContent))
 	require.NoError(t, err)
 
-	profiles, err := compile(config, digest, "local")
+	profiles, err := compile(config, digest, "local", DefaultAppOnly)
 	require.NoError(t, err)
 
 	// Get the profile and test matching
@@ -458,7 +458,7 @@ func TestProfileMatching_RegexMatch_Success(t *testing.T) {
 	config, digest, err := parse(string(yamlContent))
 	require.NoError(t, err)
 
-	profiles, err := compile(config, digest, "local")
+	profiles, err := compile(config, digest, "local", DefaultAppOnly)
 	require.NoError(t, err)
 
 	// Get the profile and test matching
@@ -482,7 +482,7 @@ func TestProfileMatching_RegexMatch_Failure(t *testing.T) {
 	config, digest, err := parse(string(yamlContent))
 	require.NoError(t, err)
 
-	profiles, err := compile(config, digest, "local")
+	profiles, err := compile(config, digest, "local", DefaultAppOnly)
 	require.NoError(t, err)
 
 	// Get the profile and test matching
@@ -508,7 +508,7 @@ func TestProfileMatching_MultipleRules_AllPass(t *testing.T) {
 	config, digest, err := parse(string(yamlContent))
 	require.NoError(t, err)
 
-	profiles, err := compile(config, digest, "local")
+	profiles, err := compile(config, digest, "local", DefaultAppOnly)
 	require.NoError(t, err)
 
 	// Get the profile and test matching
@@ -537,7 +537,7 @@ func TestProfileMatching_MultipleRules_OneFails(t *testing.T) {
 	config, digest, err := parse(string(yamlContent))
 	require.NoError(t, err)
 
-	profiles, err := compile(config, digest, "local")
+	profiles, err := compile(config, digest, "local", DefaultAppOnly)
 	require.NoError(t, err)
 
 	// Get the profile and test matching
@@ -567,7 +567,7 @@ func TestProfileMatching_EmptyRules_AlwaysPasses(t *testing.T) {
 	config, digest, err := parse(string(yamlContent))
 	require.NoError(t, err)
 
-	profiles, err := compile(config, digest, "local")
+	profiles, err := compile(config, digest, "local", DefaultAppOnly)
 	require.NoError(t, err)
 
 	// Get the profile and test matching
@@ -605,7 +605,7 @@ func TestCompilePipelineProfiles_ReservedNameRejection(t *testing.T) {
 		},
 	}
 
-	result := compilePipelineProfiles(profiles, []string{"contents:read"})
+	result := compilePipelineProfiles(profiles, []string{"contents:read"}, DefaultAppOnly)
 
 	// "default" should be invalid
 	_, err := result.Get("default")
@@ -629,7 +629,7 @@ func TestCompilePipelineProfiles_EmptyMatchRulesPass(t *testing.T) {
 		},
 	}
 
-	result := compilePipelineProfiles(profiles, []string{"contents:read"})
+	result := compilePipelineProfiles(profiles, []string{"contents:read"}, DefaultAppOnly)
 
 	profile, err := result.Get("open-profile")
 	require.NoError(t, err)
@@ -653,7 +653,7 @@ func TestCompilePipelineProfiles_EmptyPermissionsRejection(t *testing.T) {
 		},
 	}
 
-	result := compilePipelineProfiles(profiles, []string{"contents:read"})
+	result := compilePipelineProfiles(profiles, []string{"contents:read"}, DefaultAppOnly)
 
 	// "no-permissions" should be invalid
 	_, err := result.Get("no-permissions")
@@ -683,7 +683,7 @@ func TestCompilePipelineProfiles_DuplicateNames(t *testing.T) {
 		},
 	}
 
-	result := compilePipelineProfiles(profiles, []string{"contents:read"})
+	result := compilePipelineProfiles(profiles, []string{"contents:read"}, DefaultAppOnly)
 
 	// With duplicate names, the last profile wins (second's attributes overwrite first)
 	duplicateProfile, err := result.Get("duplicate")
@@ -732,7 +732,7 @@ func TestCompilePipelineProfiles_DefaultProfileCreation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := compilePipelineProfiles(tt.profiles, tt.defaultPermissions)
+			result := compilePipelineProfiles(tt.profiles, tt.defaultPermissions, DefaultAppOnly)
 
 			// "default" profile should exist
 			defaultProfile, err := result.Get("default")
@@ -758,7 +758,7 @@ func TestCompilePipelineProfiles_WithMatchRules(t *testing.T) {
 		},
 	}
 
-	result := compilePipelineProfiles(profiles, []string{"contents:read"})
+	result := compilePipelineProfiles(profiles, []string{"contents:read"}, DefaultAppOnly)
 
 	profile, err := result.Get("specific-pipeline")
 	require.NoError(t, err)
@@ -789,7 +789,7 @@ func TestCompilePipelineProfiles_InvalidMatchRule(t *testing.T) {
 		},
 	}
 
-	result := compilePipelineProfiles(profiles, []string{"contents:read"})
+	result := compilePipelineProfiles(profiles, []string{"contents:read"}, DefaultAppOnly)
 
 	// "bad-regex-profile" should be marked invalid due to bad regex
 	_, err := result.Get("bad-regex-profile")
@@ -862,7 +862,7 @@ pipeline:
 	config, digest, err := parse(yamlContent)
 	require.NoError(t, err)
 
-	profiles, err := compile(config, digest, "local")
+	profiles, err := compile(config, digest, "local", DefaultAppOnly)
 	require.NoError(t, err)
 
 	result := profiles.orgProfiles
@@ -938,7 +938,7 @@ pipeline:
 	config, digest, err := parse(yamlContent)
 	require.NoError(t, err)
 
-	profiles, err := compile(config, digest, "local")
+	profiles, err := compile(config, digest, "local", DefaultAppOnly)
 	require.NoError(t, err)
 
 	result := profiles.orgProfiles
@@ -1015,7 +1015,7 @@ pipeline:
 	config, digest, err := parse(yamlContent)
 	require.NoError(t, err)
 
-	profiles, err := compile(config, digest, "local")
+	profiles, err := compile(config, digest, "local", DefaultAppOnly)
 	require.NoError(t, err)
 
 	result := profiles.pipelineProfiles
@@ -1067,7 +1067,7 @@ pipeline:
 	config, digest, err := parse(yamlContent)
 	require.NoError(t, err)
 
-	_, err = compile(config, digest, "local")
+	_, err = compile(config, digest, "local", DefaultAppOnly)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid default permissions")
 	assert.Contains(t, err.Error(), "invalid permission field")
@@ -1164,7 +1164,7 @@ func TestCompilePipelineProfiles_MetadataReadAutoAdded(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := compilePipelineProfiles(tt.profiles, tt.defaultPermissions)
+			result := compilePipelineProfiles(tt.profiles, tt.defaultPermissions, DefaultAppOnly)
 
 			profile, err := result.Get(tt.profileName)
 			require.NoError(t, err)
@@ -1220,7 +1220,7 @@ func TestCompileOrganizationProfiles_MetadataReadAutoAdded(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := compileOrganizationProfiles(tt.profiles)
+			result := compileOrganizationProfiles(tt.profiles, DefaultAppOnly)
 
 			profile, err := result.Get(tt.profileName)
 			require.NoError(t, err)
@@ -1250,7 +1250,7 @@ pipeline:
 	config, digest, err := parse(yamlContent)
 	require.NoError(t, err)
 
-	profiles, err := compile(config, digest, "local")
+	profiles, err := compile(config, digest, "local", DefaultAppOnly)
 	require.NoError(t, err)
 
 	p, err := profiles.GetOrgProfile("scoped-profile")
@@ -1276,7 +1276,7 @@ pipeline:
 	config, digest, err := parse(yamlContent)
 	require.NoError(t, err)
 
-	profiles, err := compile(config, digest, "local")
+	profiles, err := compile(config, digest, "local", DefaultAppOnly)
 	require.NoError(t, err)
 
 	p, err := profiles.GetOrgProfile("all-repos-profile")
@@ -1329,7 +1329,7 @@ pipeline:
 			config, digest, err := parse(yamlContent)
 			require.NoError(t, err)
 
-			profiles, err := compile(config, digest, "local")
+			profiles, err := compile(config, digest, "local", DefaultAppOnly)
 			require.NoError(t, err)
 
 			_, err = profiles.GetOrgProfile(tt.profileName)
@@ -1358,7 +1358,7 @@ pipeline:
 	config, digest, err := parse(yamlContent)
 	require.NoError(t, err)
 
-	profiles, err := compile(config, digest, "local")
+	profiles, err := compile(config, digest, "local", DefaultAppOnly)
 	require.NoError(t, err)
 
 	p, err := profiles.GetOrgProfile("old-wildcard")
@@ -1398,7 +1398,7 @@ pipeline:
 			config, digest, err := parse(yamlContent)
 			require.NoError(t, err)
 
-			profiles, err := compile(config, digest, "local")
+			profiles, err := compile(config, digest, "local", DefaultAppOnly)
 			require.NoError(t, err)
 
 			_, err = profiles.GetOrgProfile(tt.profileName)
@@ -1423,7 +1423,7 @@ pipeline:
 	config, digest, err := parse(yamlContent)
 	require.NoError(t, err)
 
-	profiles, err := compile(config, digest, "local")
+	profiles, err := compile(config, digest, "local", DefaultAppOnly)
 	require.NoError(t, err)
 
 	_, err = profiles.GetPipelineProfile("team/deploy")

--- a/internal/profile/compilation_test.go
+++ b/internal/profile/compilation_test.go
@@ -279,7 +279,12 @@ func TestCompile_GracefulDegradation(t *testing.T) {
 	assert.Equal(t, "invalid-regex-pattern", unavailErr.Name)
 }
 
-func TestCompile_DuplicateNameHandling(t *testing.T) {
+// A duplicate name is served entirely from the first entry that claimed it: no
+// attribute may be taken from the rejected later entry. Compilation used to
+// build the matcher and app from the accepted entry but the scope and
+// permissions from whichever entry was visited last, splicing two different
+// YAML entries into one served profile.
+func TestCompile_DuplicateNameServesTheFirstEntryOnly(t *testing.T) {
 	yamlContent, err := os.ReadFile("testdata/profile/profile_with_duplicate_names.yaml")
 	require.NoError(t, err)
 
@@ -290,11 +295,22 @@ func TestCompile_DuplicateNameHandling(t *testing.T) {
 	require.NoError(t, err)
 	orgProfiles := profiles.orgProfiles
 
-	// With duplicate names, the last profile with that name wins in the current implementation
-	// (first is validated, but second's attributes overwrite in the profile map)
 	profile, err := orgProfiles.Get("production")
 	require.NoError(t, err)
-	assert.Equal(t, NewSpecificScope("cotton"), profile.Attrs.Scope)
+	assert.Equal(t, OrganizationProfileAttr{
+		Scope:       NewSpecificScope("silk"),
+		Permissions: []string{"contents:write", "metadata:read"},
+		App:         "default",
+	}, profile.Attrs)
+
+	// The matcher is the first entry's too: the second entry's claim value must
+	// not authorize this profile.
+	assert.True(t, profile.Match(mapClaimLookup{"pipeline_slug": "silk-prod"}).Matched)
+	assert.False(t, profile.Match(mapClaimLookup{"pipeline_slug": "cotton-prod"}).Matched)
+
+	// The rejected entry is recorded as invalid, with the reason.
+	assert.Equal(t, 1, orgProfiles.InvalidProfileCount())
+	assert.ErrorContains(t, orgProfiles.invalidProfiles["production"], `duplicate profile name: "production"`)
 
 	// "staging" should also be accessible
 	_, err = orgProfiles.Get("staging")
@@ -667,15 +683,21 @@ func TestCompilePipelineProfiles_EmptyPermissionsRejection(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// As for organization profiles, the first entry to claim a name is the one
+// served in full: the rejected duplicate contributes no attribute.
 func TestCompilePipelineProfiles_DuplicateNames(t *testing.T) {
+	app := "packages"
 	profiles := []pipelineProfile{
 		{
 			Name:        "duplicate",
 			Permissions: []string{"contents:read"},
+			Match:       []matchRule{{Claim: "pipeline_slug", Value: "silk"}},
 		},
 		{
 			Name:        "duplicate",
 			Permissions: []string{"pull_requests:write"},
+			App:         &app,
+			Match:       []matchRule{{Claim: "pipeline_slug", Value: "cotton"}},
 		},
 		{
 			Name:        "unique",
@@ -683,15 +705,21 @@ func TestCompilePipelineProfiles_DuplicateNames(t *testing.T) {
 		},
 	}
 
-	result := compilePipelineProfiles(profiles, []string{"contents:read"}, DefaultAppOnly)
+	result := compilePipelineProfiles(profiles, []string{"contents:read"}, usableApps(app))
 
-	// With duplicate names, the last profile wins (second's attributes overwrite first)
 	duplicateProfile, err := result.Get("duplicate")
 	require.NoError(t, err)
-	assert.Equal(t, []string{"pull_requests:write", "metadata:read"}, duplicateProfile.Attrs.Permissions)
+	assert.Equal(t, PipelineProfileAttr{
+		Permissions: []string{"contents:read", "metadata:read"},
+		App:         "default",
+	}, duplicateProfile.Attrs)
+
+	assert.True(t, duplicateProfile.Match(mapClaimLookup{"pipeline_slug": "silk"}).Matched)
+	assert.False(t, duplicateProfile.Match(mapClaimLookup{"pipeline_slug": "cotton"}).Matched)
 
 	// Second duplicate was rejected, verify invalid count
 	assert.Equal(t, 1, result.InvalidProfileCount(), "second duplicate should be marked invalid")
+	assert.ErrorContains(t, result.invalidProfiles["duplicate"], `duplicate profile name: "duplicate"`)
 
 	// "unique" should be accessible
 	_, err = result.Get("unique")

--- a/internal/profile/compilationapp_test.go
+++ b/internal/profile/compilationapp_test.go
@@ -1,0 +1,239 @@
+package profile
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// usableApps builds a lookup over a fixed set of enabled app names, plus the
+// default. It stands in for the registry: compilation only ever asks "may a
+// profile name this?", and the registry answers no for an unknown app and a
+// disabled one alike.
+func usableApps(names ...string) AppLookup {
+	usable := map[string]struct{}{"default": {}}
+	for _, name := range names {
+		usable[name] = struct{}{}
+	}
+
+	return func(name string) bool {
+		_, found := usable[name]
+		return found
+	}
+}
+
+func compileYAML(t *testing.T, yamlContent string, usableApp AppLookup) Profiles {
+	t.Helper()
+
+	config, digest, err := parse(yamlContent)
+	require.NoError(t, err)
+
+	profiles, err := compile(config, digest, "local", usableApp)
+	require.NoError(t, err)
+
+	return profiles
+}
+
+// An omitted app and an explicit `app: default` must be indistinguishable
+// downstream: normalising in compilation rather than at the request boundary
+// is what makes identical behaviour produce identical audit attribution.
+func TestCompile_AppNormalization(t *testing.T) {
+	tests := []struct {
+		name     string
+		app      string
+		expected string
+	}{
+		{name: "omitted resolves to the default app", app: "", expected: "default"},
+		{name: "explicit default is accepted", app: "\n      app: default", expected: "default"},
+		{name: "an enabled registry app is accepted", app: "\n      app: packages", expected: "packages"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			profiles := compileYAML(t, `
+organization:
+  profiles:
+    - name: publish`+tt.app+`
+      repositories: ["silk"]
+      permissions: ["contents:read"]
+pipeline:
+  profiles:
+    - name: build`+tt.app+`
+      permissions: ["contents:read"]
+`, usableApps("packages"))
+
+			org, err := profiles.GetOrgProfile("publish")
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, org.Attrs.App)
+
+			pipeline, err := profiles.GetPipelineProfile("build")
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, pipeline.Attrs.App)
+		})
+	}
+}
+
+// The two spellings must compile to equal attributes, not merely to equal app
+// names: anything that distinguishes them is something a downstream stage can
+// accidentally act on.
+func TestCompile_OmittedAndExplicitDefaultProduceEqualAttributes(t *testing.T) {
+	omitted := compileYAML(t, `
+organization:
+  profiles:
+    - name: publish
+      repositories: ["silk"]
+      permissions: ["contents:read"]
+pipeline:
+  profiles:
+    - name: build
+      permissions: ["contents:read"]
+`, DefaultAppOnly)
+
+	explicit := compileYAML(t, `
+organization:
+  profiles:
+    - name: publish
+      app: default
+      repositories: ["silk"]
+      permissions: ["contents:read"]
+pipeline:
+  profiles:
+    - name: build
+      app: default
+      permissions: ["contents:read"]
+`, DefaultAppOnly)
+
+	omittedOrg, err := omitted.GetOrgProfile("publish")
+	require.NoError(t, err)
+	explicitOrg, err := explicit.GetOrgProfile("publish")
+	require.NoError(t, err)
+	assert.Equal(t, omittedOrg.Attrs, explicitOrg.Attrs)
+
+	omittedPipeline, err := omitted.GetPipelineProfile("build")
+	require.NoError(t, err)
+	explicitPipeline, err := explicit.GetPipelineProfile("build")
+	require.NoError(t, err)
+	assert.Equal(t, omittedPipeline.Attrs, explicitPipeline.Attrs)
+}
+
+// A profile naming an unusable app is invalid, and only that profile is: the
+// isolation is the point, since one operator error must not withdraw every
+// other profile in the configuration.
+func TestCompile_RejectsUnusableApp(t *testing.T) {
+	tests := []struct {
+		name        string
+		app         string
+		expectedErr string
+	}{
+		{
+			name:        "empty app names nothing",
+			app:         `app: ""`,
+			expectedErr: "app must not be empty",
+		},
+		{
+			name:        "unknown app is not in the registry",
+			app:         `app: nonexistent`,
+			expectedErr: `app "nonexistent" is not a configured, enabled application`,
+		},
+		{
+			// A disabled app is indistinguishable from an absent one by
+			// design: the registry does not expose enabled state to callers.
+			name:        "disabled app is not resolvable",
+			app:         `app: disabled-packages`,
+			expectedErr: `app "disabled-packages" is not a configured, enabled application`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			profiles := compileYAML(t, `
+organization:
+  profiles:
+    - name: broken
+      `+tt.app+`
+      repositories: ["silk"]
+      permissions: ["contents:read"]
+    - name: healthy
+      app: packages
+      repositories: ["cotton"]
+      permissions: ["contents:read"]
+pipeline:
+  profiles:
+    - name: broken-pipeline
+      `+tt.app+`
+      permissions: ["contents:read"]
+    - name: healthy-pipeline
+      permissions: ["contents:read"]
+`, usableApps("packages"))
+
+			_, err := profiles.GetOrgProfile("broken")
+			var unavailable ProfileUnavailableError
+			require.ErrorAs(t, err, &unavailable)
+			assert.ErrorContains(t, err, tt.expectedErr)
+
+			_, err = profiles.GetPipelineProfile("broken-pipeline")
+			require.ErrorAs(t, err, &unavailable)
+			assert.ErrorContains(t, err, tt.expectedErr)
+
+			// Isolation: an unrelated profile in the same configuration is
+			// unaffected.
+			healthy, err := profiles.GetOrgProfile("healthy")
+			require.NoError(t, err)
+			assert.Equal(t, "packages", healthy.Attrs.App)
+
+			healthyPipeline, err := profiles.GetPipelineProfile("healthy-pipeline")
+			require.NoError(t, err)
+			assert.Equal(t, "default", healthyPipeline.Attrs.App)
+		})
+	}
+}
+
+// The default pipeline profile is synthesised rather than declared, so it has
+// no YAML to carry an app property and always mints through the default app.
+func TestCompile_DefaultPipelineProfileUsesTheDefaultApp(t *testing.T) {
+	profiles := compileYAML(t, `
+pipeline:
+  defaults:
+    permissions: ["contents:read"]
+  profiles:
+    - name: build
+      app: packages
+      permissions: ["packages:write"]
+`, usableApps("packages"))
+
+	defaultProfile, err := profiles.GetPipelineProfile("default")
+	require.NoError(t, err)
+	assert.Equal(t, "default", defaultProfile.Attrs.App)
+
+	// The reserved name is what prevents the YAML redefining it with an app.
+	reserved := compileYAML(t, `
+pipeline:
+  profiles:
+    - name: default
+      app: packages
+      permissions: ["packages:write"]
+`, usableApps("packages"))
+
+	stillDefault, err := reserved.GetPipelineProfile("default")
+	require.NoError(t, err)
+	assert.Equal(t, "default", stillDefault.Attrs.App)
+	assert.Equal(t, []string{"contents:read", "metadata:read"}, stillDefault.Attrs.Permissions)
+}
+
+// The default app is usable without any registry, so an existing deployment's
+// profiles compile exactly as they did before this feature existed.
+func TestCompile_DefaultAppIsUsableWithoutARegistry(t *testing.T) {
+	profiles := compileYAML(t, `
+organization:
+  profiles:
+    - name: publish
+      app: default
+      repositories: ["silk"]
+      permissions: ["contents:read"]
+`, DefaultAppOnly)
+
+	org, err := profiles.GetOrgProfile("publish")
+	require.NoError(t, err)
+	assert.Equal(t, "default", org.Attrs.App)
+}

--- a/internal/profile/compilationapp_test.go
+++ b/internal/profile/compilationapp_test.go
@@ -8,9 +8,7 @@ import (
 )
 
 // usableApps builds a lookup over a fixed set of enabled app names, plus the
-// default. It stands in for the registry: compilation only ever asks "may a
-// profile name this?", and the registry answers no for an unknown app and a
-// disabled one alike.
+// default. The registry answers no for an unknown app and a disabled one alike.
 func usableApps(names ...string) AppLookup {
 	usable := map[string]struct{}{"default": {}}
 	for _, name := range names {
@@ -36,8 +34,7 @@ func compileYAML(t *testing.T, yamlContent string, usableApp AppLookup) Profiles
 }
 
 // An omitted app and an explicit `app: default` must be indistinguishable
-// downstream: normalising in compilation rather than at the request boundary
-// is what makes identical behaviour produce identical audit attribution.
+// downstream, so compilation normalises rather than the request boundary.
 func TestCompile_AppNormalization(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -74,9 +71,8 @@ pipeline:
 	}
 }
 
-// The two spellings must compile to equal attributes, not merely to equal app
-// names: anything that distinguishes them is something a downstream stage can
-// accidentally act on.
+// Equality is asserted over the whole attribute set, not just the app name:
+// any remaining difference is something a downstream stage can act on.
 func TestCompile_OmittedAndExplicitDefaultProduceEqualAttributes(t *testing.T) {
 	omitted := compileYAML(t, `
 organization:
@@ -117,9 +113,8 @@ pipeline:
 	assert.Equal(t, omittedPipeline.Attrs, explicitPipeline.Attrs)
 }
 
-// A profile naming an unusable app is invalid, and only that profile is: the
-// isolation is the point, since one operator error must not withdraw every
-// other profile in the configuration.
+// A profile naming an unusable app is invalid, and only that profile is: one
+// operator error must not withdraw every other profile in the configuration.
 func TestCompile_RejectsUnusableApp(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -137,8 +132,6 @@ func TestCompile_RejectsUnusableApp(t *testing.T) {
 			expectedErr: `app "nonexistent" is not a configured, enabled application`,
 		},
 		{
-			// A disabled app is indistinguishable from an absent one by
-			// design: the registry does not expose enabled state to callers.
 			name:        "disabled app is not resolvable",
 			app:         `app: disabled-packages`,
 			expectedErr: `app "disabled-packages" is not a configured, enabled application`,
@@ -176,8 +169,6 @@ pipeline:
 			require.ErrorAs(t, err, &unavailable)
 			assert.ErrorContains(t, err, tt.expectedErr)
 
-			// Isolation: an unrelated profile in the same configuration is
-			// unaffected.
 			healthy, err := profiles.GetOrgProfile("healthy")
 			require.NoError(t, err)
 			assert.Equal(t, "packages", healthy.Attrs.App)
@@ -189,8 +180,8 @@ pipeline:
 	}
 }
 
-// The default pipeline profile is synthesised rather than declared, so it has
-// no YAML to carry an app property and always mints through the default app.
+// The default pipeline profile is synthesised, so it has no YAML to carry an
+// app property and always mints through the default app.
 func TestCompile_DefaultPipelineProfileUsesTheDefaultApp(t *testing.T) {
 	profiles := compileYAML(t, `
 pipeline:
@@ -206,7 +197,7 @@ pipeline:
 	require.NoError(t, err)
 	assert.Equal(t, "default", defaultProfile.Attrs.App)
 
-	// The reserved name is what prevents the YAML redefining it with an app.
+	// The reserved name prevents the YAML redefining it with an app.
 	reserved := compileYAML(t, `
 pipeline:
   profiles:
@@ -221,8 +212,6 @@ pipeline:
 	assert.Equal(t, []string{"contents:read", "metadata:read"}, stillDefault.Attrs.Permissions)
 }
 
-// The default app is usable without any registry, so an existing deployment's
-// profiles compile exactly as they did before this feature existed.
 func TestCompile_DefaultAppIsUsableWithoutARegistry(t *testing.T) {
 	profiles := compileYAML(t, `
 organization:

--- a/internal/profile/config.go
+++ b/internal/profile/config.go
@@ -53,12 +53,22 @@ type organizationProfile struct {
 	Match        []matchRule `yaml:"match"`
 	Repositories []string    `yaml:"repositories"`
 	Permissions  []string    `yaml:"permissions"`
+
+	// App names the GitHub App this profile's tokens are minted through. A
+	// pointer distinguishes an omitted property from an explicitly empty one:
+	// omitted means the default app, while `app: ""` names nothing and is a
+	// mistake worth reporting rather than silently reading as the default.
+	App *string `yaml:"app"`
 }
 
 type pipelineProfile struct {
 	Name        string      `yaml:"name"`
 	Match       []matchRule `yaml:"match"`
 	Permissions []string    `yaml:"permissions"`
+
+	// App names the GitHub App this profile's tokens are minted through. See
+	// organizationProfile.App for why this is a pointer.
+	App *string `yaml:"app"`
 }
 
 type matchRule struct {

--- a/internal/profile/config.go
+++ b/internal/profile/config.go
@@ -54,10 +54,9 @@ type organizationProfile struct {
 	Repositories []string    `yaml:"repositories"`
 	Permissions  []string    `yaml:"permissions"`
 
-	// App names the GitHub App this profile's tokens are minted through. A
-	// pointer distinguishes an omitted property from an explicitly empty one:
-	// omitted means the default app, while `app: ""` names nothing and is a
-	// mistake worth reporting rather than silently reading as the default.
+	// App names the GitHub App this profile's tokens are minted through. The
+	// pointer separates an omitted property, meaning the default app, from
+	// `app: ""`, which is reported as a mistake rather than read as the default.
 	App *string `yaml:"app"`
 }
 
@@ -66,8 +65,8 @@ type pipelineProfile struct {
 	Match       []matchRule `yaml:"match"`
 	Permissions []string    `yaml:"permissions"`
 
-	// App names the GitHub App this profile's tokens are minted through. See
-	// organizationProfile.App for why this is a pointer.
+	// App names the GitHub App this profile's tokens are minted through.
+	// Pointer for the reason given on organizationProfile.App.
 	App *string `yaml:"app"`
 }
 
@@ -102,14 +101,10 @@ func (e ProfileUnavailableError) Status() (int, string) {
 	return http.StatusNotFound, "profile unavailable: validation failed"
 }
 
-// AppUnresolvedError indicates a profile was resolved but the GitHub App it
-// names could not be resolved in the registry.
-//
-// This is a 500 rather than a 403 or 404: reaching it means compilation should
-// already have invalidated the profile, so it describes a defect in this
-// service rather than a denial by GitHub or a name the caller got wrong. It is
-// also the guard that stops a warm cache entry being served after its app is
-// disabled, so it must never be softened into a success.
+// AppUnresolvedError indicates a profile names a GitHub App that the registry
+// cannot resolve. It is a 500 because compilation should already have
+// invalidated such a profile; it also stops a warm cache entry being served
+// after its app is disabled, so it must not be softened into a success.
 type AppUnresolvedError struct {
 	ProfileName string
 	AppName     string

--- a/internal/profile/config.go
+++ b/internal/profile/config.go
@@ -102,6 +102,27 @@ func (e ProfileUnavailableError) Status() (int, string) {
 	return http.StatusNotFound, "profile unavailable: validation failed"
 }
 
+// AppUnresolvedError indicates a profile was resolved but the GitHub App it
+// names could not be resolved in the registry.
+//
+// This is a 500 rather than a 403 or 404: reaching it means compilation should
+// already have invalidated the profile, so it describes a defect in this
+// service rather than a denial by GitHub or a name the caller got wrong. It is
+// also the guard that stops a warm cache entry being served after its app is
+// disabled, so it must never be softened into a success.
+type AppUnresolvedError struct {
+	ProfileName string
+	AppName     string
+}
+
+func (e AppUnresolvedError) Error() string {
+	return fmt.Sprintf("profile %q names app %q, which could not be resolved", e.ProfileName, e.AppName)
+}
+
+func (e AppUnresolvedError) Status() (int, string) {
+	return http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError)
+}
+
 // ProfileNotFoundError indicates a profile was not found in the store
 type ProfileNotFoundError struct {
 	Name string

--- a/internal/profile/daemon.go
+++ b/internal/profile/daemon.go
@@ -21,21 +21,28 @@ const (
 
 // RefreshTask keeps the store's profile generation current. Callers gate
 // startup on its first success.
-func RefreshTask(profileStore *ProfileStore, gh GitHubClient, orgProfileLocation string) repeat.Task {
+//
+// usableApp is threaded through to compilation on every refresh, not applied
+// once at startup: a profile's validity depends on the app registry as well as
+// the YAML, and the digest reflects only the YAML. Without this, a profile
+// naming a registry app would be valid for one refresh interval and invalid
+// after it, with an unchanged digest — so the generation swap would log at
+// debug level while profiles silently became unavailable.
+func RefreshTask(profileStore *ProfileStore, gh GitHubClient, orgProfileLocation string, usableApp AppLookup) repeat.Task {
 	return repeat.Task{
 		Name:          "organization profile refresh",
 		Attrs:         []any{"location", orgProfileLocation},
 		FirstInterval: firstLoadRetryInterval,
 		Interval:      refreshInterval,
 		Action: func(ctx context.Context) error {
-			return refresh(ctx, profileStore, gh, orgProfileLocation)
+			return refresh(ctx, profileStore, gh, orgProfileLocation, usableApp)
 		},
 	}
 }
 
 // refresh loads one generation. Failures, including a recovered panic, are
 // returned rather than logged: the span records them, and the task logs them.
-func refresh(ctx context.Context, profileStore *ProfileStore, gh GitHubClient, orgProfileLocation string) (err error) {
+func refresh(ctx context.Context, profileStore *ProfileStore, gh GitHubClient, orgProfileLocation string, usableApp AppLookup) (err error) {
 	tracer := otel.Tracer("github.com/chinmina/chinmina-bridge/internal/profile")
 	ctx, span := tracer.Start(ctx, "refresh_organization_profile")
 	defer span.End()
@@ -48,7 +55,7 @@ func refresh(ctx context.Context, profileStore *ProfileStore, gh GitHubClient, o
 		}
 	}()
 
-	profiles, err := FetchOrganizationProfile(ctx, orgProfileLocation, gh)
+	profiles, err := FetchOrganizationProfile(ctx, orgProfileLocation, gh, usableApp)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "profile refresh failed")

--- a/internal/profile/daemon.go
+++ b/internal/profile/daemon.go
@@ -22,12 +22,9 @@ const (
 // RefreshTask keeps the store's profile generation current. Callers gate
 // startup on its first success.
 //
-// usableApp is threaded through to compilation on every refresh, not applied
-// once at startup: a profile's validity depends on the app registry as well as
-// the YAML, and the digest reflects only the YAML. Without this, a profile
-// naming a registry app would be valid for one refresh interval and invalid
-// after it, with an unchanged digest — so the generation swap would log at
-// debug level while profiles silently became unavailable.
+// usableApp is applied at every refresh, not once at startup: profile validity
+// depends on the app registry as well as the YAML, and the digest covers only
+// the YAML, so a registry change would otherwise go unnoticed.
 func RefreshTask(profileStore *ProfileStore, gh GitHubClient, orgProfileLocation string, usableApp AppLookup) repeat.Task {
 	return repeat.Task{
 		Name:          "organization profile refresh",

--- a/internal/profile/daemon_test.go
+++ b/internal/profile/daemon_test.go
@@ -61,7 +61,7 @@ func TestRefresh_Success(t *testing.T) {
 	store := NewProfileStore()
 	ctx := context.Background()
 
-	err := refresh(ctx, store, gh, "acme:silk:profile.yaml")
+	err := refresh(ctx, store, gh, "acme:silk:profile.yaml", DefaultAppOnly)
 	require.NoError(t, err)
 
 	// Verify the profile was fetched and store was updated
@@ -97,7 +97,7 @@ func TestRefresh_Failure(t *testing.T) {
 			store := NewProfileStore()
 			initialDigest := store.Digest()
 
-			err := refresh(context.Background(), store, tt.gh, "acme:silk:profile.yaml")
+			err := refresh(context.Background(), store, tt.gh, "acme:silk:profile.yaml", DefaultAppOnly)
 
 			require.Error(t, err)
 			assert.Equal(t, 1, tt.gh.calls(), "fetch should have been attempted")
@@ -114,10 +114,72 @@ func TestRefreshTask_ActionLoadsAGeneration(t *testing.T) {
 
 	store := NewProfileStore()
 
-	err := RefreshTask(store, gh, "acme:silk:profile.yaml").Action(context.Background())
+	err := RefreshTask(store, gh, "acme:silk:profile.yaml", DefaultAppOnly).Action(context.Background())
 	require.NoError(t, err)
 
 	profile, _, err := store.GetOrganizationProfile("test-profile")
 	require.NoError(t, err, "the action should have loaded the generation")
 	assert.Equal(t, NewSpecificScope("silk"), profile.Attrs.Scope)
+}
+
+// Profile validity is a function of both the YAML and the app registry, but
+// only the YAML is reflected in the digest. If the background refresh path
+// compiled without the registry, a profile naming a registry app would be
+// valid for exactly one refresh interval and invalid after it — with an
+// unchanged digest, so the generation swap would log at debug level while
+// those profiles silently became unavailable.
+//
+// This is the specific failure the requirement exists to prevent, so it is
+// asserted on the refresh path rather than on compilation.
+func TestRefresh_ProfileNamingAnEnabledAppStaysValidAcrossRefreshes(t *testing.T) {
+	gh := &mockGitHubClientForDaemon{
+		yaml: `organization:
+  profiles:
+    - name: "publish-packages"
+      app: packages
+      repositories: ["silk"]
+      permissions: ["contents:read"]
+`,
+	}
+
+	store := NewProfileStore()
+	usableApp := usableApps("packages")
+
+	// Two refreshes of unchanged content: the second is the one that would
+	// have regressed, and its digest is identical to the first's.
+	require.NoError(t, RefreshTask(store, gh, "acme:silk:profile.yaml", usableApp).Action(t.Context()))
+	firstDigest := store.Digest()
+
+	require.NoError(t, RefreshTask(store, gh, "acme:silk:profile.yaml", usableApp).Action(t.Context()))
+
+	assert.Equal(t, firstDigest, store.Digest(), "the YAML is unchanged, so the digest must be too")
+
+	published, _, err := store.GetOrganizationProfile("publish-packages")
+	require.NoError(t, err, "a profile naming an enabled app must survive a refresh")
+	assert.Equal(t, "packages", published.Attrs.App)
+	assert.Equal(t, 2, gh.calls())
+}
+
+// The converse: an app disabled at startup keeps its profiles unavailable
+// across refreshes, because disabled is terminal until the process restarts.
+func TestRefresh_ProfileNamingAnUnusableAppStaysInvalidAcrossRefreshes(t *testing.T) {
+	gh := &mockGitHubClientForDaemon{
+		yaml: `organization:
+  profiles:
+    - name: "publish-packages"
+      app: packages
+      repositories: ["silk"]
+      permissions: ["contents:read"]
+`,
+	}
+
+	store := NewProfileStore()
+
+	require.NoError(t, RefreshTask(store, gh, "acme:silk:profile.yaml", DefaultAppOnly).Action(t.Context()))
+	require.NoError(t, RefreshTask(store, gh, "acme:silk:profile.yaml", DefaultAppOnly).Action(t.Context()))
+
+	_, _, err := store.GetOrganizationProfile("publish-packages")
+
+	var unavailable ProfileUnavailableError
+	require.ErrorAs(t, err, &unavailable)
 }

--- a/internal/profile/daemon_test.go
+++ b/internal/profile/daemon_test.go
@@ -122,15 +122,10 @@ func TestRefreshTask_ActionLoadsAGeneration(t *testing.T) {
 	assert.Equal(t, NewSpecificScope("silk"), profile.Attrs.Scope)
 }
 
-// Profile validity is a function of both the YAML and the app registry, but
-// only the YAML is reflected in the digest. If the background refresh path
-// compiled without the registry, a profile naming a registry app would be
-// valid for exactly one refresh interval and invalid after it — with an
-// unchanged digest, so the generation swap would log at debug level while
-// those profiles silently became unavailable.
-//
-// This is the specific failure the requirement exists to prevent, so it is
-// asserted on the refresh path rather than on compilation.
+// Profile validity depends on both the YAML and the app registry, but only the
+// YAML feeds the digest. A refresh that compiled without the registry would
+// silently invalidate app-naming profiles under an unchanged digest, so the
+// generation swap would look like a no-op.
 func TestRefresh_ProfileNamingAnEnabledAppStaysValidAcrossRefreshes(t *testing.T) {
 	gh := &mockGitHubClientForDaemon{
 		yaml: `organization:
@@ -145,8 +140,7 @@ func TestRefresh_ProfileNamingAnEnabledAppStaysValidAcrossRefreshes(t *testing.T
 	store := NewProfileStore()
 	usableApp := usableApps("packages")
 
-	// Two refreshes of unchanged content: the second is the one that would
-	// have regressed, and its digest is identical to the first's.
+	// The second refresh is the one that would regress.
 	require.NoError(t, RefreshTask(store, gh, "acme:silk:profile.yaml", usableApp).Action(t.Context()))
 	firstDigest := store.Digest()
 
@@ -160,8 +154,8 @@ func TestRefresh_ProfileNamingAnEnabledAppStaysValidAcrossRefreshes(t *testing.T
 	assert.Equal(t, 2, gh.calls())
 }
 
-// The converse: an app disabled at startup keeps its profiles unavailable
-// across refreshes, because disabled is terminal until the process restarts.
+// Unusable is terminal until the process restarts: no refresh recovers the
+// profile.
 func TestRefresh_ProfileNamingAnUnusableAppStaysInvalidAcrossRefreshes(t *testing.T) {
 	gh := &mockGitHubClientForDaemon{
 		yaml: `organization:

--- a/internal/profile/profiles.go
+++ b/internal/profile/profiles.go
@@ -14,6 +14,19 @@ import (
 type OrganizationProfileAttr struct {
 	Scope       RepositoryScope
 	Permissions []string
+
+	// App is the name of the GitHub App this profile's tokens are minted
+	// through, never a live client: attributes are pure data, so nothing here
+	// can carry a credential into a cache payload or a log line. Compilation
+	// normalises it, so a valid profile's App is never empty.
+	App string
+}
+
+// AppName is the name of the app this profile's tokens are minted through.
+// The profile resolver is the only caller: it is the one stage that reads a
+// family-specific attribute, so it is the only one constrained by this method.
+func (attr OrganizationProfileAttr) AppName() string {
+	return attr.App
 }
 
 // HasRepository checks if the given repository is included in the profile's
@@ -31,6 +44,24 @@ func (attr OrganizationProfileAttr) RepositoryScope() RepositoryScope {
 // Slice fields are expected to be treated as immutable after construction.
 type PipelineProfileAttr struct {
 	Permissions []string
+
+	// App is the name of the GitHub App this profile's tokens are minted
+	// through. See OrganizationProfileAttr.App.
+	App string
+}
+
+// AppName is the name of the app this profile's tokens are minted through.
+func (attr PipelineProfileAttr) AppName() string {
+	return attr.App
+}
+
+// AppNamed is implemented by profile attribute types that declare which app
+// their tokens are minted through. It exists so the profile resolver — the
+// only stage that reads a family-specific attribute — can resolve the name
+// once at the handler boundary, while every stage downstream reads the
+// resolved identity from the request value and stays generic.
+type AppNamed interface {
+	AppName() string
 }
 
 // --- AuthorizedProfile (uses attribute types) ---

--- a/internal/profile/profiles.go
+++ b/internal/profile/profiles.go
@@ -15,16 +15,12 @@ type OrganizationProfileAttr struct {
 	Scope       RepositoryScope
 	Permissions []string
 
-	// App is the name of the GitHub App this profile's tokens are minted
-	// through, never a live client: attributes are pure data, so nothing here
-	// can carry a credential into a cache payload or a log line. Compilation
-	// normalises it, so a valid profile's App is never empty.
+	// App is the app's name, never a live client: attributes are pure data and
+	// must not carry a credential into a cache payload or a log line.
 	App string
 }
 
 // AppName is the name of the app this profile's tokens are minted through.
-// The profile resolver is the only caller: it is the one stage that reads a
-// family-specific attribute, so it is the only one constrained by this method.
 func (attr OrganizationProfileAttr) AppName() string {
 	return attr.App
 }
@@ -45,8 +41,7 @@ func (attr OrganizationProfileAttr) RepositoryScope() RepositoryScope {
 type PipelineProfileAttr struct {
 	Permissions []string
 
-	// App is the name of the GitHub App this profile's tokens are minted
-	// through. See OrganizationProfileAttr.App.
+	// App is the app's name. See OrganizationProfileAttr.App.
 	App string
 }
 
@@ -56,10 +51,9 @@ func (attr PipelineProfileAttr) AppName() string {
 }
 
 // AppNamed is implemented by profile attribute types that declare which app
-// their tokens are minted through. It exists so the profile resolver — the
-// only stage that reads a family-specific attribute — can resolve the name
-// once at the handler boundary, while every stage downstream reads the
-// resolved identity from the request value and stays generic.
+// their tokens are minted through. Only the profile resolver reads it: it
+// resolves the name once at the handler boundary so that downstream stages
+// stay generic.
 type AppNamed interface {
 	AppName() string
 }

--- a/internal/profile/profiletest/profiletest.go
+++ b/internal/profile/profiletest/profiletest.go
@@ -23,17 +23,30 @@ func (m mockGitHubClient) GetFileContent(ctx context.Context, owner, repo, path 
 
 // CompileFromYAML parses and compiles profile YAML for tests outside the profile package.
 // Uses the existing external API via a mock GitHub client.
-func CompileFromYAML(yamlContent string) (profile.Profiles, error) {
+//
+// Profiles compile against the set of usable app names, so a test exercising
+// an `app` property supplies its own lookup. The default is a deployment with
+// no app registry: the default app is usable and nothing else is.
+func CompileFromYAML(yamlContent string, usableApp ...profile.AppLookup) (profile.Profiles, error) {
 	mock := mockGitHubClient{yaml: yamlContent}
-	return profile.FetchOrganizationProfile(context.Background(), "test:test:test.yaml", mock)
+	return profile.FetchOrganizationProfile(context.Background(), "test:test:test.yaml", mock, appLookup(usableApp))
+}
+
+// appLookup collapses the optional lookup to exactly one, so callers that do
+// not care about apps are not made to say so.
+func appLookup(supplied []profile.AppLookup) profile.AppLookup {
+	if len(supplied) > 0 {
+		return supplied[0]
+	}
+	return profile.DefaultAppOnly
 }
 
 // CreateTestProfileStore creates a ProfileStore from the provided YAML.
 // Fails the test if YAML parsing/compilation fails.
-func CreateTestProfileStore(t *testing.T, yamlContent string) *profile.ProfileStore {
+func CreateTestProfileStore(t *testing.T, yamlContent string, usableApp ...profile.AppLookup) *profile.ProfileStore {
 	t.Helper()
 
-	profiles, err := CompileFromYAML(yamlContent)
+	profiles, err := CompileFromYAML(yamlContent, usableApp...)
 	require.NoError(t, err, "failed to compile test profiles")
 
 	store := profile.NewProfileStore()

--- a/internal/profile/profiletest/profiletest.go
+++ b/internal/profile/profiletest/profiletest.go
@@ -24,16 +24,13 @@ func (m mockGitHubClient) GetFileContent(ctx context.Context, owner, repo, path 
 // CompileFromYAML parses and compiles profile YAML for tests outside the profile package.
 // Uses the existing external API via a mock GitHub client.
 //
-// Profiles compile against the set of usable app names, so a test exercising
-// an `app` property supplies its own lookup. The default is a deployment with
-// no app registry: the default app is usable and nothing else is.
+// The optional lookup defaults to a deployment with no app registry: only the
+// default app is usable.
 func CompileFromYAML(yamlContent string, usableApp ...profile.AppLookup) (profile.Profiles, error) {
 	mock := mockGitHubClient{yaml: yamlContent}
 	return profile.FetchOrganizationProfile(context.Background(), "test:test:test.yaml", mock, appLookup(usableApp))
 }
 
-// appLookup collapses the optional lookup to exactly one, so callers that do
-// not care about apps are not made to say so.
 func appLookup(supplied []profile.AppLookup) profile.AppLookup {
 	if len(supplied) > 0 {
 		return supplied[0]

--- a/internal/profile/ref.go
+++ b/internal/profile/ref.go
@@ -16,7 +16,11 @@ const (
 )
 
 const (
-	ProfileNameDefault = "default" // Default profile name
+	// ProfileNameDefault is the reserved pipeline profile name: it names the
+	// synthesised profile that always exists, so a declared profile may not
+	// claim it. Distinct from github.DefaultAppName, which happens to share
+	// the same string but names an application, not a profile.
+	ProfileNameDefault = "default"
 )
 
 // String returns the string representation of the ProfileType.

--- a/internal/profile/store.go
+++ b/internal/profile/store.go
@@ -96,21 +96,27 @@ func (p *ProfileStore) Update(ctx context.Context, profiles Profiles) {
 	oldDigest := p.profiles.Digest()
 	newDigest := profiles.Digest()
 
+	stats := profiles.Stats()
+
 	span := trace.SpanFromContext(ctx)
 	span.SetAttributes(
 		attribute.String("profile.digest_current", oldDigest),
 		attribute.String("profile.digest_updated", newDigest),
 		attribute.Bool("profile.digest_changed", oldDigest != newDigest),
+		attribute.Int("profile.organization.valid_count", stats.OrganizationProfileCount),
+		attribute.Int("profile.organization.invalid_count", stats.OrganizationInvalidProfileCount),
+		attribute.Int("profile.pipeline.valid_count", stats.PipelineProfileCount),
+		attribute.Int("profile.pipeline.invalid_count", stats.PipelineInvalidProfileCount),
 	)
 
 	// by default, only log when the source has actually changed content
 	if oldDigest != newDigest {
 		slog.Info("profiles: updated",
-			"stats", profiles.Stats(),
+			"stats", stats,
 			"previousStats", p.profiles.Stats())
 	} else {
 		slog.Debug("profiles: no changes detected",
-			"stats", profiles.Stats())
+			"stats", stats)
 	}
 
 	p.profiles = profiles

--- a/internal/profile/store.go
+++ b/internal/profile/store.go
@@ -27,9 +27,8 @@ func NewDefaultProfiles() Profiles {
 	// Create universal matcher (empty match rules always match)
 	defaultMatcher := CompositeMatcher()
 
-	// Create pipeline profiles map with only "default", which always mints
-	// through the default app: this generation exists precisely because no
-	// configuration has been loaded, so no other app can have been named.
+	// Create pipeline profiles map with only "default": no configuration has
+	// been loaded, so no app other than the default one can have been named.
 	pipelineProfiles := map[string]AuthorizedProfile[PipelineProfileAttr]{
 		"default": NewAuthorizedProfile(defaultMatcher, PipelineProfileAttr{
 			Permissions: []string{"contents:read", "metadata:read"},
@@ -122,13 +121,8 @@ func (p *ProfileStore) Update(ctx context.Context, profiles Profiles) {
 	p.profiles = profiles
 }
 
-// FetchOrganizationProfile loads organization profile configuration from GitHub.
-// This is the main entry point for production code.
-//
-// usableApp travels with the fetch rather than being captured once at startup
-// so that the background refresh path validates against the same registry the
-// synchronous path does. A profile's validity depends on both the YAML and the
-// registry, and only one of those is reflected in the digest.
+// FetchOrganizationProfile loads organization profile configuration from
+// GitHub. This is the main entry point for production code.
 func FetchOrganizationProfile(ctx context.Context, orgProfileLocation string, gh GitHubClient, usableApp AppLookup) (Profiles, error) {
 	return load(ctx, gh, orgProfileLocation, usableApp)
 }

--- a/internal/profile/store.go
+++ b/internal/profile/store.go
@@ -30,7 +30,7 @@ func NewDefaultProfiles() Profiles {
 	// Create pipeline profiles map with only "default": no configuration has
 	// been loaded, so no app other than the default one can have been named.
 	pipelineProfiles := map[string]AuthorizedProfile[PipelineProfileAttr]{
-		"default": NewAuthorizedProfile(defaultMatcher, PipelineProfileAttr{
+		ProfileNameDefault: NewAuthorizedProfile(defaultMatcher, PipelineProfileAttr{
 			Permissions: []string{"contents:read", "metadata:read"},
 			App:         github.DefaultAppName,
 		}),

--- a/internal/profile/store.go
+++ b/internal/profile/store.go
@@ -6,6 +6,7 @@ import (
 
 	"log/slog"
 
+	"github.com/chinmina/chinmina-bridge/internal/github"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -26,10 +27,13 @@ func NewDefaultProfiles() Profiles {
 	// Create universal matcher (empty match rules always match)
 	defaultMatcher := CompositeMatcher()
 
-	// Create pipeline profiles map with only "default"
+	// Create pipeline profiles map with only "default", which always mints
+	// through the default app: this generation exists precisely because no
+	// configuration has been loaded, so no other app can have been named.
 	pipelineProfiles := map[string]AuthorizedProfile[PipelineProfileAttr]{
 		"default": NewAuthorizedProfile(defaultMatcher, PipelineProfileAttr{
 			Permissions: []string{"contents:read", "metadata:read"},
+			App:         github.DefaultAppName,
 		}),
 	}
 
@@ -114,12 +118,17 @@ func (p *ProfileStore) Update(ctx context.Context, profiles Profiles) {
 
 // FetchOrganizationProfile loads organization profile configuration from GitHub.
 // This is the main entry point for production code.
-func FetchOrganizationProfile(ctx context.Context, orgProfileLocation string, gh GitHubClient) (Profiles, error) {
-	return load(ctx, gh, orgProfileLocation)
+//
+// usableApp travels with the fetch rather than being captured once at startup
+// so that the background refresh path validates against the same registry the
+// synchronous path does. A profile's validity depends on both the YAML and the
+// registry, and only one of those is reflected in the digest.
+func FetchOrganizationProfile(ctx context.Context, orgProfileLocation string, gh GitHubClient, usableApp AppLookup) (Profiles, error) {
+	return load(ctx, gh, orgProfileLocation, usableApp)
 }
 
 // load retrieves, parses, and compiles profile configuration from GitHub.
-func load(ctx context.Context, gh GitHubClient, orgProfileLocation string) (Profiles, error) {
+func load(ctx context.Context, gh GitHubClient, orgProfileLocation string, usableApp AppLookup) (Profiles, error) {
 	yamlContent, err := retrieve(ctx, gh, orgProfileLocation)
 	if err != nil {
 		return Profiles{}, err
@@ -130,7 +139,7 @@ func load(ctx context.Context, gh GitHubClient, orgProfileLocation string) (Prof
 		return Profiles{}, err
 	}
 
-	profiles, err := compile(config, digest, orgProfileLocation)
+	profiles, err := compile(config, digest, orgProfileLocation, usableApp)
 	if err != nil {
 		return Profiles{}, err
 	}

--- a/internal/profile/store_test.go
+++ b/internal/profile/store_test.go
@@ -606,9 +606,7 @@ func TestProfileStore_Update_ProfileCountSpanAttributes(t *testing.T) {
 		expected []attribute.KeyValue
 	}{
 		{
-			// two of the three organization profiles are invalid; of the
-			// pipeline profiles one is invalid, and the synthesised "default"
-			// joins the valid one
+			// pipeline valid_count includes the synthesised "default" profile
 			name:    "mixed validity",
 			fixture: "testdata/profile/profile_mixed_validity.yaml",
 			expected: []attribute.KeyValue{
@@ -619,8 +617,8 @@ func TestProfileStore_Update_ProfileCountSpanAttributes(t *testing.T) {
 			},
 		},
 		{
-			// nothing invalid: the zero counts must still be present, so a
-			// consumer can distinguish "none invalid" from "not reported"
+			// the zero counts must still be reported, so a consumer can
+			// distinguish "none invalid" from "not reported"
 			name:    "all valid",
 			fixture: "testdata/profile/valid_profile.yaml",
 			expected: []attribute.KeyValue{

--- a/internal/profile/store_test.go
+++ b/internal/profile/store_test.go
@@ -48,7 +48,7 @@ pipeline:
 		},
 	}
 
-	profiles, err := FetchOrganizationProfile(context.Background(), "acme:silk:docs/profile.yaml", gh)
+	profiles, err := FetchOrganizationProfile(context.Background(), "acme:silk:docs/profile.yaml", gh, DefaultAppOnly)
 	require.NoError(t, err)
 
 	assert.NotEmpty(t, profiles.digest)
@@ -74,10 +74,10 @@ func TestFetchOrganizationProfile_ReturnsCorrectDigest(t *testing.T) {
 	}
 
 	// Fetch the same profile twice
-	profiles1, err := FetchOrganizationProfile(context.Background(), "acme:test:profile.yaml", gh)
+	profiles1, err := FetchOrganizationProfile(context.Background(), "acme:test:profile.yaml", gh, DefaultAppOnly)
 	require.NoError(t, err)
 
-	profiles2, err := FetchOrganizationProfile(context.Background(), "acme:test:profile.yaml", gh)
+	profiles2, err := FetchOrganizationProfile(context.Background(), "acme:test:profile.yaml", gh, DefaultAppOnly)
 	require.NoError(t, err)
 
 	// Digests should be identical for same content
@@ -101,7 +101,7 @@ func TestFetchOrganizationProfile_CanBeCalledMultipleTimes(t *testing.T) {
 
 	// Call multiple times
 	for range 3 {
-		profiles, err := FetchOrganizationProfile(context.Background(), "acme:silk:profile.yaml", gh)
+		profiles, err := FetchOrganizationProfile(context.Background(), "acme:silk:profile.yaml", gh, DefaultAppOnly)
 		require.NoError(t, err)
 		assert.NotEmpty(t, profiles.digest)
 	}
@@ -112,7 +112,7 @@ func TestFetchOrganizationProfile_NonExistent(t *testing.T) {
 		err: errors.New("404 not found"),
 	}
 
-	_, err := FetchOrganizationProfile(context.Background(), "acme:silk:nonexistent.yaml", gh)
+	_, err := FetchOrganizationProfile(context.Background(), "acme:silk:nonexistent.yaml", gh, DefaultAppOnly)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "organization profile load failed")
 }
@@ -132,7 +132,7 @@ func TestProfileStore_GetOrganizationProfile_Success(t *testing.T) {
 	}
 
 	// Fetch and load profiles
-	profiles, err := FetchOrganizationProfile(context.Background(), "acme:silk:profile.yaml", gh)
+	profiles, err := FetchOrganizationProfile(context.Background(), "acme:silk:profile.yaml", gh, DefaultAppOnly)
 	require.NoError(t, err)
 
 	// Create store and update with profiles
@@ -160,7 +160,7 @@ func TestProfileStore_GetOrganizationProfile_NotFound(t *testing.T) {
 		},
 	}
 
-	profiles, err := FetchOrganizationProfile(context.Background(), "acme:silk:profile.yaml", gh)
+	profiles, err := FetchOrganizationProfile(context.Background(), "acme:silk:profile.yaml", gh, DefaultAppOnly)
 	require.NoError(t, err)
 
 	store := NewProfileStore()
@@ -189,7 +189,7 @@ func TestProfileStore_GetOrganizationProfile_Unavailable(t *testing.T) {
 		},
 	}
 
-	profiles, err := FetchOrganizationProfile(context.Background(), "acme:silk:profile.yaml", gh)
+	profiles, err := FetchOrganizationProfile(context.Background(), "acme:silk:profile.yaml", gh, DefaultAppOnly)
 	require.NoError(t, err)
 
 	store := NewProfileStore()
@@ -226,7 +226,7 @@ pipeline:
 	}
 
 	// Fetch and load profiles
-	profiles, err := FetchOrganizationProfile(context.Background(), "acme:silk:profile.yaml", gh)
+	profiles, err := FetchOrganizationProfile(context.Background(), "acme:silk:profile.yaml", gh, DefaultAppOnly)
 	require.NoError(t, err)
 
 	// Create store and update with profiles
@@ -262,7 +262,7 @@ pipeline:
 		},
 	}
 
-	profiles, err := FetchOrganizationProfile(context.Background(), "acme:silk:profile.yaml", gh)
+	profiles, err := FetchOrganizationProfile(context.Background(), "acme:silk:profile.yaml", gh, DefaultAppOnly)
 	require.NoError(t, err)
 
 	store := NewProfileStore()
@@ -290,7 +290,7 @@ func TestProfileStore_Digest(t *testing.T) {
 		},
 	}
 
-	profiles, err := FetchOrganizationProfile(context.Background(), "acme:silk:profile.yaml", gh)
+	profiles, err := FetchOrganizationProfile(context.Background(), "acme:silk:profile.yaml", gh, DefaultAppOnly)
 	require.NoError(t, err)
 
 	store := NewProfileStore()
@@ -326,13 +326,13 @@ func TestProfileStore_Digest_ChangesWithUpdate(t *testing.T) {
 	store := NewProfileStore()
 
 	// Load first version
-	profiles1, err := FetchOrganizationProfile(context.Background(), "acme:test:v1.yaml", gh)
+	profiles1, err := FetchOrganizationProfile(context.Background(), "acme:test:v1.yaml", gh, DefaultAppOnly)
 	require.NoError(t, err)
 	store.Update(t.Context(), profiles1)
 	digest1 := store.Digest()
 
 	// Update with different content
-	profiles2, err := FetchOrganizationProfile(context.Background(), "acme:test:v2.yaml", gh)
+	profiles2, err := FetchOrganizationProfile(context.Background(), "acme:test:v2.yaml", gh, DefaultAppOnly)
 	require.NoError(t, err)
 	store.Update(t.Context(), profiles2)
 	digest2 := store.Digest()
@@ -358,7 +358,7 @@ func TestProfileStore_Concurrency(t *testing.T) {
 		},
 	}
 
-	profiles, err := FetchOrganizationProfile(context.Background(), "acme:silk:profile.yaml", gh)
+	profiles, err := FetchOrganizationProfile(context.Background(), "acme:silk:profile.yaml", gh, DefaultAppOnly)
 	require.NoError(t, err)
 
 	store := NewProfileStore()
@@ -418,7 +418,7 @@ func TestProfileStore_Update_MultipleTimes(t *testing.T) {
 	store := NewProfileStore()
 
 	// Load first version
-	profiles1, err := FetchOrganizationProfile(context.Background(), "acme:test:v1.yaml", gh)
+	profiles1, err := FetchOrganizationProfile(context.Background(), "acme:test:v1.yaml", gh, DefaultAppOnly)
 	require.NoError(t, err)
 	store.Update(t.Context(), profiles1)
 
@@ -427,7 +427,7 @@ func TestProfileStore_Update_MultipleTimes(t *testing.T) {
 	assert.Equal(t, NewSpecificScope("v1"), profile1.Attrs.Scope)
 
 	// Update with second version
-	profiles2, err := FetchOrganizationProfile(context.Background(), "acme:test:v2.yaml", gh)
+	profiles2, err := FetchOrganizationProfile(context.Background(), "acme:test:v2.yaml", gh, DefaultAppOnly)
 	require.NoError(t, err)
 	store.Update(t.Context(), profiles2)
 
@@ -457,7 +457,7 @@ func TestProfileStore_Update_NoChange(t *testing.T) {
 
 	store := NewProfileStore()
 
-	profiles, err := FetchOrganizationProfile(context.Background(), "acme:test:v1.yaml", gh)
+	profiles, err := FetchOrganizationProfile(context.Background(), "acme:test:v1.yaml", gh, DefaultAppOnly)
 	require.NoError(t, err)
 
 	// First update
@@ -479,7 +479,7 @@ func TestFetchOrganizationProfile_InvalidYAML(t *testing.T) {
 		},
 	}
 
-	_, err := FetchOrganizationProfile(context.Background(), "acme:test:invalid.yaml", gh)
+	_, err := FetchOrganizationProfile(context.Background(), "acme:test:invalid.yaml", gh, DefaultAppOnly)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "profile file parsing failed")
 }
@@ -513,7 +513,7 @@ pipeline:
 	}
 
 	// Test the load function directly (via FetchOrganizationProfile)
-	profiles, err := FetchOrganizationProfile(context.Background(), "acme:config:profile.yaml", gh)
+	profiles, err := FetchOrganizationProfile(context.Background(), "acme:config:profile.yaml", gh, DefaultAppOnly)
 	require.NoError(t, err)
 
 	// Verify profiles are loaded correctly

--- a/internal/profile/store_test.go
+++ b/internal/profile/store_test.go
@@ -3,11 +3,15 @@ package profile
 import (
 	"context"
 	"errors"
+	"os"
 	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
 // mockGitHubClient implements GitHubClient for testing
@@ -576,4 +580,74 @@ func TestNewDefaultProfiles(t *testing.T) {
 	require.Error(t, err)
 	var notFoundErr ProfileNotFoundError
 	assert.ErrorAs(t, err, &notFoundErr)
+}
+
+// tracedSpanContext returns a context carrying an active recorded span, and a
+// function that ends the span and yields its attributes.
+func tracedSpanContext(t *testing.T) (context.Context, func() []attribute.KeyValue) {
+	t.Helper()
+
+	recorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	ctx, span := tp.Tracer("test").Start(t.Context(), t.Name())
+
+	return ctx, func() []attribute.KeyValue {
+		span.End()
+		spans := recorder.Ended()
+		require.Len(t, spans, 1, "expected exactly one recorded span")
+		return spans[0].Attributes()
+	}
+}
+
+func TestProfileStore_Update_ProfileCountSpanAttributes(t *testing.T) {
+	tests := []struct {
+		name     string
+		fixture  string
+		expected []attribute.KeyValue
+	}{
+		{
+			// two of the three organization profiles are invalid; of the
+			// pipeline profiles one is invalid, and the synthesised "default"
+			// joins the valid one
+			name:    "mixed validity",
+			fixture: "testdata/profile/profile_mixed_validity.yaml",
+			expected: []attribute.KeyValue{
+				attribute.Int("profile.organization.valid_count", 1),
+				attribute.Int("profile.organization.invalid_count", 2),
+				attribute.Int("profile.pipeline.valid_count", 2),
+				attribute.Int("profile.pipeline.invalid_count", 1),
+			},
+		},
+		{
+			// nothing invalid: the zero counts must still be present, so a
+			// consumer can distinguish "none invalid" from "not reported"
+			name:    "all valid",
+			fixture: "testdata/profile/valid_profile.yaml",
+			expected: []attribute.KeyValue{
+				attribute.Int("profile.organization.valid_count", 2),
+				attribute.Int("profile.organization.invalid_count", 0),
+				attribute.Int("profile.pipeline.valid_count", 1),
+				attribute.Int("profile.pipeline.invalid_count", 0),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			yamlContent, err := os.ReadFile(tt.fixture)
+			require.NoError(t, err)
+
+			gh := &mockGitHubClient{
+				files: map[string]string{"acme:test:profiles.yaml": string(yamlContent)},
+			}
+
+			profiles, err := FetchOrganizationProfile(t.Context(), "acme:test:profiles.yaml", gh, DefaultAppOnly)
+			require.NoError(t, err)
+
+			ctx, attrs := tracedSpanContext(t)
+			NewProfileStore().Update(ctx, profiles)
+
+			assert.Subset(t, attrs(), tt.expected)
+		})
+	}
 }

--- a/internal/profile/testdata/profile/profile_mixed_validity.yaml
+++ b/internal/profile/testdata/profile/profile_mixed_validity.yaml
@@ -1,0 +1,24 @@
+organization:
+  profiles:
+    - name: "org-valid"
+      repositories: ["test"]
+      permissions: ["contents:read"]
+
+    # invalid: repositories must be non-empty
+    - name: "org-empty-repositories"
+      repositories: []
+      permissions: ["contents:read"]
+
+    # invalid: permissions must be non-empty
+    - name: "org-empty-permissions"
+      repositories: ["test"]
+      permissions: []
+
+pipeline:
+  profiles:
+    - name: "pipeline-valid"
+      permissions: ["contents:read"]
+
+    # invalid: permissions must be non-empty
+    - name: "pipeline-empty-permissions"
+      permissions: []

--- a/internal/testhelpers/mockservers.go
+++ b/internal/testhelpers/mockservers.go
@@ -129,7 +129,8 @@ func SetupMockGitHubServer(t *testing.T) *MockGitHubServer {
 
 		installation := mock.installationFor(installationIDFromPath(r))
 
-		if status := effectiveStatus(mock.StatusCode, installation.StatusCode); status != http.StatusOK {
+		status := effectiveStatus(mock.StatusCode, installation.StatusCode)
+		if !isSuccess(status) {
 			w.WriteHeader(status)
 			return
 		}
@@ -145,7 +146,7 @@ func SetupMockGitHubServer(t *testing.T) *MockGitHubServer {
 			ExpiresAt: &expiryTimestamp,
 		}
 
-		WriteJSON(w, token)
+		WriteJSONStatus(w, status, token)
 	})
 
 	router.HandleFunc("GET /app/installations/{installationID}", func(w http.ResponseWriter, r *http.Request) {
@@ -155,7 +156,8 @@ func SetupMockGitHubServer(t *testing.T) *MockGitHubServer {
 		installationID := installationIDFromPath(r)
 		installation := mock.installationFor(installationID)
 
-		if status := effectiveStatus(mock.StatusCode, installation.StatusCode); status != http.StatusOK {
+		status := effectiveStatus(mock.StatusCode, installation.StatusCode)
+		if !isSuccess(status) {
 			w.WriteHeader(status)
 			return
 		}
@@ -165,7 +167,7 @@ func SetupMockGitHubServer(t *testing.T) *MockGitHubServer {
 			accountType = "Organization"
 		}
 
-		WriteJSON(w, &github.Installation{
+		WriteJSONStatus(w, status, &github.Installation{
 			ID:         &installationID,
 			TargetType: &accountType,
 			Account: &github.User{
@@ -189,6 +191,13 @@ func effectiveStatus(serverStatus, installationStatus int) int {
 		return http.StatusOK
 	}
 	return serverStatus
+}
+
+// isSuccess reports whether a configured status asks the mock to answer as
+// GitHub does on success. The whole 2xx range counts: the real API answers
+// some requests with 201, and those responses still carry a body.
+func isSuccess(status int) bool {
+	return status >= 200 && status <= 299
 }
 
 func installationIDFromPath(r *http.Request) int64 {
@@ -278,15 +287,24 @@ func (m *MockBuildkiteServer) Close() {
 	m.Server.Close()
 }
 
-// WriteJSON is a helper function that writes a JSON response.
-// It sets the Content-Type header and marshals the payload to JSON.
+// WriteJSON is a helper function that writes a JSON response with a 200
+// status. It sets the Content-Type header and marshals the payload to JSON.
 func WriteJSON(w http.ResponseWriter, payload any) {
-	w.Header().Set("Content-Type", "application/json")
+	WriteJSONStatus(w, http.StatusOK, payload)
+}
+
+// WriteJSONStatus writes a JSON response under the given status code, so a
+// mock can reproduce a success status other than 200 without dropping the
+// body that goes with it.
+func WriteJSONStatus(w http.ResponseWriter, status int, payload any) {
 	data, err := json.Marshal(payload)
 	if err != nil {
 		// In test context, this should never happen with valid test data
 		http.Error(w, fmt.Sprintf("failed to marshal JSON: %v", err), http.StatusInternalServerError)
 		return
 	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
 	_, _ = w.Write(data)
 }

--- a/internal/testhelpers/mockservers.go
+++ b/internal/testhelpers/mockservers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -13,19 +14,102 @@ import (
 	"github.com/google/go-github/v90/github"
 )
 
+// MockInstallation is the mocked response for one installation: the account it
+// belongs to, and whether querying it succeeds at all.
+//
+// The account ID is what the app registry compares on, so a test distinguishes
+// "same organization" from "different organization" purely by choosing IDs.
+// Login exists so a test can assert what was logged, not what was decided.
+type MockInstallation struct {
+	AccountID    int64
+	AccountLogin string
+
+	// StatusCode is the response status for this installation's endpoints.
+	// Zero means 200. A non-2xx here is how a test drives "this app's
+	// installation cannot be queried" for one app without affecting the rest.
+	StatusCode int
+
+	// Token overrides the token minted for this installation, so an end-to-end
+	// test can tell which app a response was minted through.
+	Token string
+}
+
 // MockGitHubServer provides a configurable mock GitHub API server for testing.
-// The request counter is atomic: tests may drive the server concurrently.
+//
+// Responses are configurable per installation so one server can serve an app
+// on the default account, an app on a different account, and an app whose
+// installation cannot be queried, in a single boot. Counters are per
+// installation as well as global, so a test can assert which installations
+// were contacted and not merely how many calls were made.
+//
+// Counters and the installation table are guarded: tests may drive the server
+// concurrently.
 type MockGitHubServer struct {
-	Server       *httptest.Server
-	Token        string    // Token to return from CreateAccessToken
-	Expiry       time.Time // Expiry time for the token
-	StatusCode   int       // HTTP status code to return (200 if not set)
-	requestCount atomic.Int64
+	Server     *httptest.Server
+	Token      string    // Token to return from CreateAccessToken
+	Expiry     time.Time // Expiry time for the token
+	StatusCode int       // HTTP status code to return (200 if not set)
+
+	// DefaultInstallation answers any installation a test has not configured
+	// explicitly, which keeps single-app tests working unchanged.
+	DefaultInstallation MockInstallation
+
+	requestCount           atomic.Int64
+	installationQueryCount atomic.Int64
+	tokenRequestCount      atomic.Int64
+
+	mu              sync.Mutex
+	installations   map[int64]MockInstallation
+	perInstallCalls map[int64]int
 }
 
 // RequestCount reports how many requests the server has received.
 func (m *MockGitHubServer) RequestCount() int {
 	return int(m.requestCount.Load())
+}
+
+// InstallationQueryCount reports how many installation lookups were made.
+// R19 is asserted on this: a deployment with no app registry configured must
+// query no installation at startup.
+func (m *MockGitHubServer) InstallationQueryCount() int {
+	return int(m.installationQueryCount.Load())
+}
+
+// TokenRequestCount reports how many installation tokens were minted.
+func (m *MockGitHubServer) TokenRequestCount() int {
+	return int(m.tokenRequestCount.Load())
+}
+
+// CallsForInstallation reports how many requests named this installation,
+// across both the query and mint endpoints.
+func (m *MockGitHubServer) CallsForInstallation(installationID int64) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return m.perInstallCalls[installationID]
+}
+
+// SetInstallation configures the response for one installation, overriding
+// DefaultInstallation for it.
+func (m *MockGitHubServer) SetInstallation(installationID int64, installation MockInstallation) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.installations[installationID] = installation
+}
+
+// installationFor returns the configured response for an installation, falling
+// back to DefaultInstallation, and records the call against it.
+func (m *MockGitHubServer) installationFor(installationID int64) MockInstallation {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.perInstallCalls[installationID]++
+
+	if installation, configured := m.installations[installationID]; configured {
+		return installation
+	}
+	return m.DefaultInstallation
 }
 
 // SetupMockGitHubServer creates a mock GitHub API server that handles token creation requests.
@@ -37,29 +121,86 @@ func SetupMockGitHubServer(t *testing.T) *MockGitHubServer {
 		Token:      "test-github-token",
 		Expiry:     time.Now().Add(1 * time.Hour),
 		StatusCode: http.StatusOK,
+		DefaultInstallation: MockInstallation{
+			AccountID:    1,
+			AccountLogin: "test-org",
+		},
+		installations:   map[int64]MockInstallation{},
+		perInstallCalls: map[int64]int{},
 	}
 
 	router := http.NewServeMux()
 
 	router.HandleFunc("/app/installations/{installationID}/access_tokens", func(w http.ResponseWriter, r *http.Request) {
 		mock.requestCount.Add(1)
+		mock.tokenRequestCount.Add(1)
 
-		if mock.StatusCode != http.StatusOK {
-			w.WriteHeader(mock.StatusCode)
+		installation := mock.installationFor(installationIDFromPath(r))
+
+		// The server-wide StatusCode remains the single-app control it has
+		// always been; a per-installation status narrows it to one app.
+		if status := effectiveStatus(mock.StatusCode, installation.StatusCode); status != http.StatusOK {
+			w.WriteHeader(status)
 			return
+		}
+
+		tokenValue := mock.Token
+		if installation.Token != "" {
+			tokenValue = installation.Token
 		}
 
 		expiryTimestamp := github.Timestamp{Time: mock.Expiry}
 		token := &github.InstallationToken{
-			Token:     &mock.Token,
+			Token:     &tokenValue,
 			ExpiresAt: &expiryTimestamp,
 		}
 
 		WriteJSON(w, token)
 	})
 
+	router.HandleFunc("GET /app/installations/{installationID}", func(w http.ResponseWriter, r *http.Request) {
+		mock.requestCount.Add(1)
+		mock.installationQueryCount.Add(1)
+
+		installationID := installationIDFromPath(r)
+		installation := mock.installationFor(installationID)
+
+		if status := effectiveStatus(mock.StatusCode, installation.StatusCode); status != http.StatusOK {
+			w.WriteHeader(status)
+			return
+		}
+
+		WriteJSON(w, &github.Installation{
+			ID: &installationID,
+			Account: &github.User{
+				ID:    &installation.AccountID,
+				Login: &installation.AccountLogin,
+			},
+		})
+	})
+
 	mock.Server = httptest.NewServer(router)
 	return mock
+}
+
+// effectiveStatus prefers a per-installation status over the server-wide one,
+// so a test can fail one app's installation while the others succeed.
+func effectiveStatus(serverStatus, installationStatus int) int {
+	if installationStatus != 0 {
+		return installationStatus
+	}
+	if serverStatus == 0 {
+		return http.StatusOK
+	}
+	return serverStatus
+}
+
+func installationIDFromPath(r *http.Request) int64 {
+	id, err := strconv.ParseInt(r.PathValue("installationID"), 10, 64)
+	if err != nil {
+		return 0
+	}
+	return id
 }
 
 // Close shuts down the mock server.

--- a/internal/testhelpers/mockservers.go
+++ b/internal/testhelpers/mockservers.go
@@ -14,36 +14,27 @@ import (
 	"github.com/google/go-github/v90/github"
 )
 
-// MockInstallation is the mocked response for one installation: the account it
-// belongs to, and whether querying it succeeds at all.
-//
-// The account ID is what the app registry compares on, so a test distinguishes
-// "same organization" from "different organization" purely by choosing IDs.
-// Login exists so a test can assert what was logged, not what was decided.
+// MockInstallation is the mocked response for one installation. The app
+// registry compares account IDs, so a test makes apps share or differ in
+// organisation purely by choosing IDs.
 type MockInstallation struct {
 	AccountID    int64
 	AccountLogin string
 
 	// StatusCode is the response status for this installation's endpoints.
-	// Zero means 200. A non-2xx here is how a test drives "this app's
-	// installation cannot be queried" for one app without affecting the rest.
+	// Zero means 200; a non-2xx fails one app's installation only.
 	StatusCode int
 
-	// Token overrides the token minted for this installation, so an end-to-end
-	// test can tell which app a response was minted through.
+	// Token overrides the token minted for this installation, so a test can
+	// attribute a response to an app.
 	Token string
 }
 
 // MockGitHubServer provides a configurable mock GitHub API server for testing.
-//
-// Responses are configurable per installation so one server can serve an app
-// on the default account, an app on a different account, and an app whose
-// installation cannot be queried, in a single boot. Counters are per
-// installation as well as global, so a test can assert which installations
-// were contacted and not merely how many calls were made.
-//
-// Counters and the installation table are guarded: tests may drive the server
-// concurrently.
+// Responses and counters are per installation as well as server-wide, so one
+// server can serve several apps and a test can assert which installations were
+// contacted. Counters and the installation table are guarded: tests may drive
+// the server concurrently.
 type MockGitHubServer struct {
 	Server     *httptest.Server
 	Token      string    // Token to return from CreateAccessToken
@@ -51,7 +42,7 @@ type MockGitHubServer struct {
 	StatusCode int       // HTTP status code to return (200 if not set)
 
 	// DefaultInstallation answers any installation a test has not configured
-	// explicitly, which keeps single-app tests working unchanged.
+	// explicitly.
 	DefaultInstallation MockInstallation
 
 	requestCount           atomic.Int64
@@ -69,8 +60,6 @@ func (m *MockGitHubServer) RequestCount() int {
 }
 
 // InstallationQueryCount reports how many installation lookups were made.
-// R19 is asserted on this: a deployment with no app registry configured must
-// query no installation at startup.
 func (m *MockGitHubServer) InstallationQueryCount() int {
 	return int(m.installationQueryCount.Load())
 }
@@ -89,8 +78,7 @@ func (m *MockGitHubServer) CallsForInstallation(installationID int64) int {
 	return m.perInstallCalls[installationID]
 }
 
-// SetInstallation configures the response for one installation, overriding
-// DefaultInstallation for it.
+// SetInstallation overrides DefaultInstallation for one installation.
 func (m *MockGitHubServer) SetInstallation(installationID int64, installation MockInstallation) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -98,8 +86,8 @@ func (m *MockGitHubServer) SetInstallation(installationID int64, installation Mo
 	m.installations[installationID] = installation
 }
 
-// installationFor returns the configured response for an installation, falling
-// back to DefaultInstallation, and records the call against it.
+// installationFor returns the configured response for an installation, or
+// DefaultInstallation, and records the call against it.
 func (m *MockGitHubServer) installationFor(installationID int64) MockInstallation {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -137,8 +125,6 @@ func SetupMockGitHubServer(t *testing.T) *MockGitHubServer {
 
 		installation := mock.installationFor(installationIDFromPath(r))
 
-		// The server-wide StatusCode remains the single-app control it has
-		// always been; a per-installation status narrows it to one app.
 		if status := effectiveStatus(mock.StatusCode, installation.StatusCode); status != http.StatusOK {
 			w.WriteHeader(status)
 			return
@@ -184,7 +170,7 @@ func SetupMockGitHubServer(t *testing.T) *MockGitHubServer {
 }
 
 // effectiveStatus prefers a per-installation status over the server-wide one,
-// so a test can fail one app's installation while the others succeed.
+// so a test can fail one app while the others succeed.
 func effectiveStatus(serverStatus, installationStatus int) int {
 	if installationStatus != 0 {
 		return installationStatus

--- a/internal/testhelpers/mockservers.go
+++ b/internal/testhelpers/mockservers.go
@@ -21,6 +21,10 @@ type MockInstallation struct {
 	AccountID    int64
 	AccountLogin string
 
+	// AccountType is the installation's target_type. Empty defaults to
+	// "Organization", the only type most tests care about.
+	AccountType string
+
 	// StatusCode is the response status for this installation's endpoints.
 	// Zero means 200; a non-2xx fails one app's installation only.
 	StatusCode int
@@ -156,8 +160,14 @@ func SetupMockGitHubServer(t *testing.T) *MockGitHubServer {
 			return
 		}
 
+		accountType := installation.AccountType
+		if accountType == "" {
+			accountType = "Organization"
+		}
+
 		WriteJSON(w, &github.Installation{
-			ID: &installationID,
+			ID:         &installationID,
+			TargetType: &accountType,
 			Account: &github.User{
 				ID:    &installation.AccountID,
 				Login: &installation.AccountLogin,

--- a/internal/testhelpers/mockservers_test.go
+++ b/internal/testhelpers/mockservers_test.go
@@ -1,0 +1,130 @@
+package testhelpers_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-github/v90/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/chinmina/chinmina-bridge/internal/testhelpers"
+)
+
+// A configured status in the 2xx range is a success: GitHub answers some
+// requests with 201, and the mock must still return the body a caller parses.
+func TestMockGitHubServerSuccessStatuses(t *testing.T) {
+	const installationID = int64(77)
+
+	tests := []struct {
+		name       string
+		statusCode int
+	}{
+		{name: "default", statusCode: 0},
+		{name: "explicit 200", statusCode: http.StatusOK},
+		{name: "created", statusCode: http.StatusCreated},
+		{name: "accepted", statusCode: http.StatusAccepted},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := testhelpers.SetupMockGitHubServer(t)
+			defer mock.Close()
+
+			mock.SetInstallation(installationID, testhelpers.MockInstallation{
+				AccountID:    42,
+				AccountLogin: "acme",
+				StatusCode:   tt.statusCode,
+				Token:        "installation-token",
+			})
+
+			expectedStatus := tt.statusCode
+			if expectedStatus == 0 {
+				expectedStatus = http.StatusOK
+			}
+
+			installationResponse := get(t, fmt.Sprintf("%s/app/installations/%d", mock.Server.URL, installationID))
+			assert.Equal(t, expectedStatus, installationResponse.status)
+
+			var installation github.Installation
+			require.NoError(t, json.Unmarshal(installationResponse.body, &installation))
+			assert.Equal(t, installationID, installation.GetID())
+			assert.Equal(t, "Organization", installation.GetTargetType())
+			assert.Equal(t, int64(42), installation.GetAccount().GetID())
+			assert.Equal(t, "acme", installation.GetAccount().GetLogin())
+
+			tokenResponse := post(t, fmt.Sprintf("%s/app/installations/%d/access_tokens", mock.Server.URL, installationID))
+			assert.Equal(t, expectedStatus, tokenResponse.status)
+
+			var token github.InstallationToken
+			require.NoError(t, json.Unmarshal(tokenResponse.body, &token))
+			assert.Equal(t, "installation-token", token.GetToken())
+		})
+	}
+}
+
+// A non-2xx status is a failure: the status is written with no body, so a
+// caller sees the error rather than a usable response.
+func TestMockGitHubServerFailureStatuses(t *testing.T) {
+	const installationID = int64(88)
+
+	tests := []struct {
+		name       string
+		statusCode int
+	}{
+		{name: "unauthorized", statusCode: http.StatusUnauthorized},
+		{name: "not found", statusCode: http.StatusNotFound},
+		{name: "server error", statusCode: http.StatusInternalServerError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := testhelpers.SetupMockGitHubServer(t)
+			defer mock.Close()
+
+			mock.SetInstallation(installationID, testhelpers.MockInstallation{StatusCode: tt.statusCode})
+
+			installationResponse := get(t, fmt.Sprintf("%s/app/installations/%d", mock.Server.URL, installationID))
+			assert.Equal(t, tt.statusCode, installationResponse.status)
+			assert.Empty(t, installationResponse.body)
+
+			tokenResponse := post(t, fmt.Sprintf("%s/app/installations/%d/access_tokens", mock.Server.URL, installationID))
+			assert.Equal(t, tt.statusCode, tokenResponse.status)
+			assert.Empty(t, tokenResponse.body)
+		})
+	}
+}
+
+type response struct {
+	status int
+	body   []byte
+}
+
+func get(t *testing.T, url string) response {
+	t.Helper()
+	return do(t, http.MethodGet, url)
+}
+
+func post(t *testing.T, url string) response {
+	t.Helper()
+	return do(t, http.MethodPost, url)
+}
+
+func do(t *testing.T, method, url string) response {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(t.Context(), method, url, http.NoBody)
+	require.NoError(t, err)
+
+	res, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = res.Body.Close() }()
+
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+
+	return response{status: res.StatusCode, body: body}
+}

--- a/internal/vendor/cached.go
+++ b/internal/vendor/cached.go
@@ -56,7 +56,14 @@ func recordOutcome(ctx context.Context, result string, appName string) {
 // minted through the previous app. Keying on the identity rather than the name
 // means two names for one application and installation share entries.
 //
-// Numeric identifiers cannot contain the separator, so the key is unambiguous.
+// The two identifiers are integers and so never contain the separator. The
+// digest can: the synthetic default-profile digest is "default-profile:v1".
+// That is still unambiguous, because the key is only ever compared, never
+// parsed, and the digest cannot absorb the fields after it — doing so would
+// require it to supply two further separator-delimited integers of its own,
+// which neither a content hash nor that fixed literal does.
+// TestCacheKeyIsUnambiguous covers the cases.
+//
 // Changing this format orphans every existing entry; nothing reaps them, they
 // expire.
 func cacheKey[T any](r Resolved[T]) string {

--- a/internal/vendor/cached.go
+++ b/internal/vendor/cached.go
@@ -34,14 +34,37 @@ func initOutcomeMetrics() {
 	})
 }
 
-func recordOutcome(ctx context.Context, result string) {
+func recordOutcome(ctx context.Context, result string, appName string) {
 	initOutcomeMetrics()
 	if tokenCacheOutcome == nil {
 		return
 	}
 	tokenCacheOutcome.Add(ctx, 1,
-		metric.WithAttributes(attribute.String("token.cache.result", result)),
+		metric.WithAttributes(
+			attribute.String("token.cache.result", result),
+			attribute.String("token.app", appName),
+		),
 	)
+}
+
+// cacheKey identifies a cached token by configuration generation, minting app
+// identity, and profile.
+//
+// The digest alone is insufficient. The YAML names an app, but the mapping
+// from that name to a credential lives in deployment configuration, so
+// repointing a name leaves the YAML — and the digest — unchanged while the
+// cache keeps serving tokens minted through the previous app. The key carries
+// the identity rather than the name, so only a repointed app's entries are
+// orphaned: two names for one application and installation share entries,
+// differing only in attribution.
+//
+// Numeric identifiers cannot contain the separator, so the key stays
+// unambiguous. This format differs from the previous one for the default app
+// too, so deploying it orphans every existing entry once: old and new formats
+// are disjoint keyspaces, each warms independently during a rolling
+// deployment, and nothing reaps the old ones — they expire.
+func cacheKey[T any](r Resolved[T]) string {
+	return fmt.Sprintf("%s:%d:%d:%s", r.Digest, r.App.ApplicationID, r.App.InstallationID, r.Ref.String())
 }
 
 // Cached supplies a vendor that caches the results of the wrapped vendor. The
@@ -59,19 +82,25 @@ func Cached[T any](tokenCache cache.TokenCache[ProfileToken]) func(ProfileTokenV
 				return NewVendorFailed(fmt.Errorf("no configuration generation resolved for profile %s", r.Ref))
 			}
 
-			key := fmt.Sprintf("%s:%s", r.Digest, r.Ref.String())
+			// An unresolved identity would key every app's entries together
+			// under zeroes, so refuse rather than assume the default app.
+			if r.App.IsZero() {
+				return NewVendorFailed(fmt.Errorf("no app identity resolved for profile %s", r.Ref))
+			}
+
+			key := cacheKey(r)
 
 			cachedToken, found, err := tokenCache.Get(ctx, key)
 			if err != nil {
 				// retrieval errors are effectively cache misses, but we record them
 				// separately to identify cache issues in production
-				recordOutcome(ctx, "error")
+				recordOutcome(ctx, "error", r.App.Name)
 				slog.Warn("cache get failed", "error", err, "key", key)
 			} else if !found {
 				// successfully found that the key is not in the cache
-				recordOutcome(ctx, "miss")
+				recordOutcome(ctx, "miss", r.App.Name)
 			} else if token, ok := checkTokenRepository(cachedToken, requestedRepository); !ok {
-				recordOutcome(ctx, "mismatch")
+				recordOutcome(ctx, "mismatch", r.App.Name)
 
 				if r.Ref.Type == profile.ProfileTypeOrg {
 					// For org profiles, a mismatch means the request is for a repo not
@@ -101,7 +130,7 @@ func Cached[T any](tokenCache cache.TokenCache[ProfileToken]) func(ProfileTokenV
 				}
 			} else {
 				// short circuit and return on a cache hit
-				recordOutcome(ctx, "hit")
+				recordOutcome(ctx, "hit", r.App.Name)
 				return NewVendorSuccess(token)
 			}
 

--- a/internal/vendor/cached.go
+++ b/internal/vendor/cached.go
@@ -50,19 +50,15 @@ func recordOutcome(ctx context.Context, result string, appName string) {
 // cacheKey identifies a cached token by configuration generation, minting app
 // identity, and profile.
 //
-// The digest alone is insufficient. The YAML names an app, but the mapping
-// from that name to a credential lives in deployment configuration, so
-// repointing a name leaves the YAML — and the digest — unchanged while the
-// cache keeps serving tokens minted through the previous app. The key carries
-// the identity rather than the name, so only a repointed app's entries are
-// orphaned: two names for one application and installation share entries,
-// differing only in attribution.
+// The identity must be in the key: the mapping from an app name to a
+// credential lives in deployment configuration, so repointing a name leaves
+// the YAML — and its digest — unchanged while the cache still holds tokens
+// minted through the previous app. Keying on the identity rather than the name
+// means two names for one application and installation share entries.
 //
-// Numeric identifiers cannot contain the separator, so the key stays
-// unambiguous. This format differs from the previous one for the default app
-// too, so deploying it orphans every existing entry once: old and new formats
-// are disjoint keyspaces, each warms independently during a rolling
-// deployment, and nothing reaps the old ones — they expire.
+// Numeric identifiers cannot contain the separator, so the key is unambiguous.
+// Changing this format orphans every existing entry; nothing reaps them, they
+// expire.
 func cacheKey[T any](r Resolved[T]) string {
 	return fmt.Sprintf("%s:%d:%d:%s", r.Digest, r.App.ApplicationID, r.App.InstallationID, r.Ref.String())
 }
@@ -82,8 +78,7 @@ func Cached[T any](tokenCache cache.TokenCache[ProfileToken]) func(ProfileTokenV
 				return NewVendorFailed(fmt.Errorf("no configuration generation resolved for profile %s", r.Ref))
 			}
 
-			// An unresolved identity would key every app's entries together
-			// under zeroes, so refuse rather than assume the default app.
+			// Refuse rather than assuming the default app.
 			if r.App.IsZero() {
 				return NewVendorFailed(fmt.Errorf("no app identity resolved for profile %s", r.Ref))
 			}

--- a/internal/vendor/cached_internal_test.go
+++ b/internal/vendor/cached_internal_test.go
@@ -3,9 +3,135 @@ package vendor
 import (
 	"testing"
 
+	"github.com/chinmina/chinmina-bridge/internal/github"
 	"github.com/chinmina/chinmina-bridge/internal/profile"
 	"github.com/stretchr/testify/require"
 )
+
+// repoRef is a profile reference for the cache key tests, where only whether
+// two references differ matters.
+func repoRef(name string) profile.ProfileRef {
+	return profile.ProfileRef{
+		Organization: "test-org",
+		Type:         profile.ProfileTypeRepo,
+		Name:         name,
+		PipelineID:   "pipeline-id",
+		PipelineSlug: "pipeline-slug",
+	}
+}
+
+// TestCacheKeyIsUnambiguous pins the property the key format depends on: two
+// requests that differ in any keyed component get different keys. The digest
+// may contain the separator, so the cases include digests shaped to look like
+// they could shift where the application and installation IDs are read — a
+// token minted through one app must never be served for another.
+func TestCacheKeyIsUnambiguous(t *testing.T) {
+	tests := []struct {
+		name     string
+		resolved Resolved[profile.PipelineProfileAttr]
+	}{
+		{
+			name: "digest free of the separator",
+			resolved: Resolved[profile.PipelineProfileAttr]{
+				Ref:    repoRef("default"),
+				Digest: "abc123",
+				App:    github.AppIdentity{Name: "default", ApplicationID: 1, InstallationID: 2},
+			},
+		},
+		{
+			name: "synthetic digest containing the separator",
+			resolved: Resolved[profile.PipelineProfileAttr]{
+				Ref:    repoRef("default"),
+				Digest: "default-profile:v1",
+				App:    github.AppIdentity{Name: "default", ApplicationID: 1, InstallationID: 2},
+			},
+		},
+		{
+			name: "digest ending in a field that reads as an ID",
+			resolved: Resolved[profile.PipelineProfileAttr]{
+				Ref:    repoRef("default"),
+				Digest: "7:8",
+				App:    github.AppIdentity{Name: "default", ApplicationID: 1, InstallationID: 2},
+			},
+		},
+		{
+			name: "same text split differently between digest and IDs",
+			resolved: Resolved[profile.PipelineProfileAttr]{
+				Ref:    repoRef("default"),
+				Digest: "7",
+				App:    github.AppIdentity{Name: "default", ApplicationID: 8, InstallationID: 1},
+			},
+		},
+		{
+			name: "IDs that concatenate to the same digits",
+			resolved: Resolved[profile.PipelineProfileAttr]{
+				Ref:    repoRef("default"),
+				Digest: "abc123",
+				App:    github.AppIdentity{Name: "other", ApplicationID: 1, InstallationID: 23},
+			},
+		},
+		{
+			name: "IDs concatenating the same digits, split differently",
+			resolved: Resolved[profile.PipelineProfileAttr]{
+				Ref:    repoRef("default"),
+				Digest: "abc123",
+				App:    github.AppIdentity{Name: "other", ApplicationID: 12, InstallationID: 3},
+			},
+		},
+		{
+			name: "different application ID",
+			resolved: Resolved[profile.PipelineProfileAttr]{
+				Ref:    repoRef("default"),
+				Digest: "abc123",
+				App:    github.AppIdentity{Name: "other", ApplicationID: 9, InstallationID: 2},
+			},
+		},
+		{
+			name: "different installation ID",
+			resolved: Resolved[profile.PipelineProfileAttr]{
+				Ref:    repoRef("default"),
+				Digest: "abc123",
+				App:    github.AppIdentity{Name: "other", ApplicationID: 1, InstallationID: 9},
+			},
+		},
+		{
+			name: "different profile",
+			resolved: Resolved[profile.PipelineProfileAttr]{
+				Ref:    repoRef("write-packages"),
+				Digest: "abc123",
+				App:    github.AppIdentity{Name: "default", ApplicationID: 1, InstallationID: 2},
+			},
+		},
+	}
+
+	seen := make(map[string]string, len(tests))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key := cacheKey(tt.resolved)
+
+			clash, found := seen[key]
+			require.False(t, found, "key %q collides with case %q", key, clash)
+
+			seen[key] = tt.name
+		})
+	}
+}
+
+// TestCacheKeyIgnoresAppName documents the deliberate consequence of keying on
+// the app identity: two registry names for one application and installation
+// are the same credential, so they share cache entries.
+func TestCacheKeyIgnoresAppName(t *testing.T) {
+	base := Resolved[profile.PipelineProfileAttr]{
+		Ref:    repoRef("default"),
+		Digest: "abc123",
+		App:    github.AppIdentity{Name: "packages", ApplicationID: 333, InstallationID: 444},
+	}
+
+	renamed := base
+	renamed.App.Name = "publishing"
+
+	require.Equal(t, cacheKey(base), cacheKey(renamed))
+}
 
 // Direct unit tests for checkTokenRepository (internal function)
 

--- a/internal/vendor/cached_test.go
+++ b/internal/vendor/cached_test.go
@@ -2,6 +2,7 @@ package vendor_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"testing"
@@ -748,6 +749,78 @@ func TestCacheAllRepositories_SameCallGetsCacheHit(t *testing.T) {
 	require.Equal(t, vendor.VendStatusSuccess, result.Status())
 	token = result.Token()
 	assert.Equal(t, "first-call", token.Token)
+}
+
+// The identifiers live in the cached payload, so a hit and a miss are
+// indistinguishable. Stripping them inside the chain would break that.
+func TestCache_AppIdentityIsPartOfTheCachedShape(t *testing.T) {
+	minted := vendor.ProfileToken{
+		Token:               "minted-token",
+		VendedRepositoryURL: "https://github.com/test-org/any-repo.git",
+		Repositories:        profile.NewSpecificScope("any-repo"),
+		Profile:             "repo:default",
+		App:                 testApp.Name,
+		ApplicationID:       testApp.ApplicationID,
+		InstallationID:      testApp.InstallationID,
+	}
+
+	calls := 0
+	wrapped := vendor.ProfileTokenVendor[cacheAttr](func(context.Context, vendor.Resolved[cacheAttr], string) vendor.VendorResult {
+		calls++
+		return vendor.NewVendorSuccess(minted)
+	})
+
+	v := newTestCached(t, defaultTTL)(wrapped)
+	ref := profile.ProfileRef{
+		Organization: "org",
+		Name:         "default",
+		Type:         profile.ProfileTypeRepo,
+		PipelineID:   "pipeline-id",
+	}
+
+	miss := v(context.Background(), cacheRequest(ref), "https://github.com/test-org/any-repo.git")
+	hit := v(context.Background(), cacheRequest(ref), "https://github.com/test-org/any-repo.git")
+
+	require.Equal(t, 1, calls, "the second call must be served from the cache")
+	assertVendorSuccess(t, miss, minted)
+	assertVendorSuccess(t, hit, minted)
+}
+
+// These keys are a storage-compatibility surface: renaming one silently drops
+// the identifiers from every entry an older deployment wrote.
+func TestCache_StorageShapeCarriesAppIdentity(t *testing.T) {
+	stored := vendor.ProfileToken{
+		Token:          "minted-token",
+		Profile:        "repo:default",
+		App:            "publisher",
+		ApplicationID:  4242,
+		InstallationID: 8484,
+	}
+
+	data, err := json.Marshal(stored)
+	require.NoError(t, err)
+
+	var keys map[string]any
+	require.NoError(t, json.Unmarshal(data, &keys))
+	assert.Equal(t, float64(4242), keys["appId"])
+	assert.Equal(t, float64(8484), keys["installationId"])
+
+	var roundTripped vendor.ProfileToken
+	require.NoError(t, json.Unmarshal(data, &roundTripped))
+	assert.Equal(t, stored, roundTripped)
+}
+
+// An entry written before the identifiers existed must read back as absent
+// keys, not as application zero.
+func TestCache_StorageShapeOmitsUnresolvedIdentifiers(t *testing.T) {
+	data, err := json.Marshal(vendor.ProfileToken{Token: "minted-token", App: "publisher"})
+	require.NoError(t, err)
+
+	var keys map[string]any
+	require.NoError(t, json.Unmarshal(data, &keys))
+	assert.Equal(t, "publisher", keys["app"])
+	assert.NotContains(t, keys, "appId")
+	assert.NotContains(t, keys, "installationId")
 }
 
 // sequenceVendor returns each of the calls in sequence, either a token or an error

--- a/internal/vendor/cached_test.go
+++ b/internal/vendor/cached_test.go
@@ -868,7 +868,7 @@ organization:
 	})
 
 	c := newTestCached(t, defaultTTL)
-	m := vendor.Authorized(c(vendor.Vending(vendor.OrgRepositories, tokenVendor)))
+	m := vendor.Authorized(c(vendor.Vending(vendor.OrgRepositories, mintingThrough(tokenVendor))))
 	v := vendor.Auditor(m)
 
 	ref := profile.ProfileRef{

--- a/internal/vendor/cachedapp_test.go
+++ b/internal/vendor/cachedapp_test.go
@@ -15,12 +15,9 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
-// A name is a label on an identity, and an operator may repoint it. The YAML —
-// and so the digest — is unchanged when they do, so a key that carried only
-// the digest would keep serving tokens minted through the previous app. These
-// tests assert observable cache behaviour rather than the key string: the key
-// format is an implementation detail, but "these two requests must not share
-// an entry" is the guarantee.
+// An operator may repoint a name at a different app without touching the YAML,
+// so a key carrying only the digest would keep serving tokens minted through
+// the previous app. These tests assert entry sharing, not the key format.
 func TestCached_AppIdentityPartitionsTheCache(t *testing.T) {
 	ref := profile.ProfileRef{
 		Organization: "acme",
@@ -45,9 +42,6 @@ func TestCached_AppIdentityPartitionsTheCache(t *testing.T) {
 			second: github.AppIdentity{Name: "deploy", ApplicationID: 777, InstallationID: 444},
 		},
 		{
-			// The key carries identity rather than name, so two names for one
-			// application and installation are one cache entry, differing only
-			// in attribution.
 			name:   "two names for one identity share entries",
 			first:  github.AppIdentity{Name: "packages", ApplicationID: 333, InstallationID: 444},
 			second: github.AppIdentity{Name: "publishing", ApplicationID: 333, InstallationID: 444},
@@ -91,9 +85,8 @@ func TestCached_AppIdentityPartitionsTheCache(t *testing.T) {
 	}
 }
 
-// The cached payload is the response, so a cache hit and a cache miss must
-// carry the same attribution. Without this a caller could not tell which app
-// minted a token it was served warm.
+// The cached payload is the response, so a hit must carry the same attribution
+// as a miss: otherwise a caller cannot tell which app minted a warm token.
 func TestCached_HitCarriesTheMintingApp(t *testing.T) {
 	app := github.AppIdentity{Name: "packages", ApplicationID: 333, InstallationID: 444}
 
@@ -118,10 +111,9 @@ func TestCached_HitCarriesTheMintingApp(t *testing.T) {
 	assert.Equal(t, miss.Token(), hit.Token(), "a hit and a miss must return the same shape")
 }
 
-// An unresolved identity would key every app's entries together under zeroes,
-// which is precisely the collision the key exists to prevent. Refusing is the
-// only safe answer: defaulting would silently serve one app's token through
-// another's key.
+// A zero identity would key every app's entries together, which is the
+// collision the key exists to prevent. Defaulting would serve one app's token
+// through another's key.
 func TestCached_RefusesAnUnresolvedAppIdentity(t *testing.T) {
 	cached := newTestCached(t, 45*time.Minute)(func(context.Context, vendor.Resolved[cacheAttr], string) vendor.VendorResult {
 		t.Fatal("the wrapped vendor must not be reached")
@@ -136,9 +128,8 @@ func TestCached_RefusesAnUnresolvedAppIdentity(t *testing.T) {
 	assertVendorFailure(t, result, "no app identity resolved")
 }
 
-// The cache outcome metric is attributed with the app, so a partly-cold cache
-// can be attributed to the app whose entries were orphaned rather than read as
-// a service-wide regression.
+// The cache outcome metric carries the app, so a partly-cold cache reads as one
+// app's entries being orphaned rather than a service-wide regression.
 func TestCached_OutcomeMetricIsAttributedWithTheApp(t *testing.T) {
 	reader := sdkmetric.NewManualReader()
 	previous := otel.GetMeterProvider()

--- a/internal/vendor/cachedapp_test.go
+++ b/internal/vendor/cachedapp_test.go
@@ -1,0 +1,180 @@
+package vendor_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/chinmina/chinmina-bridge/internal/github"
+	"github.com/chinmina/chinmina-bridge/internal/profile"
+	"github.com/chinmina/chinmina-bridge/internal/vendor"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+// A name is a label on an identity, and an operator may repoint it. The YAML —
+// and so the digest — is unchanged when they do, so a key that carried only
+// the digest would keep serving tokens minted through the previous app. These
+// tests assert observable cache behaviour rather than the key string: the key
+// format is an implementation detail, but "these two requests must not share
+// an entry" is the guarantee.
+func TestCached_AppIdentityPartitionsTheCache(t *testing.T) {
+	ref := profile.ProfileRef{
+		Organization: "acme",
+		Type:         profile.ProfileTypeOrg,
+		Name:         "publish",
+	}
+
+	tests := []struct {
+		name   string
+		first  github.AppIdentity
+		second github.AppIdentity
+		shared bool
+	}{
+		{
+			name:   "different installations of one application do not share entries",
+			first:  github.AppIdentity{Name: "packages", ApplicationID: 333, InstallationID: 444},
+			second: github.AppIdentity{Name: "packages", ApplicationID: 333, InstallationID: 555},
+		},
+		{
+			name:   "different applications do not share entries",
+			first:  github.AppIdentity{Name: "packages", ApplicationID: 333, InstallationID: 444},
+			second: github.AppIdentity{Name: "deploy", ApplicationID: 777, InstallationID: 444},
+		},
+		{
+			// The key carries identity rather than name, so two names for one
+			// application and installation are one cache entry, differing only
+			// in attribution.
+			name:   "two names for one identity share entries",
+			first:  github.AppIdentity{Name: "packages", ApplicationID: 333, InstallationID: 444},
+			second: github.AppIdentity{Name: "publishing", ApplicationID: 333, InstallationID: 444},
+			shared: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mints := 0
+			cached := newTestCached(t, 45*time.Minute)(func(_ context.Context, r vendor.Resolved[cacheAttr], _ string) vendor.VendorResult {
+				mints++
+				return vendor.NewVendorSuccess(vendor.ProfileToken{
+					Profile: r.Ref.ShortString(),
+					App:     r.App.Name,
+					Token:   "token-for-" + r.App.Name,
+					Expiry:  time.Now().Add(time.Hour),
+				})
+			})
+
+			first := vendor.Resolved[cacheAttr]{Ref: ref, Digest: testGeneration, App: tt.first}
+			second := vendor.Resolved[cacheAttr]{Ref: ref, Digest: testGeneration, App: tt.second}
+
+			firstResult := cached(t.Context(), first, "")
+			secondResult := cached(t.Context(), second, "")
+
+			require.Equal(t, vendor.VendStatusSuccess, firstResult.Status())
+			require.Equal(t, vendor.VendStatusSuccess, secondResult.Status())
+
+			if tt.shared {
+				assert.Equal(t, 1, mints, "one identity is one cache entry")
+				assert.Equal(t, "token-for-"+tt.first.Name, secondResult.Token().Token,
+					"the second request must be served the first's entry")
+				return
+			}
+
+			assert.Equal(t, 2, mints, "each identity must mint its own token")
+			assert.Equal(t, "token-for-"+tt.second.Name, secondResult.Token().Token,
+				"the second request must not be served the first's token")
+		})
+	}
+}
+
+// The cached payload is the response, so a cache hit and a cache miss must
+// carry the same attribution. Without this a caller could not tell which app
+// minted a token it was served warm.
+func TestCached_HitCarriesTheMintingApp(t *testing.T) {
+	app := github.AppIdentity{Name: "packages", ApplicationID: 333, InstallationID: 444}
+
+	cached := newTestCached(t, 45*time.Minute)(func(_ context.Context, r vendor.Resolved[cacheAttr], _ string) vendor.VendorResult {
+		return vendor.NewVendorSuccess(vendor.ProfileToken{
+			App:    r.App.Name,
+			Token:  "minted",
+			Expiry: time.Now().Add(time.Hour),
+		})
+	})
+
+	request := vendor.Resolved[cacheAttr]{
+		Ref:    profile.ProfileRef{Organization: "acme", Type: profile.ProfileTypeOrg, Name: "publish"},
+		Digest: testGeneration,
+		App:    app,
+	}
+
+	miss := cached(t.Context(), request, "")
+	hit := cached(t.Context(), request, "")
+
+	assert.Equal(t, "packages", miss.Token().App)
+	assert.Equal(t, miss.Token(), hit.Token(), "a hit and a miss must return the same shape")
+}
+
+// An unresolved identity would key every app's entries together under zeroes,
+// which is precisely the collision the key exists to prevent. Refusing is the
+// only safe answer: defaulting would silently serve one app's token through
+// another's key.
+func TestCached_RefusesAnUnresolvedAppIdentity(t *testing.T) {
+	cached := newTestCached(t, 45*time.Minute)(func(context.Context, vendor.Resolved[cacheAttr], string) vendor.VendorResult {
+		t.Fatal("the wrapped vendor must not be reached")
+		return vendor.VendorResult{}
+	})
+
+	result := cached(t.Context(), vendor.Resolved[cacheAttr]{
+		Ref:    profile.ProfileRef{Organization: "acme", Type: profile.ProfileTypeOrg, Name: "publish"},
+		Digest: testGeneration,
+	}, "")
+
+	assertVendorFailure(t, result, "no app identity resolved")
+}
+
+// The cache outcome metric is attributed with the app, so a partly-cold cache
+// can be attributed to the app whose entries were orphaned rather than read as
+// a service-wide regression.
+func TestCached_OutcomeMetricIsAttributedWithTheApp(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	previous := otel.GetMeterProvider()
+	otel.SetMeterProvider(sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)))
+	t.Cleanup(func() { otel.SetMeterProvider(previous) })
+
+	cached := newTestCached(t, 45*time.Minute)(func(_ context.Context, r vendor.Resolved[cacheAttr], _ string) vendor.VendorResult {
+		return vendor.NewVendorSuccess(vendor.ProfileToken{App: r.App.Name, Token: "minted", Expiry: time.Now().Add(time.Hour)})
+	})
+
+	request := vendor.Resolved[cacheAttr]{
+		Ref:    profile.ProfileRef{Organization: "acme", Type: profile.ProfileTypeOrg, Name: "publish"},
+		Digest: testGeneration,
+		App:    github.AppIdentity{Name: "packages", ApplicationID: 333, InstallationID: 444},
+	}
+
+	cached(t.Context(), request, "") // miss
+	cached(t.Context(), request, "") // hit
+
+	var collected metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &collected))
+
+	outcomes := map[string]string{}
+	for _, scope := range collected.ScopeMetrics {
+		for _, m := range scope.Metrics {
+			sum, isSum := m.Data.(metricdata.Sum[int64])
+			if m.Name != "token.cache.outcome" || !isSum {
+				continue
+			}
+			for _, point := range sum.DataPoints {
+				result, _ := point.Attributes.Value("token.cache.result")
+				app, _ := point.Attributes.Value("token.app")
+				outcomes[result.AsString()] = app.AsString()
+			}
+		}
+	}
+
+	assert.Equal(t, map[string]string{"miss": "packages", "hit": "packages"}, outcomes)
+}

--- a/internal/vendor/orgvending_test.go
+++ b/internal/vendor/orgvending_test.go
@@ -117,6 +117,9 @@ func TestOrgVending_SuccessfulTokenProvisioning(t *testing.T) {
 			assertVendorSuccess(t, result, vendor.ProfileToken{
 				Token:               "non-default-token-value",
 				HashedToken:         vendor.HashToken("non-default-token-value"),
+				App:                 "publisher",
+				ApplicationID:       4242,
+				InstallationID:      8484,
 				Repositories:        profile.NewSpecificScope("secret-repo", "another-secret-repo"),
 				Permissions:         []string{"contents:read", "packages:read", "metadata:read"},
 				Profile:             "org:non-default-profile",
@@ -175,6 +178,9 @@ func TestOrgVending_WildcardRepository(t *testing.T) {
 			assertVendorSuccess(t, result, vendor.ProfileToken{
 				Token:               "wildcard-token-value",
 				HashedToken:         vendor.HashToken("wildcard-token-value"),
+				App:                 "publisher",
+				ApplicationID:       4242,
+				InstallationID:      8484,
 				Repositories:        profile.NewWildcardScope(),
 				Permissions:         []string{"contents:read", "packages:read", "metadata:read"},
 				Profile:             "org:wildcard-profile",
@@ -214,6 +220,9 @@ func TestOrgVending_CallerScopedRepository_Success(t *testing.T) {
 	assertVendorSuccess(t, result, vendor.ProfileToken{
 		Token:               "scoped-token",
 		HashedToken:         vendor.HashToken("scoped-token"),
+		App:                 "publisher",
+		ApplicationID:       4242,
+		InstallationID:      8484,
 		Repositories:        profile.NewSpecificScope("target-repo"),
 		Permissions:         []string{"contents:write", "metadata:read"},
 		Profile:             "org:caller-scoped-profile/target-repo",
@@ -288,6 +297,9 @@ func TestOrgVending_GitCredentials_CallerScoped_DerivesRepoFromURL(t *testing.T)
 	assertVendorSuccess(t, result, vendor.ProfileToken{
 		Token:               "scoped-token",
 		HashedToken:         vendor.HashToken("scoped-token"),
+		App:                 "publisher",
+		ApplicationID:       4242,
+		InstallationID:      8484,
 		Repositories:        profile.NewSpecificScope("target-repo"),
 		Permissions:         []string{"contents:write", "metadata:read"},
 		Profile:             "org:caller-scoped-profile/target-repo",

--- a/internal/vendor/orgvending_test.go
+++ b/internal/vendor/orgvending_test.go
@@ -65,7 +65,7 @@ func TestOrgVending_FailWhenTokenVendorFails(t *testing.T) {
 		return "", time.Time{}, errors.New("token vendor failed")
 	})
 
-	v := vendor.Vending(vendor.OrgRepositories, tokenVendor)
+	v := vendor.Vending(vendor.OrgRepositories, mintingThrough(tokenVendor))
 
 	ref := profile.ProfileRef{
 		Organization: "organization-slug",
@@ -86,7 +86,7 @@ func TestOrgVending_SuccessfulTokenProvisioning(t *testing.T) {
 	tokenVendor := vendor.TokenVendor(func(ctx context.Context, repositoryURLs []string, scopes []string) (string, time.Time, error) {
 		return "non-default-token-value", vendedDate, nil
 	})
-	v := vendor.Vending(vendor.OrgRepositories, tokenVendor)
+	v := vendor.Vending(vendor.OrgRepositories, mintingThrough(tokenVendor))
 
 	tests := []struct {
 		name         string
@@ -138,7 +138,7 @@ func TestOrgVending_WildcardRepository(t *testing.T) {
 		return "wildcard-token-value", vendedDate, nil
 	})
 
-	v := vendor.Vending(vendor.OrgRepositories, tokenVendor)
+	v := vendor.Vending(vendor.OrgRepositories, mintingThrough(tokenVendor))
 
 	tests := []struct {
 		name         string
@@ -195,7 +195,7 @@ func TestOrgVending_CallerScopedRepository_Success(t *testing.T) {
 		return "scoped-token", vendedDate, nil
 	})
 
-	v := vendor.Vending(vendor.OrgRepositories, tokenVendor)
+	v := vendor.Vending(vendor.OrgRepositories, mintingThrough(tokenVendor))
 
 	ref := profile.ProfileRef{
 		Organization:     "organization-slug",
@@ -235,7 +235,7 @@ func TestOrgVending_CallerScoped_MissingScopeParameter(t *testing.T) {
 		return "", time.Time{}, nil
 	})
 
-	v := vendor.Vending(vendor.OrgRepositories, tokenVendor)
+	v := vendor.Vending(vendor.OrgRepositories, mintingThrough(tokenVendor))
 
 	ref := profile.ProfileRef{
 		Organization: "organization-slug",
@@ -268,7 +268,7 @@ func TestOrgVending_GitCredentials_CallerScoped_DerivesRepoFromURL(t *testing.T)
 		return "scoped-token", vendedDate, nil
 	})
 
-	v := vendor.Vending(vendor.OrgRepositories, tokenVendor)
+	v := vendor.Vending(vendor.OrgRepositories, mintingThrough(tokenVendor))
 
 	ref := profile.ProfileRef{
 		Organization:     "organization-slug",
@@ -307,7 +307,7 @@ func TestOrgVending_GitCredentials_CallerScoped_IssuanceFailure(t *testing.T) {
 		return "", time.Time{}, errors.New("GitHub API rejected request")
 	})
 
-	v := vendor.Vending(vendor.OrgRepositories, tokenVendor)
+	v := vendor.Vending(vendor.OrgRepositories, mintingThrough(tokenVendor))
 
 	ref := profile.ProfileRef{
 		Organization:     "organization-slug",
@@ -332,7 +332,7 @@ func TestOrgVending_GitCredentials_AllRepos_NoUnmatched(t *testing.T) {
 		return "", time.Time{}, errors.New("GitHub API rejected request")
 	})
 
-	v := vendor.Vending(vendor.OrgRepositories, tokenVendor)
+	v := vendor.Vending(vendor.OrgRepositories, mintingThrough(tokenVendor))
 
 	ref := profile.ProfileRef{
 		Organization: "organization-slug",

--- a/internal/vendor/pipelinevending_test.go
+++ b/internal/vendor/pipelinevending_test.go
@@ -89,7 +89,7 @@ func TestPipelineVending_FailsWhenTokenVendorFails(t *testing.T) {
 		return "", time.Time{}, errors.New("token vendor failed")
 	})
 
-	v := vendor.Vending(vendor.PipelineRepositories(repoLookup), tokenVendor)
+	v := vendor.Vending(vendor.PipelineRepositories(repoLookup), mintingThrough(tokenVendor))
 
 	ref := profile.ProfileRef{
 		Organization: "organization-slug",
@@ -115,7 +115,7 @@ func TestPipelineVending_SucceedsWithTokenWhenPossible(t *testing.T) {
 		return "vended-token-value", vendedDate, nil
 	})
 
-	v := vendor.Vending(vendor.PipelineRepositories(repoLookup), tokenVendor)
+	v := vendor.Vending(vendor.PipelineRepositories(repoLookup), mintingThrough(tokenVendor))
 
 	ref := profile.ProfileRef{
 		Organization: "organization-slug",
@@ -152,7 +152,7 @@ func TestPipelineVending_SucceedsWithEmptyRequestedRepo(t *testing.T) {
 		return "vended-token-value", vendedDate, nil
 	})
 
-	v := vendor.Vending(vendor.PipelineRepositories(repoLookup), tokenVendor)
+	v := vendor.Vending(vendor.PipelineRepositories(repoLookup), mintingThrough(tokenVendor))
 
 	ref := profile.ProfileRef{
 		Organization: "organization-slug",
@@ -189,7 +189,7 @@ func TestPipelineVending_TranslatesSSHToHTTPSForPipelineRepo(t *testing.T) {
 		return "vended-token-value", vendedDate, nil
 	})
 
-	v := vendor.Vending(vendor.PipelineRepositories(repoLookup), tokenVendor)
+	v := vendor.Vending(vendor.PipelineRepositories(repoLookup), mintingThrough(tokenVendor))
 
 	ref := profile.ProfileRef{
 		Organization: "organization-slug",
@@ -256,7 +256,7 @@ func TestPipelineVending_IssuesTheResolvedProfilesPermissions(t *testing.T) {
 				return "vended-token-value", vendedDate, nil
 			})
 
-			v := vendor.Vending(vendor.PipelineRepositories(repoLookup), tokenVendor)
+			v := vendor.Vending(vendor.PipelineRepositories(repoLookup), mintingThrough(tokenVendor))
 
 			ref := profile.ProfileRef{
 				Organization: "organization-slug",

--- a/internal/vendor/pipelinevending_test.go
+++ b/internal/vendor/pipelinevending_test.go
@@ -130,6 +130,9 @@ func TestPipelineVending_SucceedsWithTokenWhenPossible(t *testing.T) {
 	assertVendorSuccess(t, result, vendor.ProfileToken{
 		Token:               "vended-token-value",
 		HashedToken:         vendor.HashToken("vended-token-value"),
+		App:                 "publisher",
+		ApplicationID:       4242,
+		InstallationID:      8484,
 		Repositories:        profile.NewSpecificScope("repo-url"),
 		Permissions:         []string{"contents:read", "metadata:read"},
 		Profile:             "repo:default",
@@ -168,6 +171,9 @@ func TestPipelineVending_SucceedsWithEmptyRequestedRepo(t *testing.T) {
 	assertVendorSuccess(t, result, vendor.ProfileToken{
 		Token:               "vended-token-value",
 		HashedToken:         vendor.HashToken("vended-token-value"),
+		App:                 "publisher",
+		ApplicationID:       4242,
+		InstallationID:      8484,
 		Repositories:        profile.NewSpecificScope("pipeline-repo"),
 		Permissions:         []string{"contents:read", "metadata:read"},
 		Profile:             "repo:default",
@@ -205,6 +211,9 @@ func TestPipelineVending_TranslatesSSHToHTTPSForPipelineRepo(t *testing.T) {
 	assertVendorSuccess(t, result, vendor.ProfileToken{
 		Token:               "vended-token-value",
 		HashedToken:         vendor.HashToken("vended-token-value"),
+		App:                 "publisher",
+		ApplicationID:       4242,
+		InstallationID:      8484,
 		Repositories:        profile.NewSpecificScope("repo-url"),
 		Permissions:         []string{"contents:read", "metadata:read"},
 		Profile:             "repo:default",
@@ -272,6 +281,9 @@ func TestPipelineVending_IssuesTheResolvedProfilesPermissions(t *testing.T) {
 			assertVendorSuccess(t, result, vendor.ProfileToken{
 				Token:               "vended-token-value",
 				HashedToken:         vendor.HashToken("vended-token-value"),
+				App:                 "publisher",
+				ApplicationID:       4242,
+				InstallationID:      8484,
 				Repositories:        profile.NewSpecificScope("repo-url"),
 				Permissions:         tc.permissions,
 				Profile:             "repo:" + tc.profileName,

--- a/internal/vendor/testhelpers_test.go
+++ b/internal/vendor/testhelpers_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/chinmina/chinmina-bridge/internal/cache"
+	"github.com/chinmina/chinmina-bridge/internal/github"
 	"github.com/chinmina/chinmina-bridge/internal/jwt"
 	"github.com/chinmina/chinmina-bridge/internal/profile"
 	"github.com/chinmina/chinmina-bridge/internal/vendor"
@@ -34,6 +35,12 @@ func newTestCached(t *testing.T, ttl time.Duration) func(vendor.ProfileTokenVend
 // so they all address one namespace.
 const testGeneration = "test-generation"
 
+// testApp stands in for the app identity the boundary resolver stamps. The
+// cache key includes it, so every helper here supplies one: a zero identity is
+// refused by Cached rather than defaulted, which is the behaviour that stops
+// an unresolved request keying every app's entries together.
+var testApp = github.AppIdentity{Name: "default", ApplicationID: 111, InstallationID: 222}
+
 // cacheRequest wraps a ref the way the handler boundary would, for tests that
 // exercise the cache without depending on the resolved profile value.
 func cacheRequest(ref profile.ProfileRef) vendor.Resolved[cacheAttr] {
@@ -43,7 +50,7 @@ func cacheRequest(ref profile.ProfileRef) vendor.Resolved[cacheAttr] {
 // cacheRequestAt wraps a ref as cacheRequest does, pinning the configuration
 // generation the request was resolved from.
 func cacheRequestAt(ref profile.ProfileRef, digest string) vendor.Resolved[cacheAttr] {
-	return vendor.Resolved[cacheAttr]{Ref: ref, Digest: digest}
+	return vendor.Resolved[cacheAttr]{Ref: ref, Digest: digest, App: testApp}
 }
 
 // resolvedOrg builds the Resolved value the organization boundary resolver
@@ -52,7 +59,7 @@ func resolvedOrg(t *testing.T, store *profile.ProfileStore, ref profile.ProfileR
 	t.Helper()
 	authProfile, digest, err := store.GetOrganizationProfile(ref.Name)
 	require.NoError(t, err)
-	return vendor.Resolved[profile.OrganizationProfileAttr]{Ref: ref, Profile: authProfile, Digest: digest}
+	return vendor.Resolved[profile.OrganizationProfileAttr]{Ref: ref, Profile: authProfile, Digest: digest, App: testApp}
 }
 
 // resolvedPipeline builds the Resolved value the pipeline boundary resolver
@@ -61,7 +68,15 @@ func resolvedPipeline(t *testing.T, store *profile.ProfileStore, ref profile.Pro
 	t.Helper()
 	authProfile, digest, err := store.GetPipelineProfile(ref.Name)
 	require.NoError(t, err)
-	return vendor.Resolved[profile.PipelineProfileAttr]{Ref: ref, Profile: authProfile, Digest: digest}
+	return vendor.Resolved[profile.PipelineProfileAttr]{Ref: ref, Profile: authProfile, Digest: digest, App: testApp}
+}
+
+// mintingThrough adapts a plain token vendor to the app-aware signature,
+// recording which identity each mint was requested through.
+func mintingThrough(mint vendor.TokenVendor) vendor.AppTokenVendor {
+	return func(ctx context.Context, _ github.AppIdentity, repoNames []string, scopes []string) (string, time.Time, error) {
+		return mint(ctx, repoNames, scopes)
+	}
 }
 
 // assertVendorSuccess verifies that vending succeeded and returns the expected token

--- a/internal/vendor/testhelpers_test.go
+++ b/internal/vendor/testhelpers_test.go
@@ -35,10 +35,8 @@ func newTestCached(t *testing.T, ttl time.Duration) func(vendor.ProfileTokenVend
 // so they all address one namespace.
 const testGeneration = "test-generation"
 
-// testApp stands in for the app identity the boundary resolver stamps. The
-// cache key includes it, so every helper here supplies one: a zero identity is
-// refused by Cached rather than defaulted, which is the behaviour that stops
-// an unresolved request keying every app's entries together.
+// testApp stands in for the app identity the boundary resolver stamps. Cached
+// refuses a zero identity, so every helper here supplies one.
 var testApp = github.AppIdentity{Name: "default", ApplicationID: 111, InstallationID: 222}
 
 // cacheRequest wraps a ref the way the handler boundary would, for tests that
@@ -71,8 +69,7 @@ func resolvedPipeline(t *testing.T, store *profile.ProfileStore, ref profile.Pro
 	return vendor.Resolved[profile.PipelineProfileAttr]{Ref: ref, Profile: authProfile, Digest: digest, App: testApp}
 }
 
-// mintingThrough adapts a plain token vendor to the app-aware signature,
-// recording which identity each mint was requested through.
+// mintingThrough adapts a plain token vendor to the app-aware signature.
 func mintingThrough(mint vendor.TokenVendor) vendor.AppTokenVendor {
 	return func(ctx context.Context, _ github.AppIdentity, repoNames []string, scopes []string) (string, time.Time, error) {
 		return mint(ctx, repoNames, scopes)

--- a/internal/vendor/vending.go
+++ b/internal/vendor/vending.go
@@ -45,11 +45,8 @@ type RepositoryResolver[T any] func(ctx context.Context, r Resolved[T], requeste
 // app identity supplies the installation, so the token can only ever describe
 // the profile generation the request was authorized against.
 //
-// It deliberately does not resolve the app itself. The chain is
-// Audit -> Authorized -> Cached -> Vending, and Cached short-circuits on a hit
-// before this runs, so a registry check here would be absent on exactly the
-// requests where it matters: a profile that was valid long enough to warm an
-// entry and has since had its app disabled. The resolver owns that lookup.
+// It deliberately does not resolve the app itself: Cached short-circuits
+// before this runs, so the lookup belongs at the request boundary.
 func Vending[T any](resolve RepositoryResolver[T], tokenVendor AppTokenVendor) ProfileTokenVendor[T] {
 	return func(ctx context.Context, r Resolved[T], requestedRepoURL string) VendorResult {
 		target, err := resolve(ctx, r, requestedRepoURL)

--- a/internal/vendor/vending.go
+++ b/internal/vendor/vending.go
@@ -41,10 +41,16 @@ func noRepositories() (RepositoryTarget, error) {
 type RepositoryResolver[T any] func(ctx context.Context, r Resolved[T], requestedRepoURL string) (RepositoryTarget, error)
 
 // Vending issues the token for a resolved request. It holds no configuration:
-// the resolved profile supplies the scope and permissions, so the token can
-// only ever describe the profile generation the request was authorized
-// against.
-func Vending[T any](resolve RepositoryResolver[T], tokenVendor TokenVendor) ProfileTokenVendor[T] {
+// the resolved profile supplies the scope and permissions, and the resolved
+// app identity supplies the installation, so the token can only ever describe
+// the profile generation the request was authorized against.
+//
+// It deliberately does not resolve the app itself. The chain is
+// Audit -> Authorized -> Cached -> Vending, and Cached short-circuits on a hit
+// before this runs, so a registry check here would be absent on exactly the
+// requests where it matters: a profile that was valid long enough to warm an
+// entry and has since had its app disabled. The resolver owns that lookup.
+func Vending[T any](resolve RepositoryResolver[T], tokenVendor AppTokenVendor) ProfileTokenVendor[T] {
 	return func(ctx context.Context, r Resolved[T], requestedRepoURL string) VendorResult {
 		target, err := resolve(ctx, r, requestedRepoURL)
 		if err != nil {
@@ -67,7 +73,7 @@ func Vending[T any](resolve RepositoryResolver[T], tokenVendor TokenVendor) Prof
 		// A wildcard scope carries a nil repository list, and GitHub reads nil
 		// as "every repository in the installation" — the intended
 		// all-repositories behaviour. Do not "fix" this into an empty slice.
-		token, expiry, err := tokenVendor(ctx, target.Scope.Names, target.Permissions)
+		token, expiry, err := tokenVendor(ctx, r.App, target.Scope.Names, target.Permissions)
 		if err != nil {
 			return NewVendorFailed(fmt.Errorf("could not issue token for profile %s (repositories %v): %w", r.Ref, target.Scope.NamesForDisplay(), err))
 		}
@@ -75,6 +81,7 @@ func Vending[T any](resolve RepositoryResolver[T], tokenVendor TokenVendor) Prof
 		slog.Info("profile token issued",
 			"organization", r.Ref.Organization,
 			"profile", r.Ref.ShortString(),
+			"app", r.App.Name,
 		)
 
 		return NewVendorSuccess(ProfileToken{
@@ -83,6 +90,7 @@ func Vending[T any](resolve RepositoryResolver[T], tokenVendor TokenVendor) Prof
 			Repositories:        target.Scope,
 			Permissions:         target.Permissions,
 			Profile:             r.Ref.ShortString(),
+			App:                 r.App.Name,
 			Token:               token,
 			HashedToken:         HashToken(token),
 			Expiry:              expiry,

--- a/internal/vendor/vending.go
+++ b/internal/vendor/vending.go
@@ -88,6 +88,8 @@ func Vending[T any](resolve RepositoryResolver[T], tokenVendor AppTokenVendor) P
 			Permissions:         target.Permissions,
 			Profile:             r.Ref.ShortString(),
 			App:                 r.App.Name,
+			ApplicationID:       r.App.ApplicationID,
+			InstallationID:      r.App.InstallationID,
 			Token:               token,
 			HashedToken:         HashToken(token),
 			Expiry:              expiry,

--- a/internal/vendor/vending_test.go
+++ b/internal/vendor/vending_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/chinmina/chinmina-bridge/internal/github"
 	"github.com/chinmina/chinmina-bridge/internal/profile"
 	"github.com/chinmina/chinmina-bridge/internal/vendor"
 	"github.com/stretchr/testify/assert"
@@ -12,6 +13,10 @@ import (
 )
 
 var vendingExpiry = time.Date(2024, time.May, 7, 17, 59, 36, 0, time.UTC)
+
+// vendingApp's identifiers are non-zero, so a token that fails to carry them
+// is visible.
+var vendingApp = github.AppIdentity{Name: "publisher", ApplicationID: 4242, InstallationID: 8484}
 
 // recordingTokenVendor captures the repository names and permissions the
 // GitHub call was asked for, which is the contract the resolvers determine.
@@ -31,6 +36,7 @@ func orgResolved(ref profile.ProfileRef, attrs profile.OrganizationProfileAttr) 
 		Ref:     ref,
 		Profile: profile.NewAuthorizedProfile(profile.CompositeMatcher(), attrs),
 		Digest:  "test-digest",
+		App:     vendingApp,
 	}
 }
 
@@ -39,6 +45,7 @@ func pipelineResolved(ref profile.ProfileRef, attrs profile.PipelineProfileAttr)
 		Ref:     ref,
 		Profile: profile.NewAuthorizedProfile(profile.CompositeMatcher(), attrs),
 		Digest:  "test-digest",
+		App:     vendingApp,
 	}
 }
 
@@ -70,6 +77,9 @@ func TestVending_OrgPermissionsComeFromResolvedProfile(t *testing.T) {
 		Repositories:     profile.NewSpecificScope("widget", "gadget"),
 		Permissions:      []string{"contents:write"},
 		Profile:          "org:prod-deploy",
+		App:              "publisher",
+		ApplicationID:    4242,
+		InstallationID:   8484,
 		Token:            "minted-token",
 		HashedToken:      vendor.HashToken("minted-token"),
 		Expiry:           vendingExpiry,
@@ -146,7 +156,19 @@ func TestVending_PipelinePermissionsComeFromResolvedProfile(t *testing.T) {
 	require.Equal(t, vendor.VendStatusSuccess, result.Status())
 	assert.Equal(t, []string{"widget"}, *gotRepos)
 	assert.Equal(t, []string{"contents:read"}, *gotPermissions)
-	assert.Equal(t, "https://github.com/organization-slug/widget", result.Token().VendedRepositoryURL)
+	assert.Equal(t, vendor.ProfileToken{
+		OrganizationSlug:    "organization-slug",
+		VendedRepositoryURL: "https://github.com/organization-slug/widget",
+		Repositories:        profile.NewSpecificScope("widget"),
+		Permissions:         []string{"contents:read"},
+		Profile:             "repo:default",
+		App:                 "publisher",
+		ApplicationID:       4242,
+		InstallationID:      8484,
+		Token:               "minted-token",
+		HashedToken:         vendor.HashToken("minted-token"),
+		Expiry:              vendingExpiry,
+	}, result.Token())
 }
 
 // TestVending_PipelineRejectsRepositoryOtherThanThePipelines keeps git's

--- a/internal/vendor/vending_test.go
+++ b/internal/vendor/vending_test.go
@@ -48,7 +48,7 @@ func pipelineResolved(ref profile.ProfileRef, attrs profile.PipelineProfileAttr)
 // vending mint a token the authorized generation never described.
 func TestVending_OrgPermissionsComeFromResolvedProfile(t *testing.T) {
 	tokenVendor, gotRepos, gotPermissions := recordingTokenVendor(t)
-	v := vendor.Vending(vendor.OrgRepositories, tokenVendor)
+	v := vendor.Vending(vendor.OrgRepositories, mintingThrough(tokenVendor))
 
 	ref := profile.ProfileRef{
 		Organization: "organization-slug",
@@ -83,7 +83,7 @@ func TestVending_OrgPermissionsComeFromResolvedProfile(t *testing.T) {
 // guard rejects an empty repository list, and must not catch a wildcard.
 func TestVending_OrgWildcardPassesNilRepositories(t *testing.T) {
 	tokenVendor, gotRepos, _ := recordingTokenVendor(t)
-	v := vendor.Vending(vendor.OrgRepositories, tokenVendor)
+	v := vendor.Vending(vendor.OrgRepositories, mintingThrough(tokenVendor))
 
 	ref := profile.ProfileRef{Organization: "organization-slug", Type: profile.ProfileTypeOrg, Name: "all-repos"}
 	attrs := profile.OrganizationProfileAttr{
@@ -102,7 +102,7 @@ func TestVending_OrgWildcardPassesNilRepositories(t *testing.T) {
 // carries, rather than the profile's declared scope literal.
 func TestVending_OrgCallerScopedNarrowsToRequestedRepository(t *testing.T) {
 	tokenVendor, gotRepos, _ := recordingTokenVendor(t)
-	v := vendor.Vending(vendor.OrgRepositories, tokenVendor)
+	v := vendor.Vending(vendor.OrgRepositories, mintingThrough(tokenVendor))
 
 	ref := profile.ProfileRef{
 		Organization:     "organization-slug",
@@ -130,7 +130,7 @@ func TestVending_PipelinePermissionsComeFromResolvedProfile(t *testing.T) {
 	repoLookup := vendor.RepositoryLookup(func(context.Context, string, string) (string, error) {
 		return "https://github.com/organization-slug/widget", nil
 	})
-	v := vendor.Vending(vendor.PipelineRepositories(repoLookup), tokenVendor)
+	v := vendor.Vending(vendor.PipelineRepositories(repoLookup), mintingThrough(tokenVendor))
 
 	ref := profile.ProfileRef{
 		Organization: "organization-slug",
@@ -157,7 +157,7 @@ func TestVending_PipelineRejectsRepositoryOtherThanThePipelines(t *testing.T) {
 	repoLookup := vendor.RepositoryLookup(func(context.Context, string, string) (string, error) {
 		return "https://github.com/organization-slug/widget", nil
 	})
-	v := vendor.Vending(vendor.PipelineRepositories(repoLookup), tokenVendor)
+	v := vendor.Vending(vendor.PipelineRepositories(repoLookup), mintingThrough(tokenVendor))
 
 	ref := profile.ProfileRef{
 		Organization: "organization-slug",
@@ -200,7 +200,7 @@ func TestVending_EmptyScopeFailsClosed(t *testing.T) {
 					return vendor.RepositoryTarget{Scope: scope, Permissions: []string{"contents:write"}, Matched: true}, nil
 				},
 			)
-			v := vendor.Vending(resolve, tokenVendor)
+			v := vendor.Vending(resolve, mintingThrough(tokenVendor))
 
 			ref := profile.ProfileRef{Organization: "organization-slug", Type: profile.ProfileTypeOrg, Name: "empty"}
 

--- a/internal/vendor/vendor.go
+++ b/internal/vendor/vendor.go
@@ -59,9 +59,12 @@ type ProfileToken struct {
 	Repositories        profile.RepositoryScope `json:"repositories"`
 	Permissions         []string                `json:"permissions"`
 
-	// App names the GitHub App the token was minted through. It is part of the
-	// cached payload, so hits and misses return the same shape.
-	App string `json:"app"`
+	// All three are part of the cached payload, so hits and misses return the
+	// same shape; what a client sees is chosen at the wire boundary. omitzero
+	// covers an entry cached before the identifiers existed.
+	App            string `json:"app"`
+	ApplicationID  int64  `json:"appId,omitzero"`
+	InstallationID int64  `json:"installationId,omitzero"`
 
 	Token       string    `json:"token"`
 	HashedToken string    `json:"hashedToken"`

--- a/internal/vendor/vendor.go
+++ b/internal/vendor/vendor.go
@@ -35,11 +35,8 @@ type Resolved[T any] struct {
 	// App is the GitHub App identity this request's token is minted through,
 	// resolved from the profile's app name at the handler boundary.
 	//
-	// It is data rather than a closure over a client, so this whole value
-	// stays loggable and no credential is captured in something that flows
-	// into a cache payload. The stages downstream read it from here rather
-	// than consulting the registry themselves, which is what keeps the
-	// registry lookup on the one code path that runs for every request.
+	// It is data rather than a closure over a client, so this value stays
+	// loggable and no credential reaches the cache payload.
 	App github.AppIdentity
 }
 
@@ -53,9 +50,6 @@ type RepositoryLookup func(ctx context.Context, organizationSlug, pipelineSlug s
 type TokenVendor func(ctx context.Context, repoNames []string, scopes []string) (string, time.Time, error)
 
 // AppTokenVendor vends a token through a specific GitHub App installation.
-// Resolving the identity to a minting client is an O(1) lookup against the
-// immutable registry, so this stays a plain function call rather than
-// something a request has to carry a client for.
 type AppTokenVendor func(ctx context.Context, app github.AppIdentity, repoNames []string, scopes []string) (string, time.Time, error)
 
 type ProfileToken struct {
@@ -66,8 +60,7 @@ type ProfileToken struct {
 	Permissions         []string                `json:"permissions"`
 
 	// App names the GitHub App the token was minted through. It is part of the
-	// cached payload, not merely of the live response, so a cache hit and a
-	// cache miss return the same shape.
+	// cached payload, so hits and misses return the same shape.
 	App string `json:"app"`
 
 	Token       string    `json:"token"`

--- a/internal/vendor/vendor.go
+++ b/internal/vendor/vendor.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/chinmina/chinmina-bridge/internal/github"
 	"github.com/chinmina/chinmina-bridge/internal/profile"
 )
 
@@ -31,6 +32,15 @@ type Resolved[T any] struct {
 	Profile profile.AuthorizedProfile[T]
 	// Digest identifies the configuration generation Profile was read from.
 	Digest string
+	// App is the GitHub App identity this request's token is minted through,
+	// resolved from the profile's app name at the handler boundary.
+	//
+	// It is data rather than a closure over a client, so this whole value
+	// stays loggable and no credential is captured in something that flows
+	// into a cache payload. The stages downstream read it from here rather
+	// than consulting the registry themselves, which is what keeps the
+	// registry lookup on the one code path that runs for every request.
+	App github.AppIdentity
 }
 
 type ProfileTokenVendor[T any] func(ctx context.Context, r Resolved[T], repo string) VendorResult
@@ -42,15 +52,27 @@ type RepositoryLookup func(ctx context.Context, organizationSlug, pipelineSlug s
 // GitHub repository that the vendor has permissions to access.
 type TokenVendor func(ctx context.Context, repoNames []string, scopes []string) (string, time.Time, error)
 
+// AppTokenVendor vends a token through a specific GitHub App installation.
+// Resolving the identity to a minting client is an O(1) lookup against the
+// immutable registry, so this stays a plain function call rather than
+// something a request has to carry a client for.
+type AppTokenVendor func(ctx context.Context, app github.AppIdentity, repoNames []string, scopes []string) (string, time.Time, error)
+
 type ProfileToken struct {
 	OrganizationSlug    string                  `json:"organizationSlug"`
 	Profile             string                  `json:"profile"`
 	VendedRepositoryURL string                  `json:"repositoryUrl"`
 	Repositories        profile.RepositoryScope `json:"repositories"`
 	Permissions         []string                `json:"permissions"`
-	Token               string                  `json:"token"`
-	HashedToken         string                  `json:"hashedToken"`
-	Expiry              time.Time               `json:"expiry"`
+
+	// App names the GitHub App the token was minted through. It is part of the
+	// cached payload, not merely of the live response, so a cache hit and a
+	// cache miss return the same shape.
+	App string `json:"app"`
+
+	Token       string    `json:"token"`
+	HashedToken string    `json:"hashedToken"`
+	Expiry      time.Time `json:"expiry"`
 }
 
 func (t ProfileToken) URL() (*url.URL, error) {

--- a/justfile
+++ b/justfile
@@ -57,12 +57,12 @@ fuzz secs=env('FUZZING_LOCAL_SECS', "30"):
 # CI: run unit tests with race detection, coverage output for codecov
 [group('ci')]
 ci-unit:
-    CGO_ENABLED=1 go test -race -coverprofile=coverage.out -covermode=atomic ./...
+    CGO_ENABLED=1 go test -race -coverprofile=coverage.out -coverpkg=./... -covermode=atomic ./...
 
 # CI: run integration tests with race detection, coverage output for codecov
 [group('ci')]
 ci-integration:
-    CGO_ENABLED=1 go test -tags=integration -run='^TestIntegration' -race -coverprofile=coverage.out -covermode=atomic ./...
+    CGO_ENABLED=1 go test -tags=integration -run='^TestIntegration' -race -coverprofile=coverage.out -coverpkg=./... -covermode=atomic ./...
 
 # CI: run fuzz tests (seconds per target, default 10s)
 [group('ci')]

--- a/main.go
+++ b/main.go
@@ -268,12 +268,12 @@ func runWithShutdownHooks(ctx context.Context, run func(context.Context, *server
 //
 // No timeout: a deadline of ours would be evidence about this service rather
 // than the profile source, so the platform's grace period is the backstop.
-func startProfileRefresh(taskCtx context.Context, orgProfile *profile.ProfileStore, source *github.Client, location string) error {
+func startProfileRefresh(taskCtx context.Context, orgProfile *profile.ProfileStore, source *github.Client, location string, usableApp profile.AppLookup) error {
 	if source == nil {
 		return nil
 	}
 
-	ready := profile.RefreshTask(orgProfile, *source, location).Start(taskCtx)
+	ready := profile.RefreshTask(orgProfile, *source, location, usableApp).Start(taskCtx)
 
 	return awaitFirstLoad(taskCtx, ready)
 }
@@ -348,7 +348,7 @@ func startServer(serverContext context.Context, shutdownHooks *server.ShutdownHo
 	// every exit from startup, not just once the server is serving.
 	shutdownHooks.Add("context", func() error { stop(); return nil })
 
-	err = startProfileRefresh(taskCtx, orgProfile, clients.profileSource, validated.orgProfileLocation)
+	err = startProfileRefresh(taskCtx, orgProfile, clients.profileSource, validated.orgProfileLocation, clients.apps.IsUsable)
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -70,16 +70,15 @@ type upstreamClients struct {
 	buildkite buildkite.PipelineLookup
 
 	// apps is the authority on which GitHub App a profile mints through. It
-	// includes the default app, so single-app deployments go through the same
-	// path as multi-app ones and there is no untested second code path.
+	// includes the default app, so single-app deployments take the same path as
+	// multi-app ones.
 	apps github.Registry
 
 	// Token rather than app transport, because it reads repository content.
 	// Nil when unconfigured, which is what leaves the refresh task unstarted.
 	//
-	// Always the default app: the profile configuration decides which app a
-	// profile uses, so reading it through a profile-selected app would be
-	// circular.
+	// Always the default app: the profile configuration selects each profile's
+	// app, so reading that configuration through a selected app is circular.
 	profileSource *github.Client
 
 	tokenCache cache.TokenCache[vendor.ProfileToken]
@@ -87,9 +86,7 @@ type upstreamClients struct {
 
 // configureUpstreamClients must run after installOutboundTransport: clients
 // capture http.DefaultTransport as they are built, so one made earlier
-// silently loses pool tuning and tracing. That applies to the app registry's
-// clients too — built here, after the transport is installed, so registry
-// traffic is traced and pool-tuned like everything else. Add new clients here.
+// silently loses pool tuning and tracing. Add new clients here.
 func configureUpstreamClients(ctx context.Context, cfg config.Config, validated validatedConfig, hooks *server.ShutdownHooks) (upstreamClients, error) {
 	bk, err := buildkite.New(cfg.Buildkite)
 	if err != nil {
@@ -101,9 +98,9 @@ func configureUpstreamClients(ctx context.Context, cfg config.Config, validated 
 		return upstreamClients{}, fmt.Errorf("github configuration failed: %w", err)
 	}
 
-	// ctx is the long-lived server context by contract: it reaches KMS signing
-	// key construction, and a key built under a shorter-lived context boots
-	// cleanly and then fails every mint once that context expires.
+	// ctx must be the long-lived server context: it reaches KMS signing key
+	// construction, and a key built under a shorter-lived one boots cleanly
+	// then fails every mint once that context expires.
 	apps, err := github.NewRegistry(ctx, cfg.Github, gh)
 	if err != nil {
 		return upstreamClients{}, fmt.Errorf("github app registry configuration failed: %w", err)
@@ -175,10 +172,6 @@ func configureServerRoutes(validated validatedConfig, clients upstreamClients, o
 
 	// Pipeline (repo) routes
 
-	// Vending mints through whichever app the request resolved to. The
-	// registry is passed as a minting function rather than resolved per
-	// request inside the chain: Cached short-circuits before Vending runs, so
-	// the resolution that guards a warm entry has to happen in the resolver.
 	mint := clients.apps.CreateAccessToken
 	resolveApp := clients.apps.Resolve
 

--- a/main.go
+++ b/main.go
@@ -31,6 +31,9 @@ type validatedConfig struct {
 	basePath           string // "" when served at the root
 	orgProfileLocation string // "" when no organization profile is configured
 	authorizer         alice.Constructor
+
+	// The bool stops here: route construction receives a marshaller instead.
+	discloseAppIdentifiers bool
 }
 
 // validateConfiguration must not make network calls, so that a configuration
@@ -58,9 +61,10 @@ func validateConfiguration(cfg config.Config) (validatedConfig, error) {
 	}
 
 	return validatedConfig{
-		basePath:           basePath,
-		orgProfileLocation: orgProfileLocation,
-		authorizer:         authorizer,
+		basePath:               basePath,
+		orgProfileLocation:     orgProfileLocation,
+		authorizer:             authorizer,
+		discloseAppIdentifiers: cfg.Development.DiscloseAppIdentifiers,
 	}, nil
 }
 
@@ -155,6 +159,12 @@ func configureServerRoutes(validated validatedConfig, clients upstreamClients, o
 		slog.Info("serving under base path", "path", validated.basePath)
 	}
 
+	if validated.discloseAppIdentifiers {
+		slog.Warn("github app identifiers are disclosed in token responses; development use only",
+			"flag", "DEV_DISCLOSE_APP_IDENTIFIERS")
+	}
+	marshaler := newTokenResponseMarshaler(validated.discloseAppIdentifiers)
+
 	authorizedRouteMiddleware := alice.New(requestLimiter, auditor, validated.authorizer)
 	standardRouteMiddleware := alice.New(requestLimiter)
 
@@ -184,11 +194,11 @@ func configureServerRoutes(validated validatedConfig, clients upstreamClients, o
 	)
 
 	pipelineResolver := NewPipelineProfileResolver(orgProfile.GetPipelineProfile, resolveApp)
-	pipelineTokenHandler := authorizedRouteMiddleware.Then(handlePostToken(repoVendor, pipelineResolver))
+	pipelineTokenHandler := authorizedRouteMiddleware.Then(handlePostToken(repoVendor, pipelineResolver, marshaler))
 	mux.Handle("POST /token", pipelineTokenHandler)
 	mux.Handle("POST /token/{profile}", pipelineTokenHandler)
 
-	pipelineGitCredentialsHandler := authorizedRouteMiddleware.Then(handlePostGitCredentials(repoVendor, pipelineResolver))
+	pipelineGitCredentialsHandler := authorizedRouteMiddleware.Then(handlePostGitCredentials(repoVendor, pipelineResolver, marshaler))
 	mux.Handle("POST /git-credentials", pipelineGitCredentialsHandler)
 	mux.Handle("POST /git-credentials/{profile}", pipelineGitCredentialsHandler)
 
@@ -203,8 +213,8 @@ func configureServerRoutes(validated validatedConfig, clients upstreamClients, o
 	)
 
 	orgResolver := NewOrgProfileResolver(orgProfile.GetOrganizationProfile, resolveApp)
-	mux.Handle("POST /organization/token/{profile}", authorizedRouteMiddleware.Then(handlePostToken(orgVendor, orgResolver)))
-	mux.Handle("POST /organization/git-credentials/{profile}", authorizedRouteMiddleware.Then(handlePostGitCredentials(orgVendor, orgResolver)))
+	mux.Handle("POST /organization/token/{profile}", authorizedRouteMiddleware.Then(handlePostToken(orgVendor, orgResolver, marshaler)))
+	mux.Handle("POST /organization/git-credentials/{profile}", authorizedRouteMiddleware.Then(handlePostGitCredentials(orgVendor, orgResolver, marshaler)))
 
 	// healthchecks are not included in telemetry or authorization
 	muxWithoutTelemetry.Handle("GET /healthcheck", standardRouteMiddleware.Then(handleHealthCheck()))

--- a/main.go
+++ b/main.go
@@ -175,23 +175,22 @@ func configureServerRoutes(validated validatedConfig, clients upstreamClients, o
 
 	// Pipeline (repo) routes
 
-	// Until profiles can name an app, every token mints through the default
-	// app's identity. The registry is still the minting path so single-app and
-	// multi-app deployments share one code path.
-	defaultApp := clients.apps.DefaultIdentity()
-	mintDefault := func(ctx context.Context, repoNames []string, scopes []string) (string, time.Time, error) {
-		return clients.apps.CreateAccessToken(ctx, defaultApp, repoNames, scopes)
-	}
+	// Vending mints through whichever app the request resolved to. The
+	// registry is passed as a minting function rather than resolved per
+	// request inside the chain: Cached short-circuits before Vending runs, so
+	// the resolution that guards a warm entry has to happen in the resolver.
+	mint := clients.apps.CreateAccessToken
+	resolveApp := clients.apps.Resolve
 
 	repoVendor := vendor.Auditor(
 		vendor.Authorized(
 			vendor.Cached[profile.PipelineProfileAttr](clients.tokenCache)(
-				vendor.Vending(vendor.PipelineRepositories(clients.buildkite.RepositoryLookup), mintDefault),
+				vendor.Vending(vendor.PipelineRepositories(clients.buildkite.RepositoryLookup), mint),
 			),
 		),
 	)
 
-	pipelineResolver := NewPipelineProfileResolver(orgProfile.GetPipelineProfile)
+	pipelineResolver := NewPipelineProfileResolver(orgProfile.GetPipelineProfile, resolveApp)
 	pipelineTokenHandler := authorizedRouteMiddleware.Then(handlePostToken(repoVendor, pipelineResolver))
 	mux.Handle("POST /token", pipelineTokenHandler)
 	mux.Handle("POST /token/{profile}", pipelineTokenHandler)
@@ -205,12 +204,12 @@ func configureServerRoutes(validated validatedConfig, clients upstreamClients, o
 	orgVendor := vendor.Auditor(
 		vendor.Authorized(
 			vendor.Cached[profile.OrganizationProfileAttr](clients.tokenCache)(
-				vendor.Vending(vendor.OrgRepositories, mintDefault),
+				vendor.Vending(vendor.OrgRepositories, mint),
 			),
 		),
 	)
 
-	orgResolver := NewOrgProfileResolver(orgProfile.GetOrganizationProfile)
+	orgResolver := NewOrgProfileResolver(orgProfile.GetOrganizationProfile, resolveApp)
 	mux.Handle("POST /organization/token/{profile}", authorizedRouteMiddleware.Then(handlePostToken(orgVendor, orgResolver)))
 	mux.Handle("POST /organization/git-credentials/{profile}", authorizedRouteMiddleware.Then(handlePostGitCredentials(orgVendor, orgResolver)))
 

--- a/main.go
+++ b/main.go
@@ -68,10 +68,18 @@ func validateConfiguration(cfg config.Config) (validatedConfig, error) {
 // the handlers would keep the old values.
 type upstreamClients struct {
 	buildkite buildkite.PipelineLookup
-	github    github.Client
+
+	// apps is the authority on which GitHub App a profile mints through. It
+	// includes the default app, so single-app deployments go through the same
+	// path as multi-app ones and there is no untested second code path.
+	apps github.Registry
 
 	// Token rather than app transport, because it reads repository content.
 	// Nil when unconfigured, which is what leaves the refresh task unstarted.
+	//
+	// Always the default app: the profile configuration decides which app a
+	// profile uses, so reading it through a profile-selected app would be
+	// circular.
 	profileSource *github.Client
 
 	tokenCache cache.TokenCache[vendor.ProfileToken]
@@ -79,7 +87,9 @@ type upstreamClients struct {
 
 // configureUpstreamClients must run after installOutboundTransport: clients
 // capture http.DefaultTransport as they are built, so one made earlier
-// silently loses pool tuning and tracing. Add new clients here.
+// silently loses pool tuning and tracing. That applies to the app registry's
+// clients too — built here, after the transport is installed, so registry
+// traffic is traced and pool-tuned like everything else. Add new clients here.
 func configureUpstreamClients(ctx context.Context, cfg config.Config, validated validatedConfig, hooks *server.ShutdownHooks) (upstreamClients, error) {
 	bk, err := buildkite.New(cfg.Buildkite)
 	if err != nil {
@@ -89,6 +99,14 @@ func configureUpstreamClients(ctx context.Context, cfg config.Config, validated 
 	gh, err := github.New(ctx, cfg.Github)
 	if err != nil {
 		return upstreamClients{}, fmt.Errorf("github configuration failed: %w", err)
+	}
+
+	// ctx is the long-lived server context by contract: it reaches KMS signing
+	// key construction, and a key built under a shorter-lived context boots
+	// cleanly and then fails every mint once that context expires.
+	apps, err := github.NewRegistry(ctx, cfg.Github, gh)
+	if err != nil {
+		return upstreamClients{}, fmt.Errorf("github app registry configuration failed: %w", err)
 	}
 
 	var profileSource *github.Client
@@ -115,7 +133,7 @@ func configureUpstreamClients(ctx context.Context, cfg config.Config, validated 
 
 	return upstreamClients{
 		buildkite:     bk,
-		github:        gh,
+		apps:          apps,
 		profileSource: profileSource,
 		tokenCache:    tokenCache,
 	}, nil
@@ -157,10 +175,18 @@ func configureServerRoutes(validated validatedConfig, clients upstreamClients, o
 
 	// Pipeline (repo) routes
 
+	// Until profiles can name an app, every token mints through the default
+	// app's identity. The registry is still the minting path so single-app and
+	// multi-app deployments share one code path.
+	defaultApp := clients.apps.DefaultIdentity()
+	mintDefault := func(ctx context.Context, repoNames []string, scopes []string) (string, time.Time, error) {
+		return clients.apps.CreateAccessToken(ctx, defaultApp, repoNames, scopes)
+	}
+
 	repoVendor := vendor.Auditor(
 		vendor.Authorized(
 			vendor.Cached[profile.PipelineProfileAttr](clients.tokenCache)(
-				vendor.Vending(vendor.PipelineRepositories(clients.buildkite.RepositoryLookup), clients.github.CreateAccessToken),
+				vendor.Vending(vendor.PipelineRepositories(clients.buildkite.RepositoryLookup), mintDefault),
 			),
 		),
 	)
@@ -179,7 +205,7 @@ func configureServerRoutes(validated validatedConfig, clients upstreamClients, o
 	orgVendor := vendor.Auditor(
 		vendor.Authorized(
 			vendor.Cached[profile.OrganizationProfileAttr](clients.tokenCache)(
-				vendor.Vending(vendor.OrgRepositories, clients.github.CreateAccessToken),
+				vendor.Vending(vendor.OrgRepositories, mintDefault),
 			),
 		),
 	)

--- a/main_test.go
+++ b/main_test.go
@@ -293,3 +293,26 @@ func TestAwaitFirstLoad(t *testing.T) {
 		assert.Contains(t, err.Error(), "initial organization profile load abandoned")
 	})
 }
+
+// Without this link, the flag could be set and silently never reach a response.
+func TestValidateConfiguration_CarriesTheDisclosureFlag(t *testing.T) {
+	tests := []struct {
+		name       string
+		configured bool
+	}{
+		{name: "unset means production behaviour", configured: false},
+		{name: "set for development", configured: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validConfig(t)
+			cfg.Development.DiscloseAppIdentifiers = tt.configured
+
+			validated, err := validateConfiguration(cfg)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.configured, validated.discloseAppIdentifiers)
+		})
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -268,7 +268,7 @@ func TestStartProfileRefresh_NotConfigured(t *testing.T) {
 
 	// Returning cleanly is the assertion: nothing loaded, no gate entered, so an
 	// unconfigured deployment starts as it always did.
-	err := startProfileRefresh(t.Context(), store, nil, "")
+	err := startProfileRefresh(t.Context(), store, nil, "", profile.DefaultAppOnly)
 
 	require.NoError(t, err)
 	assert.Equal(t, before, store.Digest())

--- a/multiapp_integration_test.go
+++ b/multiapp_integration_test.go
@@ -1,0 +1,207 @@
+//go:build integration
+
+package main
+
+import (
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/chinmina/chinmina-bridge/internal/jwt/jwxtest"
+	"github.com/chinmina/chinmina-bridge/internal/testhelpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	packagesAppID          = int64(333)
+	packagesInstallationID = int64(444)
+
+	// defaultAccountID matches the mock's default installation account, which
+	// the default app resolves to. Registry apps sharing it are enabled.
+	defaultAccountID = int64(1)
+	otherAccountID   = int64(99)
+)
+
+const multiAppProfiles = `organization:
+  profiles:
+    - name: publish-packages
+      app: packages
+      repositories:
+        - test-repo
+      permissions:
+        - contents:read
+    - name: read-source
+      repositories:
+        - test-repo
+      permissions:
+        - contents:read
+`
+
+// packagesApp is a registry entry pointed at the harness's mock. Its key is
+// any valid RSA key: the mock does not verify the App JWT, and what is under
+// test is which installation was contacted, not how it was authenticated.
+func packagesApp(t *testing.T) GitHubAppEntry {
+	t.Helper()
+
+	return GitHubAppEntry{
+		Name:           "packages",
+		ApplicationID:  packagesAppID,
+		InstallationID: packagesInstallationID,
+		PrivateKey:     jwxtest.NewJWK(t).PrivateKeyPEM(),
+	}
+}
+
+// enabledPackagesInstallation puts the packages app on the default app's
+// account, so verification enables it, and gives it its own token so a
+// response can be attributed to it.
+func enabledPackagesInstallation() testhelpers.MockInstallation {
+	return testhelpers.MockInstallation{
+		AccountID:    defaultAccountID,
+		AccountLogin: "test-org",
+		Token:        "packages-installation-token",
+	}
+}
+
+// A profile bound to a second app must mint through that app's installation,
+// and say so: the response body is how an operator attributes a credential to
+// the app that issued it.
+func TestIntegrationMultiApp_VendsThroughTheProfilesApp(t *testing.T) {
+	harness := NewAPITestHarness(t,
+		WithInstallation(packagesInstallationID, enabledPackagesInstallation()),
+		WithGitHubApps(packagesApp(t)),
+	)
+	harness.UpdateProfiles(t, multiAppProfiles)
+
+	token, err := harness.Client().OrganizationToken(harness.PipelineToken(), "publish-packages")
+	require.NoError(t, err)
+
+	assert.Equal(t, "packages-installation-token", token.Token,
+		"the token must come from the named app's installation")
+	assert.Equal(t, "packages", token.App)
+	assert.Positive(t, harness.GitHubMock.CallsForInstallation(packagesInstallationID))
+}
+
+// A profile with no app property mints through the default app, unchanged from
+// how the service behaved before an app could be named at all.
+func TestIntegrationMultiApp_ProfileWithoutAnAppUsesTheDefault(t *testing.T) {
+	harness := NewAPITestHarness(t,
+		WithInstallation(packagesInstallationID, enabledPackagesInstallation()),
+		WithGitHubApps(packagesApp(t)),
+	)
+	harness.UpdateProfiles(t, multiAppProfiles)
+
+	token, err := harness.Client().OrganizationToken(harness.PipelineToken(), "read-source")
+	require.NoError(t, err)
+
+	assert.Equal(t, "test-github-token", token.Token)
+	assert.Equal(t, "default", token.App)
+}
+
+// An app on a different account is disabled at startup, so a profile naming it
+// is invalid and the request is refused. Falling back to a different
+// credential is the hazard this feature exists to avoid, so "unavailable" is
+// the correct answer even though a working default app is right there.
+func TestIntegrationMultiApp_ProfileNamingADisabledAppIsUnavailable(t *testing.T) {
+	harness := NewAPITestHarness(t,
+		WithInstallation(packagesInstallationID, testhelpers.MockInstallation{
+			AccountID:    otherAccountID,
+			AccountLogin: "someone-else",
+		}),
+		WithGitHubApps(packagesApp(t)),
+	)
+	harness.UpdateProfiles(t, multiAppProfiles)
+
+	_, err := harness.Client().OrganizationToken(harness.PipelineToken(), "publish-packages")
+
+	var apiErr *APIError
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, http.StatusNotFound, apiErr.StatusCode)
+
+	// Isolation: one disabled app must not withdraw every other profile.
+	_, err = harness.Client().OrganizationToken(harness.PipelineToken(), "read-source")
+	assert.NoError(t, err)
+}
+
+// An app whose installation cannot be queried is disabled rather than fatal,
+// so the service starts and every other profile keeps working.
+func TestIntegrationMultiApp_UnreachableInstallationDisablesOnlyThatApp(t *testing.T) {
+	harness := NewAPITestHarness(t,
+		WithInstallation(packagesInstallationID, testhelpers.MockInstallation{
+			StatusCode: http.StatusInternalServerError,
+		}),
+		WithGitHubApps(packagesApp(t)),
+	)
+	harness.UpdateProfiles(t, multiAppProfiles)
+
+	_, err := harness.Client().OrganizationToken(harness.PipelineToken(), "publish-packages")
+	var apiErr *APIError
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, http.StatusNotFound, apiErr.StatusCode)
+
+	token, err := harness.Client().OrganizationToken(harness.PipelineToken(), "read-source")
+	require.NoError(t, err)
+	assert.Equal(t, "default", token.App)
+}
+
+// Two profiles resolving through different apps must not share cache entries:
+// each response has to carry the token its own app minted, however many times
+// the pair is requested.
+func TestIntegrationMultiApp_AppsDoNotShareCacheEntries(t *testing.T) {
+	harness := NewAPITestHarness(t,
+		WithInstallation(packagesInstallationID, enabledPackagesInstallation()),
+		WithGitHubApps(packagesApp(t)),
+	)
+	harness.UpdateProfiles(t, multiAppProfiles)
+
+	for range 3 {
+		packages, err := harness.Client().OrganizationToken(harness.PipelineToken(), "publish-packages")
+		require.NoError(t, err)
+		assert.Equal(t, "packages-installation-token", packages.Token)
+
+		source, err := harness.Client().OrganizationToken(harness.PipelineToken(), "read-source")
+		require.NoError(t, err)
+		assert.Equal(t, "test-github-token", source.Token)
+	}
+}
+
+// The registry is built once and never written afterwards, so parallel
+// requests across apps need no synchronisation. Under -race this fails if a
+// future change introduces lazily-populated registry state.
+func TestIntegrationMultiApp_ParallelRequestsAcrossApps(t *testing.T) {
+	harness := NewAPITestHarness(t,
+		WithInstallation(packagesInstallationID, enabledPackagesInstallation()),
+		WithGitHubApps(packagesApp(t)),
+	)
+	harness.UpdateProfiles(t, multiAppProfiles)
+
+	expected := map[string]string{
+		"publish-packages": "packages-installation-token",
+		"read-source":      "test-github-token",
+	}
+
+	var wg sync.WaitGroup
+	for range 10 {
+		for profileName, expectedToken := range expected {
+			wg.Go(func() {
+				token, err := harness.Client().OrganizationToken(harness.PipelineToken(), profileName)
+				if assert.NoError(t, err) {
+					assert.Equal(t, expectedToken, token.Token)
+				}
+			})
+		}
+	}
+	wg.Wait()
+}
+
+// A deployment not using the feature must pay nothing for its existence: no
+// GITHUB_APPS means no installation is queried at startup.
+func TestIntegrationMultiApp_NoRegistryQueriesNoInstallation(t *testing.T) {
+	harness := NewAPITestHarness(t)
+
+	assert.Equal(t, 0, harness.GitHubMock.InstallationQueryCount())
+
+	token, err := harness.Client().Token(harness.PipelineToken(), "")
+	require.NoError(t, err)
+	assert.Equal(t, "default", token.App)
+}

--- a/multiapp_integration_test.go
+++ b/multiapp_integration_test.go
@@ -193,3 +193,58 @@ func TestIntegrationMultiApp_NoRegistryQueriesNoInstallation(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "default", token.App)
 }
+
+// Nothing here hands a flag to the handlers: the shape is whatever
+// configureServerRoutes builds from an unset environment.
+func TestIntegrationMultiApp_ProductionDefaultWithholdsAppIdentifiers(t *testing.T) {
+	harness := NewAPITestHarness(t,
+		WithInstallation(packagesInstallationID, enabledPackagesInstallation()),
+		WithGitHubApps(packagesApp(t)),
+	)
+	harness.UpdateProfiles(t, multiAppProfiles)
+
+	response, status, err := harness.Client().RequestJSON(
+		"POST", "/organization/token/publish-packages", harness.PipelineToken(), nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, status)
+
+	assert.Equal(t, "packages", response["app"], "the app name has always been part of the response")
+	assert.NotContains(t, response, "appId")
+	assert.NotContains(t, response, "installationId")
+
+	props, err := harness.Client().OrganizationGitCredentials(harness.PipelineToken(), "publish-packages",
+		GitCredentialRequest{Protocol: "https", Host: "github.com", Path: "test-org/test-repo"})
+	require.NoError(t, err)
+
+	for i := props.Iter(); i.HasNext(); {
+		k, _ := i.Next()
+		assert.NotContains(t, k, "chinmina_", "git must receive only the properties it consumes")
+	}
+}
+
+// The default-off tests cannot tell a working gate from one wired to a
+// constant, so this drives the flag through configureServerRoutes.
+func TestIntegrationMultiApp_ConfiguredDisclosureReachesBothFormats(t *testing.T) {
+	harness := NewAPITestHarness(t,
+		WithInstallation(packagesInstallationID, enabledPackagesInstallation()),
+		WithGitHubApps(packagesApp(t)),
+		WithDisclosedAppIdentifiers(),
+	)
+	harness.UpdateProfiles(t, multiAppProfiles)
+
+	response, status, err := harness.Client().RequestJSON(
+		"POST", "/organization/token/publish-packages", harness.PipelineToken(), nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, status)
+
+	assert.Equal(t, float64(packagesAppID), response["appId"])
+	assert.Equal(t, float64(packagesInstallationID), response["installationId"])
+
+	props, err := harness.Client().OrganizationGitCredentials(harness.PipelineToken(), "publish-packages",
+		GitCredentialRequest{Protocol: "https", Host: "github.com", Path: "test-org/test-repo"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "packages", props.Get("chinmina_app_name"))
+	assert.Equal(t, "333", props.Get("chinmina_app_id"))
+	assert.Equal(t, "444", props.Get("chinmina_installation_id"))
+}

--- a/multiapp_integration_test.go
+++ b/multiapp_integration_test.go
@@ -17,8 +17,8 @@ const (
 	packagesAppID          = int64(333)
 	packagesInstallationID = int64(444)
 
-	// defaultAccountID matches the mock's default installation account, which
-	// the default app resolves to. Registry apps sharing it are enabled.
+	// defaultAccountID matches the mock's default installation account.
+	// Registry apps sharing it are enabled by verification.
 	defaultAccountID = int64(1)
 	otherAccountID   = int64(99)
 )
@@ -38,9 +38,8 @@ const multiAppProfiles = `organization:
         - contents:read
 `
 
-// packagesApp is a registry entry pointed at the harness's mock. Its key is
-// any valid RSA key: the mock does not verify the App JWT, and what is under
-// test is which installation was contacted, not how it was authenticated.
+// packagesApp is a registry entry pointed at the harness's mock. Any valid RSA
+// key will do: the mock does not verify the App JWT.
 func packagesApp(t *testing.T) GitHubAppEntry {
 	t.Helper()
 
@@ -53,8 +52,7 @@ func packagesApp(t *testing.T) GitHubAppEntry {
 }
 
 // enabledPackagesInstallation puts the packages app on the default app's
-// account, so verification enables it, and gives it its own token so a
-// response can be attributed to it.
+// account, which is what verification requires to enable it.
 func enabledPackagesInstallation() testhelpers.MockInstallation {
 	return testhelpers.MockInstallation{
 		AccountID:    defaultAccountID,
@@ -63,9 +61,6 @@ func enabledPackagesInstallation() testhelpers.MockInstallation {
 	}
 }
 
-// A profile bound to a second app must mint through that app's installation,
-// and say so: the response body is how an operator attributes a credential to
-// the app that issued it.
 func TestIntegrationMultiApp_VendsThroughTheProfilesApp(t *testing.T) {
 	harness := NewAPITestHarness(t,
 		WithInstallation(packagesInstallationID, enabledPackagesInstallation()),
@@ -82,8 +77,6 @@ func TestIntegrationMultiApp_VendsThroughTheProfilesApp(t *testing.T) {
 	assert.Positive(t, harness.GitHubMock.CallsForInstallation(packagesInstallationID))
 }
 
-// A profile with no app property mints through the default app, unchanged from
-// how the service behaved before an app could be named at all.
 func TestIntegrationMultiApp_ProfileWithoutAnAppUsesTheDefault(t *testing.T) {
 	harness := NewAPITestHarness(t,
 		WithInstallation(packagesInstallationID, enabledPackagesInstallation()),
@@ -98,10 +91,9 @@ func TestIntegrationMultiApp_ProfileWithoutAnAppUsesTheDefault(t *testing.T) {
 	assert.Equal(t, "default", token.App)
 }
 
-// An app on a different account is disabled at startup, so a profile naming it
-// is invalid and the request is refused. Falling back to a different
-// credential is the hazard this feature exists to avoid, so "unavailable" is
-// the correct answer even though a working default app is right there.
+// A profile naming a disabled app is refused rather than falling back to the
+// default app: silently vending a different credential is the hazard this
+// feature exists to avoid.
 func TestIntegrationMultiApp_ProfileNamingADisabledAppIsUnavailable(t *testing.T) {
 	harness := NewAPITestHarness(t,
 		WithInstallation(packagesInstallationID, testhelpers.MockInstallation{
@@ -118,13 +110,12 @@ func TestIntegrationMultiApp_ProfileNamingADisabledAppIsUnavailable(t *testing.T
 	require.ErrorAs(t, err, &apiErr)
 	assert.Equal(t, http.StatusNotFound, apiErr.StatusCode)
 
-	// Isolation: one disabled app must not withdraw every other profile.
+	// One disabled app must not withdraw every other profile.
 	_, err = harness.Client().OrganizationToken(harness.PipelineToken(), "read-source")
 	assert.NoError(t, err)
 }
 
-// An app whose installation cannot be queried is disabled rather than fatal,
-// so the service starts and every other profile keeps working.
+// A failed installation query disables that app rather than failing startup.
 func TestIntegrationMultiApp_UnreachableInstallationDisablesOnlyThatApp(t *testing.T) {
 	harness := NewAPITestHarness(t,
 		WithInstallation(packagesInstallationID, testhelpers.MockInstallation{
@@ -144,9 +135,8 @@ func TestIntegrationMultiApp_UnreachableInstallationDisablesOnlyThatApp(t *testi
 	assert.Equal(t, "default", token.App)
 }
 
-// Two profiles resolving through different apps must not share cache entries:
-// each response has to carry the token its own app minted, however many times
-// the pair is requested.
+// Repeated interleaved requests: a cache key that ignored the app would return
+// one app's token for the other.
 func TestIntegrationMultiApp_AppsDoNotShareCacheEntries(t *testing.T) {
 	harness := NewAPITestHarness(t,
 		WithInstallation(packagesInstallationID, enabledPackagesInstallation()),
@@ -165,9 +155,8 @@ func TestIntegrationMultiApp_AppsDoNotShareCacheEntries(t *testing.T) {
 	}
 }
 
-// The registry is built once and never written afterwards, so parallel
-// requests across apps need no synchronisation. Under -race this fails if a
-// future change introduces lazily-populated registry state.
+// The registry is built once and never written afterwards. Under -race this
+// fails if a change introduces lazily-populated registry state.
 func TestIntegrationMultiApp_ParallelRequestsAcrossApps(t *testing.T) {
 	harness := NewAPITestHarness(t,
 		WithInstallation(packagesInstallationID, enabledPackagesInstallation()),
@@ -194,8 +183,7 @@ func TestIntegrationMultiApp_ParallelRequestsAcrossApps(t *testing.T) {
 	wg.Wait()
 }
 
-// A deployment not using the feature must pay nothing for its existence: no
-// GITHUB_APPS means no installation is queried at startup.
+// No GITHUB_APPS means no installation is queried at startup.
 func TestIntegrationMultiApp_NoRegistryQueriesNoInstallation(t *testing.T) {
 	harness := NewAPITestHarness(t)
 

--- a/tokenresponse.go
+++ b/tokenresponse.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"encoding/json"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/chinmina/chinmina-bridge/internal/credentialhandler"
+	"github.com/chinmina/chinmina-bridge/internal/vendor"
+)
+
+// TokenResponseMarshaler fixes the response shape once from configuration: no
+// request-time input decides what is disclosed, and the zero value withholds.
+type TokenResponseMarshaler struct {
+	disclose bool
+}
+
+func newTokenResponseMarshaler(withAppIdentity bool) TokenResponseMarshaler {
+	return TokenResponseMarshaler{disclose: withAppIdentity}
+}
+
+// MarshalToken zeroes the identifiers on its own copy when withholding, so the
+// payload's omitzero tags decide the shape and no second field list exists.
+func (m TokenResponseMarshaler) MarshalToken(t vendor.ProfileToken) ([]byte, error) {
+	if !m.disclose {
+		t.ApplicationID, t.InstallationID = 0, 0
+	}
+	return json.Marshal(t)
+}
+
+// CredentialProperties renders the token in git's credential-helper format.
+func (m TokenResponseMarshaler) CredentialProperties(t vendor.ProfileToken, u *url.URL) *credentialhandler.ArrayMap {
+	props := credentialhandler.NewMap(9)
+
+	props.Set("protocol", u.Scheme)
+	props.Set("host", u.Host)
+	props.Set("path", strings.TrimPrefix(u.Path, "/"))
+	props.Set("username", "x-access-token")
+	props.Set("password", t.Token)
+	props.Set("password_expiry_utc", t.ExpiryUnix())
+
+	if !m.disclose {
+		return props
+	}
+
+	// gitcredentials(7) discards attributes it does not recognise, but a provided
+	// attribute overwrites one git already knows: hence chinmina_.
+	setNonEmpty(props, "chinmina_app_name", t.App)
+	setNonEmpty(props, "chinmina_app_id", formatID(t.ApplicationID))
+	setNonEmpty(props, "chinmina_installation_id", formatID(t.InstallationID))
+
+	return props
+}
+
+// setNonEmpty mirrors omitzero: a value the token never carried is absent
+// rather than present and blank.
+func setNonEmpty(props *credentialhandler.ArrayMap, key, val string) {
+	if val == "" {
+		return
+	}
+	props.Set(key, val)
+}
+
+func formatID(id int64) string {
+	if id == 0 {
+		return ""
+	}
+	return strconv.FormatInt(id, 10)
+}

--- a/tokenresponse_test.go
+++ b/tokenresponse_test.go
@@ -1,0 +1,226 @@
+package main
+
+import (
+	"encoding/json/v2"
+	"maps"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/chinmina/chinmina-bridge/internal/credentialhandler"
+	"github.com/chinmina/chinmina-bridge/internal/profile"
+	"github.com/chinmina/chinmina-bridge/internal/vendor"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// vendedToken's identifiers must stay non-zero, or a withholding assertion
+// passes against a marshaller that discloses.
+var vendedToken = vendor.ProfileToken{
+	OrganizationSlug:    "acme",
+	Profile:             "org:publish",
+	VendedRepositoryURL: "https://github.com/acme/widget",
+	Repositories:        profile.NewSpecificScope("widget"),
+	Permissions:         []string{"contents:read"},
+	App:                 "publisher",
+	ApplicationID:       4242,
+	InstallationID:      8484,
+	Token:               "minted-token",
+	HashedToken:         "hashed-token",
+	Expiry:              time.Date(2024, time.May, 7, 17, 59, 36, 0, time.UTC),
+}
+
+func marshalToMap(t *testing.T, m TokenResponseMarshaler, token vendor.ProfileToken) map[string]any {
+	t.Helper()
+
+	data, err := m.MarshalToken(token)
+	require.NoError(t, err)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(data, &out))
+	return out
+}
+
+// Asserted as a difference between the two shapes rather than a key list, so
+// one assertion catches both a leak and an accidentally dropped field.
+func TestMarshalToken_WithholdingDropsExactlyTheIdentifiers(t *testing.T) {
+	disclosed := marshalToMap(t, newTokenResponseMarshaler(true), vendedToken)
+	withheld := marshalToMap(t, newTokenResponseMarshaler(false), vendedToken)
+
+	dropped := slices.Sorted(maps.Keys(disclosed))
+	dropped = slices.DeleteFunc(dropped, func(k string) bool {
+		_, kept := withheld[k]
+		return kept
+	})
+
+	assert.Equal(t, []string{"appId", "installationId"}, dropped)
+	for k, v := range withheld {
+		assert.Equal(t, disclosed[k], v, "key %q must be unchanged by withholding", k)
+	}
+}
+
+// The zero-value case is deliberate: a marshaller nobody constructed must
+// withhold.
+func TestMarshalToken_IdentifierKeys(t *testing.T) {
+	stale := vendedToken
+	stale.ApplicationID, stale.InstallationID = 0, 0
+
+	tests := []struct {
+		name      string
+		marshaler TokenResponseMarshaler
+		token     vendor.ProfileToken
+		expected  map[string]any
+		absent    []string
+	}{
+		{
+			name:      "disclosing carries both identifiers",
+			marshaler: disclosed,
+			token:     vendedToken,
+			expected:  map[string]any{"app": "publisher", "appId": float64(4242), "installationId": float64(8484)},
+		},
+		{
+			name:      "withholding carries neither",
+			marshaler: withheld,
+			token:     vendedToken,
+			expected:  map[string]any{"app": "publisher"},
+			absent:    []string{"appId", "installationId"},
+		},
+		{
+			name:      "the zero value withholds",
+			marshaler: TokenResponseMarshaler{},
+			token:     vendedToken,
+			expected:  map[string]any{"app": "publisher"},
+			absent:    []string{"appId", "installationId"},
+		},
+		{
+			name:      "disclosing a stale cached token",
+			marshaler: disclosed,
+			token:     stale,
+			expected:  map[string]any{"app": "publisher"},
+			absent:    []string{"appId", "installationId"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			response := marshalToMap(t, tt.marshaler, tt.token)
+
+			for key, want := range tt.expected {
+				assert.Equal(t, want, response[key])
+			}
+			for _, key := range tt.absent {
+				assert.NotContains(t, response, key)
+			}
+		})
+	}
+}
+
+func credentialKeys(t *testing.T, m TokenResponseMarshaler, token vendor.ProfileToken) ([]string, map[string]string) {
+	t.Helper()
+
+	u, err := token.URL()
+	require.NoError(t, err)
+
+	props := m.CredentialProperties(token, u)
+
+	keys := make([]string, 0, props.Len())
+	values := make(map[string]string, props.Len())
+	for i := props.Iter(); i.HasNext(); {
+		k, v := i.Next()
+		keys = append(keys, k)
+		values[k] = v
+	}
+	return keys, values
+}
+
+// gitCredentialKeys are the properties git has always received, in order:
+// a credential helper's output is a protocol, not a map.
+var gitCredentialKeys = []string{"protocol", "host", "path", "username", "password", "password_expiry_utc"}
+
+// All three chinmina_ keys are new to git-credentials clients — unlike the JSON
+// response, which has always carried the app name — so all three are gated.
+func TestCredentialProperties_Keys(t *testing.T) {
+	stale := vendedToken
+	stale.ApplicationID, stale.InstallationID = 0, 0
+
+	tests := []struct {
+		name      string
+		marshaler TokenResponseMarshaler
+		token     vendor.ProfileToken
+		expected  []string
+		values    map[string]string
+	}{
+		{
+			name:      "withholding emits only git's keys",
+			marshaler: withheld,
+			token:     vendedToken,
+			expected:  gitCredentialKeys,
+			values:    map[string]string{"username": "x-access-token", "password": "minted-token"},
+		},
+		{
+			name:      "the zero value withholds",
+			marshaler: TokenResponseMarshaler{},
+			token:     vendedToken,
+			expected:  gitCredentialKeys,
+		},
+		{
+			name:      "disclosing appends the chinmina keys",
+			marshaler: disclosed,
+			token:     vendedToken,
+			expected:  append(slices.Clone(gitCredentialKeys), "chinmina_app_name", "chinmina_app_id", "chinmina_installation_id"),
+			values: map[string]string{
+				"chinmina_app_name":        "publisher",
+				"chinmina_app_id":          "4242",
+				"chinmina_installation_id": "8484",
+			},
+		},
+		{
+			name:      "disclosing a stale cached token names its app and nothing more",
+			marshaler: disclosed,
+			token:     stale,
+			expected:  append(slices.Clone(gitCredentialKeys), "chinmina_app_name"),
+			values:    map[string]string{"chinmina_app_name": "publisher"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			keys, values := credentialKeys(t, tt.marshaler, tt.token)
+
+			assert.Equal(t, tt.expected, keys)
+			for key, want := range tt.values {
+				assert.Equal(t, want, values[key])
+			}
+		})
+	}
+}
+
+// WriteProperties rejects a key containing '\n', '=' or NUL, so the new keys
+// have to be shown to survive it.
+func TestCredentialProperties_KeysAreWritableByTheHelperProtocol(t *testing.T) {
+	u, err := vendedToken.URL()
+	require.NoError(t, err)
+
+	var out strings.Builder
+	require.NoError(t, credentialhandler.WriteProperties(
+		newTokenResponseMarshaler(true).CredentialProperties(vendedToken, u), &out))
+
+	assert.Contains(t, out.String(), "chinmina_installation_id=8484\n")
+}
+
+// null and {} are the existing wire shapes; choosing the response shape at the
+// call site must not disturb them.
+func TestMarshalToken_NilSlicesStayNull(t *testing.T) {
+	unscoped := vendedToken
+	unscoped.Permissions = nil
+	unscoped.Repositories = profile.RepositoryScope{}
+
+	for _, m := range []TokenResponseMarshaler{withheld, disclosed, {}} {
+		data, err := m.MarshalToken(unscoped)
+		require.NoError(t, err)
+
+		assert.Contains(t, string(data), `"permissions":null`)
+		assert.Contains(t, string(data), `"repositories":{}`)
+	}
+}


### PR DESCRIPTION
## Purpose

A single GitHub App installation forces an operator to choose between widening that one app until it covers every use case — so a routine build's token is minted by an app that can also write packages or administer repositories — or standing up a second deployment. This lets an operator install additional apps under logical names and lets a profile declare which one its tokens are minted through, so the blast radius of any one credential matches what the profiles using it actually need.

Introducing a credential stays a deploy-time privilege: apps are declared in deployment configuration, and profile YAML can only select between what is already installed. Adding an app is a deployment decision, choosing between them is a profile-review decision, and neither can be escalated from the repository the profiles live in.

Deployments that configure no additional apps are unaffected and pay nothing: the default app is registered under the same mechanism, so single-app and multi-app deployments share one minting path rather than a well-trodden one and an untested second.

## Context

- Builds on #369, #370 and #371.
- Apps must be installed on the same organization as the default app; this is verified at startup by account ID rather than login, since a login is renameable and, once released, claimable by another account. An app that fails verification is disabled rather than fatal, so one unreachable credential does not stop vending for every other profile.
- Ambiguous configuration fails startup instead: those outcomes are deterministic and identical on every instance, so a deployment either works everywhere or nowhere.
- Token cache entries are keyed on the app identity, not its name. Repointing a name at a different app leaves the profile YAML and its digest unchanged, so a name-based key would keep serving tokens minted by the previous app.
- Operator-facing documentation for the profile schema and verification behaviour is published from the chinmina.github.io repository and is not part of this change; `.envrc` carries the configuration reference.
- Per-commit reasoning is in the commit history.