### PR TITLE
build: make 'just docker ...' a reusable Compose entry point for load-test overlays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 
 dist/
 docker-compose.*.y?ml
+integration/.docker-endpoint.env

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,10 +25,15 @@ just docker down        # Stop the stack; `docker` forwards any args to `docker 
 just docker logs -f     # ...so `ps`, `logs`, `exec` and the rest work the same way
 ```
 
-Both recipes work out how traefik reaches the Docker API (see
-`integration/resolve-docker-endpoint.sh`), since the daemon socket is rarely at
-`/var/run/docker.sock` on a non-admin macOS install. Set `DOCKER_HOST` to point
-elsewhere; a TCP endpoint on this host is rewritten to `host.docker.internal`.
+`just docker ...` is the supported Compose entry point for the local
+integration stack and for downstream overlays such as `bridge-load`. Before
+running Compose, it invokes `integration/resolve-docker-endpoint.sh`, which
+writes the resolved endpoint values to `integration/.docker-endpoint.env`.
+That file is consumed by the compose stack as the Docker socket mount and the
+Traefik Docker provider endpoint. The daemon socket is rarely at
+`/var/run/docker.sock` on a non-admin macOS install, so set `DOCKER_HOST` to
+point elsewhere; a TCP endpoint on this host is rewritten to
+`host.docker.internal`.
 
 ### Testing
 

--- a/integration/resolve-docker-endpoint.sh
+++ b/integration/resolve-docker-endpoint.sh
@@ -5,10 +5,12 @@
 #
 # Usage: resolve-docker-endpoint.sh [ENDPOINT]
 #
-# Prints two space-separated fields for the caller to export: the host path to
-# bind at /var/run/docker.sock (DOCKER_SOCKET), and the endpoint traefik's
-# docker provider dials (DOCKER_ENDPOINT). How it gets there depends on how the
-# local docker CLI talks to the daemon:
+# Writes the resolved values to .docker-endpoint.env in the same directory:
+#
+#   DOCKER_SOCKET=<resolved host socket or /dev/null>
+#   DOCKER_ENDPOINT=<Traefik provider endpoint>
+#
+# How it gets there depends on how the local docker CLI talks to the daemon:
 #
 #   unix://PATH   bind the socket in. Only an admin install puts it at the
 #                 default /var/run/docker.sock; OrbStack, Rancher Desktop and
@@ -27,6 +29,9 @@ readonly DEFAULT_DOCKER_PORT=2375
 
 # Hostname that resolves to this host from inside a container.
 readonly CONTAINER_HOST_ALIAS='host.docker.internal'
+
+# Generated env file, consumed by `just docker ...`.
+readonly OUTPUT_FILE='.docker-endpoint.env'
 
 # Print a message to STDERR.
 err() {
@@ -75,6 +80,22 @@ split_hostport() {
   esac
 
   printf '%s %s\n' "${host}" "${port:-${DEFAULT_DOCKER_PORT}}"
+}
+
+# Atomically write the resolved socket and provider endpoint to the env file.
+write_env_file() {
+  local socket="$1" provider="$2" tmp
+
+  tmp="$(mktemp "${OUTPUT_FILE}.XXXXXX")"
+  trap 'rm -f "${tmp}"' EXIT
+
+  cat > "${tmp}" <<EOF
+DOCKER_SOCKET="${socket}"
+DOCKER_ENDPOINT="${provider}"
+EOF
+
+  mv -f "${tmp}" "${OUTPUT_FILE}"
+  trap - EXIT
 }
 
 # Entry point. Receives an optional endpoint override as "$1".
@@ -132,7 +153,8 @@ main() {
       ;;
   esac
 
-  printf '%s %s\n' "${socket}" "${provider}"
+  err "Resolved docker endpoint: ${provider} (mount: ${socket})"
+  write_env_file "${socket}" "${provider}"
 }
 
 main "$@"

--- a/justfile
+++ b/justfile
@@ -98,23 +98,18 @@ build-oidc:
 run: build-local
     dist/chinmina-bridge-local
 
+# Resolve the local Docker endpoint and write it to .docker-endpoint.env for
+# the integration stack. Run automatically as a dependency of `just docker ...`.
+[group('dev')]
+[working-directory('integration')]
+resolve-docker-endpoint:
+    ./resolve-docker-endpoint.sh
+
 # Run docker compose against the integration stack, e.g. `just docker down`, `just docker logs -f`
 [group('dev')]
 [working-directory('integration')]
-docker *args:
-    #!/usr/bin/env bash
-    set -euo pipefail
-
-    # Traefik needs a route to the Docker API from inside its container: see
-    # ./resolve-docker-endpoint.sh, which works out the socket to bind and the
-    # endpoint to dial.
-    resolved="$(./resolve-docker-endpoint.sh)"
-    read -r DOCKER_SOCKET DOCKER_ENDPOINT <<<"${resolved}"
-    export DOCKER_SOCKET DOCKER_ENDPOINT
-
-    echo "Resolved docker endpoint: ${DOCKER_ENDPOINT} (mount: ${DOCKER_SOCKET})" >&2
-
-    docker compose {{ args }}
+docker *args: resolve-docker-endpoint
+    docker compose --env-file .docker-endpoint.env {{ args }}
 
 # Build, then bring the integration stack up; extra `docker compose up` args are forwarded
 [group('dev')]


### PR DESCRIPTION
## Purpose

Make `just docker ...` a stable Compose entry point that downstream projects can reuse, so load-testing infrastructure such as `bridge-load` can supply its own `-f` overlays without reimplementing Docker endpoint discovery. Today the resolver emits space-delimited values that only the local justfile can consume; by writing a generated env file instead, external overlays get a clean contract to the resolved Docker socket and Traefik provider endpoint while `chinmina-bridge` keeps ownership of endpoint translation and validation.

## Context

- Builds on the integration stack portability work in #368.
