### PR TITLE
fix(tooling): pin goreleaser to 2.17.1

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 go            = "1.26.6"
 golangci-lint = "2.13.1"
-goreleaser    = "2.18.0"
+goreleaser    = "2.17.1"
 cosign        = "3.1.3"
 just          = "1.58.0"


### PR DESCRIPTION
## Purpose

Keeps release builds working on linux/x86 by pinning goreleaser back to a known-good version, avoiding blocked releases from an upstream regression.

## Context

- goreleaser 2.18.0 fails on linux/x86 builds: [goreleaser/goreleaser#6814](https://github.com/goreleaser/goreleaser/issues/6814)
- Revert to 2.17.1 until upstream ships a fix; re-pin forward once the issue is resolved.