### PR TITLE
test: gate the local integration stack on service readiness

### DIFF
--- a/integration/build/Dockerfile
+++ b/integration/build/Dockerfile
@@ -1,0 +1,9 @@
+# Runtime image for the chinmina-bridge workers in the local integration stack.
+#
+# The binary itself is not baked in: the repo is bind-mounted at /src and the
+# worker runs ./dist/chinmina-bridge from there, so a rebuild on the host is
+# picked up without rebuilding this image.
+FROM cgr.dev/chainguard/busybox:latest
+
+# statically linked, no-dependency HTTP probe (~70KB)
+COPY --from=tarampampam/microcheck:1 /bin/httpcheck /usr/local/bin/httpcheck

--- a/integration/docker-compose.yaml
+++ b/integration/docker-compose.yaml
@@ -52,7 +52,13 @@ services:
   chinmina-bridge: # ingress container
     image: traefik:v3
     depends_on:
-      - chinmina-bridge-worker
+      # the workers report healthy only once the first profile has been
+      # generated, so the ingress doesn't route to a container that would 503
+      chinmina-bridge-worker:
+        condition: service_healthy
+      # No-op while the alternate pool is `scale: 0`, ie. every stack but rolling
+      chinmina-bridge-alternate:
+        condition: service_healthy
     environment:
       TRAEFIK_API_INSECURE: "true"                       # Enable Dashboard
       TRAEFIK_PROVIDERS_DOCKER: "true"                   # Enable Docker Auto-discovery
@@ -81,6 +87,13 @@ services:
       TRAEFIK_METRICS_OTLP_ADDSERVICESLABELS: "true"     # Adds service info (whoami, etc.)
     ports:
       - "127.0.0.1:18889:8080"  # dashboard
+    healthcheck:
+      # Probes through the web entrypoint: unrouted requests 404. Traefik's /ping
+      # reports OK before the docker provider has discovered anything.
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:80/healthcheck"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
     extra_hosts:
       # so a daemon listening on a port of this host is dialable (native on
       # Docker Desktop and OrbStack, needs the mapping on Linux)
@@ -125,10 +138,16 @@ services:
   # Environment keys with no value are passed through from the host.
   chinmina-bridge-template:
     scale: 0
-    image: alpine
+    build:
+      context: build
+    # built to an explicit image name shared by extending services,
+    # so the image is built once rather than per worker pool.
+    image: chinmina-bridge-integration-base
     depends_on:
-      - openobserve
-      - valkey
+      openobserve:
+        condition: service_started  # no healthcheck available on this image
+      valkey:
+        condition: service_healthy
     working_dir: "/src"
     command: ["./dist/chinmina-bridge"]
     environment:
@@ -165,6 +184,14 @@ services:
       AWS_DEFAULT_REGION:
     volumes:
       - "..:/src"
+    healthcheck:
+      test: ["CMD", "httpcheck", "http://127.0.0.1:80/healthcheck"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+      # allow time for startup depending on loading profiles, which need a GitHub
+      # round trip
+      start_period: 30s
     labels: # labelling allows scaled replicas to be routed via traefik
       - "traefik.enable=true"
       - "traefik.http.routers.chinmina.rule=PathPrefix(`/`)"
@@ -180,6 +207,9 @@ services:
   chinmina-bridge-alternate:
     extends:
       service: chinmina-bridge-template
+    # Restated: Compose drops the extends-resolved image when pruning a `scale: 0`
+    # service that something depends_on.
+    image: chinmina-bridge-integration-base
     scale: 0
 
   # OpenObserve all-in-one: OTLP endpoint (traces, metrics, logs) plus UI. Data is written

--- a/justfile
+++ b/justfile
@@ -109,7 +109,7 @@ resolve-docker-endpoint:
 [group('dev')]
 [working-directory('integration')]
 docker *args: resolve-docker-endpoint
-    docker compose --env-file .docker-endpoint.env {{ args }}
+    docker compose --env-file .docker-endpoint.env -f docker-compose.yaml {{ args }}
 
 # Build, then bring the integration stack up; extra `docker compose up` args are forwarded
 [group('dev')]


### PR DESCRIPTION
## Purpose

Container start is not readiness: startup gates on the first profile generation, so agents and k6 were hitting workers that hadn't fetched profiles yet and getting 503s that looked like test failures. Health now means profiles loaded (or timed out), and the ingress is healthy only once it can route to a healthy worker, so load runs can't start before the system under test is serving.

Costs a slower `up`, since agents wait behind profile generation rather than racing it.

## Context

- Depends on the startup gate from #371.
- Feeds the `bridge-load` overlays enabled by #376.
- The worker image exists only to supply a probe binary; the stock images have no HTTP client to healthcheck with.
