### PR TITLE
fix: add resolved profile and app details to traces

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -11,13 +11,16 @@ import (
 	"strings"
 	"unicode"
 
+	"log/slog"
+
 	"github.com/chinmina/chinmina-bridge/internal/audit"
 	"github.com/chinmina/chinmina-bridge/internal/credentialhandler"
 	"github.com/chinmina/chinmina-bridge/internal/github"
 	"github.com/chinmina/chinmina-bridge/internal/jwt"
 	"github.com/chinmina/chinmina-bridge/internal/profile"
 	"github.com/chinmina/chinmina-bridge/internal/vendor"
-	"log/slog"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // HTTPStatuser provides HTTP status information for errors
@@ -211,16 +214,15 @@ func resolveProfile[T profile.AppNamed](ctx context.Context, pv PathValuer, look
 	return vendor.Resolved[T]{Ref: ref, Profile: authProfile, Digest: digest, App: app}, nil
 }
 
-// recordResolvedRequest stamps the request's intent on the audit entry once
-// the profile has resolved. The canonical URN is written only for a profile
-// that actually exists, so its presence means "this name resolved" rather
-// than "this name was asked for"; unresolved names stay as the raw value
+// recordResolvedRequest stamps the request's intent on the audit entry and the
+// trace once the profile has resolved. The canonical URN is written only for a
+// profile that actually exists, so its presence means "this name resolved"
+// rather than "this name was asked for"; unresolved names stay as the raw value
 // stamped by recordRequestedName.
 //
 // The converse does not hold: net/http unescapes %2F after routing, so a raw
-// name can itself be URN-shaped. Distinguish a served request from a
-// rejected one via the entry's error field, never the shape of
-// requestedProfile.
+// name can itself be URN-shaped. Distinguish a served request from a rejected
+// one via the entry's error field, never the shape of requestedProfile.
 func recordResolvedRequest[T any](ctx context.Context, resolved vendor.Resolved[T], requestedRepo string) {
 	entry := audit.Log(ctx)
 	entry.RequestedProfile = resolved.Ref.String()
@@ -231,6 +233,15 @@ func recordResolvedRequest[T any](ctx context.Context, resolved vendor.Resolved[
 	entry.App = resolved.App.Name
 	entry.ApplicationID = resolved.App.ApplicationID
 	entry.InstallationID = resolved.App.InstallationID
+
+	tc := trace.SpanFromContext(ctx)
+	tc.SetAttributes(
+		attribute.String("profile.version_digest", resolved.Digest),
+		attribute.String("profile.name", resolved.Ref.ShortString()),
+		attribute.String("profile.app.name", resolved.App.Name),
+		attribute.Int64("profile.app.application_id", resolved.App.ApplicationID),
+		attribute.Int64("profile.app.installation_id", resolved.App.InstallationID),
+	)
 }
 
 // recordRequestedName stamps the raw profile path parameter before anything can

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
-	"encoding/json"
+	"encoding/json/v2"
 	"errors"
 	"io"
 	"net/http"
@@ -24,6 +24,9 @@ import (
 	"github.com/chinmina/chinmina-bridge/internal/vendor"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
 var defaultExpiry = time.Date(2024, time.May, 7, 17, 59, 36, 0, time.UTC)
@@ -45,6 +48,41 @@ func testAppResolver(name string) (github.AppIdentity, bool) {
 		return github.AppIdentity{}, false
 	}
 	return testApp, true
+}
+
+func TestRecordResolvedRequest_AddsProfileAndAppTraceAttributes(t *testing.T) {
+	recorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	ctx, _ := audit.Context(t.Context())
+	ctx, span := tp.Tracer("test").Start(ctx, t.Name())
+
+	resolved := vendor.Resolved[struct{}]{
+		Ref: profile.ProfileRef{
+			Organization:     "acme",
+			Type:             profile.ProfileTypeOrg,
+			Name:             "packages",
+			ScopedRepository: "frontend",
+		},
+		Digest: "sha256:profile-version",
+		App: github.AppIdentity{
+			Name:           "package-writer",
+			ApplicationID:  123,
+			InstallationID: 456,
+		},
+	}
+
+	recordResolvedRequest(ctx, resolved, "frontend")
+	span.End()
+
+	spans := recorder.Ended()
+	require.Len(t, spans, 1)
+	assert.ElementsMatch(t, []attribute.KeyValue{
+		attribute.String("profile.version_digest", "sha256:profile-version"),
+		attribute.String("profile.name", "org:packages/frontend"),
+		attribute.String("profile.app.name", "package-writer"),
+		attribute.Int64("profile.app.application_id", 123),
+		attribute.Int64("profile.app.installation_id", 456),
+	}, spans[0].Attributes())
 }
 
 // testPipelineResolver returns a pipeline ProfileResolver whose lookup always


### PR DESCRIPTION
## Purpose

Make token-vending traces self-contained for operational diagnosis. A request can resolve to different profile generations and GitHub Apps, but the span previously lacked those decisions; operators therefore had to correlate traces with audit logs before they could identify the configuration and credentials involved.

Recording the resolved profile version and application identity on the request span reduces that diagnostic gap while retaining the audit record as the authoritative request log.

## Context

Multiple GitHub App support makes application selection part of profile resolution. Exposing that resolved identity, together with the profile digest, lets operators distinguish configuration rollouts, app-specific failures, and installation-specific behavior directly in tracing data.

The attributes are recorded only after successful resolution, matching the existing audit semantics: unresolved requests cannot appear to have selected a canonical profile or application.