### PR TITLE
feat: support _FILE variants for static JWKS and GitHub app private key

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -111,6 +111,8 @@ source_env_if_exists .envrc.private
 # use "make keygen" to generate a new key pair for testing
 # jwks="$(cat .development/keys/jwk-sig-testing-pub.json)"
 # export JWT_JWKS_STATIC="${jwks}"
+# or, read the value from a file instead (mutually exclusive with JWT_JWKS_STATIC):
+# export JWT_JWKS_STATIC_FILE=".development/keys/jwk-sig-testing-pub.json"
 # export JWT_ISSUER_URL="https://local.testing"
 # export JWT_AUDIENCE="test-audience"
 
@@ -135,6 +137,8 @@ source_env_if_exists .envrc.private
 
 # required (one of)
 # export GITHUB_APP_PRIVATE_KEY="<app private key pem>"
+# or, read the value from a file instead (mutually exclusive with GITHUB_APP_PRIVATE_KEY):
+# export GITHUB_APP_PRIVATE_KEY_FILE="<path to app private key pem>"
 # export GITHUB_APP_PRIVATE_KEY_ARN="<AWS KMS alias arn>"
 
 # required

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,7 +2,10 @@ package config
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/sethvargo/go-envconfig"
 )
@@ -131,7 +134,16 @@ type ObserveConfig struct {
 }
 
 func Load(ctx context.Context) (Config, error) {
-	return load(ctx, nil) // load from OS environment
+	lookup := newFileContentLookuper(envconfig.OsLookuper(), "JWT_JWKS_STATIC", "GITHUB_APP_PRIVATE_KEY")
+	return load(ctx, lookup)
+}
+
+// errLookuper is implemented by lookupers that may accumulate an error while
+// resolving values (e.g. a "_FILE" decoder failing to read its target file).
+// load checks for this after ProcessWith completes, since [envconfig.Lookuper.Lookup]
+// itself has no way to report an error.
+type errLookuper interface {
+	Err() error
 }
 
 func load(ctx context.Context, lookup envconfig.Lookuper) (Config, error) {
@@ -142,6 +154,9 @@ func load(ctx context.Context, lookup envconfig.Lookuper) (Config, error) {
 	})
 	if err != nil {
 		return cfg, err
+	}
+	if el, ok := lookup.(errLookuper); ok && el.Err() != nil {
+		return cfg, fmt.Errorf("invalid configuration: %w", el.Err())
 	}
 
 	err = cfg.Cache.Validate()
@@ -233,4 +248,72 @@ func (v *ValkeyConfig) validateIAM() error {
 	// treating a mismatch as a configuration error.
 	v.TLS = true
 	return nil
+}
+
+// fileContentLookuper decorates a [envconfig.Lookuper] with the "_FILE"
+// convention for a fixed allowlist of keys: for each allowed key K, if K
+// itself is unset, K_FILE is checked; when present, its value is treated as
+// a path and the file's contents (trimmed of surrounding whitespace) are
+// used as K's value. This lets specific secret-bearing fields — currently
+// GITHUB_APP_PRIVATE_KEY and JWT_JWKS_STATIC — be supplied via a mounted
+// secret file instead of an inline environment variable. Keys outside the
+// allowlist pass straight through to the wrapped lookuper.
+//
+// Setting both K and K_FILE is rejected, since the intended source is
+// ambiguous. Lookup cannot itself return an error, so failures (a bad path,
+// or both variants set) are accumulated and surfaced via Err, which the
+// caller must check after processing completes.
+type fileContentLookuper struct {
+	next    envconfig.Lookuper
+	allowed map[string]struct{}
+	err     error
+}
+
+func newFileContentLookuper(next envconfig.Lookuper, allowedKeys ...string) *fileContentLookuper {
+	allowed := make(map[string]struct{}, len(allowedKeys))
+	for _, key := range allowedKeys {
+		allowed[key] = struct{}{}
+	}
+
+	return &fileContentLookuper{next: next, allowed: allowed}
+}
+
+// Err returns the accumulated errors from all Lookup calls, joined via
+// [errors.Join], if any.
+func (f *fileContentLookuper) Err() error {
+	return f.err
+}
+
+func (f *fileContentLookuper) Lookup(key string) (string, bool) {
+	value, valueSet := f.next.Lookup(key)
+
+	if _, ok := f.allowed[key]; !ok {
+		return value, valueSet
+	}
+
+	path, pathSet := f.next.Lookup(key + "_FILE")
+	if !pathSet || path == "" {
+		return value, valueSet
+	}
+
+	if valueSet {
+		f.err = errors.Join(f.err, fmt.Errorf("%s and %s_FILE are mutually exclusive", key, key))
+		return value, valueSet
+	}
+
+	//nolint:gosec // G304: path is an operator-supplied config value (an
+	// allowlisted "<KEY>_FILE" environment variable), not user input.
+	content, err := os.ReadFile(path)
+	if err != nil {
+		f.err = errors.Join(f.err, fmt.Errorf("read %s_FILE: %w", key, err))
+		return "", false
+	}
+
+	trimmed := strings.TrimSpace(string(content))
+	if trimmed == "" {
+		f.err = errors.Join(f.err, fmt.Errorf("%s_FILE at %q is empty", key, path))
+		return "", false
+	}
+
+	return trimmed, true
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/sethvargo/go-envconfig"
@@ -459,4 +461,200 @@ func TestLoad_Errors(t *testing.T) {
 			assert.Contains(t, err.Error(), tt.expectedErr)
 		})
 	}
+}
+
+func TestFileContentLookuper(t *testing.T) {
+	dir := t.TempDir()
+
+	pemPath := filepath.Join(dir, "private-key.pem")
+	require.NoError(t, os.WriteFile(pemPath, []byte("file-key\n"), 0o600))
+
+	missingPath := filepath.Join(dir, "does-not-exist")
+
+	blankPath := filepath.Join(dir, "blank")
+	require.NoError(t, os.WriteFile(blankPath, []byte("  \n\t\n"), 0o600))
+
+	tests := []struct {
+		name string
+		// base seeds the wrapped lookuper; allowedKeys restricts which keys the
+		// "_FILE" convention applies to.
+		base        map[string]string
+		allowedKeys []string
+		lookupKey   string
+		wantValue   string
+		wantOK      bool
+		wantErr     string
+	}{
+		{
+			name:        "allowed key with no value or file passes through unset",
+			base:        map[string]string{},
+			allowedKeys: []string{"GITHUB_APP_PRIVATE_KEY"},
+			lookupKey:   "GITHUB_APP_PRIVATE_KEY",
+			wantValue:   "",
+			wantOK:      false,
+		},
+		{
+			name:        "allowed key with inline value only passes through unchanged",
+			base:        map[string]string{"GITHUB_APP_PRIVATE_KEY": "inline-key"},
+			allowedKeys: []string{"GITHUB_APP_PRIVATE_KEY"},
+			lookupKey:   "GITHUB_APP_PRIVATE_KEY",
+			wantValue:   "inline-key",
+			wantOK:      true,
+		},
+		{
+			name:        "allowed key with _FILE only reads and trims file contents",
+			base:        map[string]string{"GITHUB_APP_PRIVATE_KEY_FILE": pemPath},
+			allowedKeys: []string{"GITHUB_APP_PRIVATE_KEY"},
+			lookupKey:   "GITHUB_APP_PRIVATE_KEY",
+			wantValue:   "file-key",
+			wantOK:      true,
+		},
+		{
+			name: "allowed key with both value and _FILE set is an error",
+			base: map[string]string{
+				"GITHUB_APP_PRIVATE_KEY":      "inline-key",
+				"GITHUB_APP_PRIVATE_KEY_FILE": pemPath,
+			},
+			allowedKeys: []string{"GITHUB_APP_PRIVATE_KEY"},
+			lookupKey:   "GITHUB_APP_PRIVATE_KEY",
+			wantValue:   "inline-key",
+			wantOK:      true,
+			wantErr:     "GITHUB_APP_PRIVATE_KEY and GITHUB_APP_PRIVATE_KEY_FILE are mutually exclusive",
+		},
+		{
+			name:        "allowed key with unreadable _FILE path is an error",
+			base:        map[string]string{"GITHUB_APP_PRIVATE_KEY_FILE": missingPath},
+			allowedKeys: []string{"GITHUB_APP_PRIVATE_KEY"},
+			lookupKey:   "GITHUB_APP_PRIVATE_KEY",
+			wantValue:   "",
+			wantOK:      false,
+			wantErr:     "read GITHUB_APP_PRIVATE_KEY_FILE",
+		},
+		{
+			name:        "key outside the allowlist ignores its _FILE variant",
+			base:        map[string]string{"VALKEY_PASSWORD_FILE": pemPath},
+			allowedKeys: []string{"GITHUB_APP_PRIVATE_KEY"},
+			lookupKey:   "VALKEY_PASSWORD",
+			wantValue:   "",
+			wantOK:      false,
+		},
+		{
+			name:        "empty _FILE value is treated as unset",
+			base:        map[string]string{"GITHUB_APP_PRIVATE_KEY_FILE": ""},
+			allowedKeys: []string{"GITHUB_APP_PRIVATE_KEY"},
+			lookupKey:   "GITHUB_APP_PRIVATE_KEY",
+			wantValue:   "",
+			wantOK:      false,
+		},
+		{
+			name:        "whitespace-only _FILE content is an error",
+			base:        map[string]string{"GITHUB_APP_PRIVATE_KEY_FILE": blankPath},
+			allowedKeys: []string{"GITHUB_APP_PRIVATE_KEY"},
+			lookupKey:   "GITHUB_APP_PRIVATE_KEY",
+			wantValue:   "",
+			wantOK:      false,
+			wantErr:     "is empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lookuper := newFileContentLookuper(envconfig.MapLookuper(tt.base), tt.allowedKeys...)
+
+			value, ok := lookuper.Lookup(tt.lookupKey)
+			assert.Equal(t, tt.wantValue, value)
+			assert.Equal(t, tt.wantOK, ok)
+
+			if tt.wantErr == "" {
+				assert.NoError(t, lookuper.Err())
+			} else {
+				require.Error(t, lookuper.Err())
+				assert.Contains(t, lookuper.Err().Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestLoad_FileOverrides(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "private-key.pem")
+	require.NoError(t, os.WriteFile(path, []byte("file-key\n"), 0o600))
+
+	configMap := map[string]string{
+		"JWT_BUILDKITE_ORGANIZATION_SLUG": "test-org",
+		"BUILDKITE_API_TOKEN":             "test-token",
+		"GITHUB_APP_ID":                   "123",
+		"GITHUB_APP_INSTALLATION_ID":      "456",
+		"GITHUB_APP_PRIVATE_KEY_FILE":     path,
+	}
+	lookuper := newFileContentLookuper(
+		envconfig.MapLookuper(configMap), "JWT_JWKS_STATIC", "GITHUB_APP_PRIVATE_KEY",
+	)
+
+	cfg, err := load(context.Background(), lookuper)
+	require.NoError(t, err)
+	assert.Equal(t, "file-key", cfg.Github.PrivateKey)
+}
+
+// TestLoad_FileOverrides_Error verifies that load surfaces a
+// fileContentLookuper failure (here: an unreadable GITHUB_APP_PRIVATE_KEY_FILE
+// path) as a wrapped "invalid configuration" error, rather than silently
+// proceeding with a zero-value field.
+func TestLoad_FileOverrides_Error(t *testing.T) {
+	configMap := map[string]string{
+		"JWT_BUILDKITE_ORGANIZATION_SLUG": "test-org",
+		"BUILDKITE_API_TOKEN":             "test-token",
+		"GITHUB_APP_ID":                   "123",
+		"GITHUB_APP_INSTALLATION_ID":      "456",
+		"GITHUB_APP_PRIVATE_KEY_FILE":     "/nonexistent/private-key.pem",
+	}
+	lookuper := newFileContentLookuper(
+		envconfig.MapLookuper(configMap), "JWT_JWKS_STATIC", "GITHUB_APP_PRIVATE_KEY",
+	)
+
+	_, err := load(context.Background(), lookuper)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid configuration")
+	assert.Contains(t, err.Error(), "read GITHUB_APP_PRIVATE_KEY_FILE")
+}
+
+// TestLoad_RealEnvironment exercises the public Load entrypoint end to end:
+// Load wires up the real OS environment lookuper (unlike load, which every
+// other test drives with an explicit envconfig.Lookuper), so this is the
+// only test that proves GITHUB_APP_PRIVATE_KEY_FILE and JWT_JWKS_STATIC_FILE
+// actually reach the process environment main.go reads from in production.
+//
+// t.Setenv scopes every variable to this test and restores the prior
+// environment on cleanup, so it cannot leak state into other tests even
+// under `go test` process reuse.
+func TestLoad_RealEnvironment(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "private-key.pem")
+	require.NoError(t, os.WriteFile(path, []byte("file-key\n"), 0o600))
+
+	for key, value := range requiredConfig {
+		if key == "GITHUB_APP_PRIVATE_KEY" {
+			continue // sourced from GITHUB_APP_PRIVATE_KEY_FILE below instead
+		}
+		t.Setenv(key, value)
+	}
+	unsetEnv(t, "GITHUB_APP_PRIVATE_KEY")
+	t.Setenv("GITHUB_APP_PRIVATE_KEY_FILE", path)
+
+	cfg, err := Load(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "file-key", cfg.Github.PrivateKey)
+}
+
+// unsetEnv removes key from the environment for the duration of the test,
+// restoring whatever value (or absence) preceded it on cleanup. This guards
+// against the ambient test environment already defining key, which would
+// otherwise make it look "set" to fileContentLookuper and falsely trip its
+// mutual-exclusion check against a "_FILE" counterpart.
+func unsetEnv(t *testing.T, key string) {
+	t.Helper()
+
+	if prior, ok := os.LookupEnv(key); ok {
+		t.Cleanup(func() { require.NoError(t, os.Setenv(key, prior)) })
+	}
+	require.NoError(t, os.Unsetenv(key))
 }


### PR DESCRIPTION
## Purpose

Let JWT_JWKS_STATIC and GITHUB_APP_PRIVATE_KEY be sourced from a mounted file via a `_FILE` suffix, matching the convention orchestrators (Docker/K8s secrets, Vault agent templates, ECS secret injection) already expect for sensitive values. Removes pressure to pass this key material through inline env vars, which are more prone to leaking via process listings, logs, and CI variable dumps.

## Context

Implemented as a `fileContentLookuper` decorator over `envconfig.Lookuper`, scoped to an explicit allowlist of the two secret-bearing keys so other config fields can't pick up file overrides unintentionally. Setting both the inline var and its `_FILE` counterpart is rejected as ambiguous.